### PR TITLE
feat: support defining networks inline in project

### DIFF
--- a/examples/icp-network-inline/README.md
+++ b/examples/icp-network-inline/README.md
@@ -1,0 +1,15 @@
+# Inline Network Example
+
+This example demonstrates how to define an inline network in an ICP project manifest.
+
+## Overview
+
+This project defines a `staging` network that is an alias for the mainnet. This allows you to deploy a separate set of canisters to the mainnet for staging purposes.
+
+## Instructions
+
+To deploy the canister to the `staging` network, run the following command:
+
+```bash
+icp deploy --network staging
+```

--- a/examples/icp-network-inline/icp.yaml
+++ b/examples/icp-network-inline/icp.yaml
@@ -1,0 +1,13 @@
+canister:
+  name: my-canister
+
+  build:
+    steps:
+      - type: pre-built
+        path: ../icp-pre-built/dist/hello_world.wasm
+        sha256: 17a05e36278cd04c7ae6d3d3226c136267b9df7525a0657521405e22ec96be7a
+
+networks:
+  - name: staging
+    mode: connected
+    url: https://icp0.io

--- a/lib/icp-network/src/config/model/connected.rs
+++ b/lib/icp-network/src/config/model/connected.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum RouteField {
     /// Single url
@@ -12,7 +12,7 @@ pub enum RouteField {
 
 /// A "connected network" is a network that we connect to but don't manage.
 /// Typical examples are mainnet or testnets.
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConnectedNetworkModel {
     /// The URL(s) this network can be reached at.

--- a/lib/icp-network/src/config/model/managed.rs
+++ b/lib/icp-network/src/config/model/managed.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Deserializer};
 
 /// A "managed network" is a network that we start, configure, stop.
-#[derive(Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize, Default)]
 pub struct ManagedNetworkModel {
     pub gateway: GatewayModel,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GatewayModel {
     #[serde(default = "default_host")]
     pub host: String,

--- a/lib/icp-network/src/config/model/network_config.rs
+++ b/lib/icp-network/src/config/model/network_config.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 pub type NetworkName = String;
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "mode", rename_all = "kebab-case")]
 pub enum NetworkConfig {
     Managed(ManagedNetworkModel),

--- a/lib/icp-project/src/model.rs
+++ b/lib/icp-project/src/model.rs
@@ -1,5 +1,7 @@
-use icp_canister::model::CanisterManifest;
 use serde::Deserialize;
+
+use icp_canister::model::CanisterManifest;
+use icp_network::NetworkConfig;
 
 /// Provides the default glob pattern for locating canister manifests
 /// when no `canisters` are explicitly specified in the YAML.
@@ -14,10 +16,11 @@ pub fn default_canisters() -> CanistersField {
 
 /// Provides the default glob pattern for locating network definition files
 /// when the `networks` field is not explicitly specified in the YAML.
-pub fn default_networks() -> Vec<String> {
+pub fn default_networks() -> Vec<NetworkField> {
     ["networks/*"]
         .into_iter()
         .map(String::from)
+        .map(NetworkField::Path)
         .collect::<Vec<_>>()
 }
 
@@ -26,6 +29,21 @@ pub fn default_networks() -> Vec<String> {
 pub enum CanistersField {
     Canister(CanisterManifest),
     Canisters(Vec<String>),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct NetworkManifest {
+    pub name: String,
+
+    #[serde(flatten)]
+    pub config: NetworkConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum NetworkField {
+    Path(String),
+    Definition(NetworkManifest),
 }
 
 /// Represents the manifest for an ICP project, typically loaded from `icp.yaml`.
@@ -43,5 +61,5 @@ pub struct ProjectManifest {
 
     /// List of network definition files relevant to the project.
     /// Supports glob patterns to reference multiple network config files.
-    pub networks: Option<Vec<String>>,
+    pub networks: Option<Vec<NetworkField>>,
 }


### PR DESCRIPTION
This change makes it so that one can define networks "inline" in the icp.yaml manifest file. E.g:
```yaml
canisters:
  ...
  
networks:
  - name: my-network
     mode: connected:
     url: ...
```