### PR TITLE
feat: Add canister command scaffolding

### DIFF
--- a/bin/icp-cli/src/commands.rs
+++ b/bin/icp-cli/src/commands.rs
@@ -1,5 +1,7 @@
 use crate::{
-    commands::{build::BuildCommandError, network::NetworkCommandError},
+    commands::{
+        build::BuildCommandError, canister::CanisterCommandError, network::NetworkCommandError,
+    },
     env::Env,
 };
 use clap::{Parser, Subcommand};
@@ -7,6 +9,7 @@ use identity::IdentityCommandError;
 use snafu::Snafu;
 
 mod build;
+mod canister;
 mod identity;
 mod network;
 
@@ -19,6 +22,7 @@ pub struct Cmd {
 #[derive(Subcommand, Debug)]
 pub enum Subcmd {
     Build(build::Cmd),
+    Canister(canister::Cmd),
     Identity(identity::IdentityCmd),
     Network(network::NetworkCmd),
 }
@@ -26,6 +30,7 @@ pub enum Subcmd {
 pub async fn dispatch(env: &Env, cli: Cmd) -> Result<(), DispatchError> {
     match cli.subcommand {
         Subcmd::Build(opts) => build::exec(opts).await?,
+        Subcmd::Canister(opts) => canister::dispatch(env, opts).await?,
         Subcmd::Identity(opts) => identity::dispatch(env, opts).await?,
         Subcmd::Network(opts) => network::dispatch(env, opts).await?,
     }
@@ -36,6 +41,9 @@ pub async fn dispatch(env: &Env, cli: Cmd) -> Result<(), DispatchError> {
 pub enum DispatchError {
     #[snafu(transparent)]
     Build { source: BuildCommandError },
+
+    #[snafu(transparent)]
+    Canister { source: CanisterCommandError },
 
     #[snafu(transparent)]
     Identity { source: IdentityCommandError },

--- a/bin/icp-cli/src/commands/canister.rs
+++ b/bin/icp-cli/src/commands/canister.rs
@@ -1,0 +1,38 @@
+use clap::{Parser, Subcommand};
+use snafu::Snafu;
+
+use crate::env::Env;
+
+mod create;
+mod install;
+
+#[derive(Debug, Parser)]
+pub struct Cmd {
+    #[command(subcommand)]
+    subcmd: CanisterSubcmd,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CanisterSubcmd {
+    Create(create::CanisterCreateCmd),
+    Install(install::CanisterInstallCmd),
+}
+
+pub async fn dispatch(env: &Env, cmd: Cmd) -> Result<(), CanisterCommandError> {
+    match cmd.subcmd {
+        CanisterSubcmd::Create(subcmd) => create::exec(env, subcmd)?,
+        CanisterSubcmd::Install(subcmd) => install::exec(env, subcmd)?,
+    }
+    Ok(())
+}
+
+#[derive(Debug, Snafu)]
+pub enum CanisterCommandError {
+    #[snafu(transparent)]
+    Create { source: create::CanisterCreateError },
+
+    #[snafu(transparent)]
+    Install {
+        source: install::CanisterInstallError,
+    },
+}

--- a/bin/icp-cli/src/commands/canister/create.rs
+++ b/bin/icp-cli/src/commands/canister/create.rs
@@ -1,0 +1,16 @@
+use crate::env::Env;
+use clap::Parser;
+use snafu::Snafu;
+
+#[derive(Debug, Parser)]
+pub struct CanisterCreateCmd {}
+
+pub fn exec(_env: &Env, _cmd: CanisterCreateCmd) -> Result<(), CanisterCreateError> {
+    Ok(())
+}
+
+#[derive(Debug, Snafu)]
+pub enum CanisterCreateError {
+    #[snafu(display("{error}"))]
+    Unexpected { error: String },
+}

--- a/bin/icp-cli/src/commands/canister/install.rs
+++ b/bin/icp-cli/src/commands/canister/install.rs
@@ -1,0 +1,16 @@
+use crate::env::Env;
+use clap::Parser;
+use snafu::Snafu;
+
+#[derive(Debug, Parser)]
+pub struct CanisterInstallCmd {}
+
+pub fn exec(_env: &Env, _cmd: CanisterInstallCmd) -> Result<(), CanisterInstallError> {
+    Ok(())
+}
+
+#[derive(Debug, Snafu)]
+pub enum CanisterInstallError {
+    #[snafu(display("{error}"))]
+    Unexpected { error: String },
+}


### PR DESCRIPTION
This PR introduces the initial scaffolding for the icp-cli canister command and its subcommands, create and install.

The core logic for these commands is not yet implemented and will be added in a subsequent PR. This change focuses solely on setting up the command structure within clap and defining the necessary modules and error handling boilerplate.