### PR TITLE
chore: parallelize tests

### DIFF
--- a/bin/icp-cli/tests/canister_create_tests.rs
+++ b/bin/icp-cli/tests/canister_create_tests.rs
@@ -5,12 +5,10 @@ use predicates::{
     prelude::PredicateBooleanExt,
     str::{contains, starts_with},
 };
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_create() {
     let ctx = TestContext::new().with_dfx();
 
@@ -34,6 +32,7 @@ fn canister_create() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network
@@ -53,7 +52,6 @@ fn canister_create() {
 }
 
 #[test]
-#[serial]
 fn canister_create_with_settings() {
     let ctx = TestContext::new().with_dfx();
 
@@ -90,6 +88,7 @@ fn canister_create_with_settings() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network
@@ -126,7 +125,6 @@ fn canister_create_with_settings() {
 }
 
 #[test]
-#[serial]
 fn canister_create_with_settings_cmdline_override() {
     let ctx = TestContext::new().with_dfx();
 
@@ -158,6 +156,7 @@ fn canister_create_with_settings_cmdline_override() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/canister_delete_tests.rs
+++ b/bin/icp-cli/tests/canister_delete_tests.rs
@@ -1,11 +1,9 @@
 use crate::common::TestContext;
 use icp_fs::fs::write;
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_delete() {
     let ctx = TestContext::new().with_dfx();
 
@@ -35,6 +33,7 @@ fn canister_delete() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/canister_info_tests.rs
+++ b/bin/icp-cli/tests/canister_info_tests.rs
@@ -1,12 +1,10 @@
 use crate::common::TestContext;
 use icp_fs::fs::write;
 use predicates::{prelude::PredicateBooleanExt, str::contains};
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_status() {
     let ctx = TestContext::new().with_dfx();
 
@@ -36,6 +34,7 @@ fn canister_status() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/canister_install_tests.rs
+++ b/bin/icp-cli/tests/canister_install_tests.rs
@@ -1,12 +1,10 @@
 use crate::common::TestContext;
 use icp_fs::fs::write;
 use predicates::{ord::eq, str::PredicateStrExt};
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_install() {
     let ctx = TestContext::new().with_dfx();
 
@@ -36,6 +34,7 @@ fn canister_install() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/canister_start_tests.rs
+++ b/bin/icp-cli/tests/canister_start_tests.rs
@@ -4,12 +4,10 @@ use predicates::{
     prelude::PredicateBooleanExt,
     str::{contains, starts_with},
 };
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_start() {
     let ctx = TestContext::new().with_dfx();
 
@@ -39,6 +37,7 @@ fn canister_start() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/canister_status_tests.rs
+++ b/bin/icp-cli/tests/canister_status_tests.rs
@@ -4,12 +4,10 @@ use predicates::{
     prelude::PredicateBooleanExt,
     str::{contains, starts_with},
 };
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_status() {
     let ctx = TestContext::new().with_dfx();
 
@@ -39,6 +37,7 @@ fn canister_status() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/canister_stop_tests.rs
+++ b/bin/icp-cli/tests/canister_stop_tests.rs
@@ -4,12 +4,10 @@ use predicates::{
     prelude::PredicateBooleanExt,
     str::{contains, starts_with},
 };
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn canister_stop() {
     let ctx = TestContext::new().with_dfx();
 
@@ -39,6 +37,7 @@ fn canister_stop() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/deploy_tests.rs
+++ b/bin/icp-cli/tests/deploy_tests.rs
@@ -1,7 +1,6 @@
 use crate::common::TestContext;
 use icp_fs::fs::write;
 use predicates::{ord::eq, str::PredicateStrExt};
-use serial_test::serial;
 
 mod common;
 
@@ -61,7 +60,6 @@ fn deploy_canister_not_found() {
 }
 
 #[test]
-#[serial]
 fn deploy() {
     let ctx = TestContext::new().with_dfx();
 
@@ -91,6 +89,7 @@ fn deploy() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network
@@ -113,7 +112,6 @@ fn deploy() {
 }
 
 #[test]
-#[serial]
 fn deploy_twice_should_succeed() {
     let ctx = TestContext::new().with_dfx();
 
@@ -143,6 +141,7 @@ fn deploy_twice_should_succeed() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network

--- a/bin/icp-cli/tests/sync_tests.rs
+++ b/bin/icp-cli/tests/sync_tests.rs
@@ -1,15 +1,14 @@
 use crate::common::TestContext;
 use icp_fs::fs::write;
+use icp_network::NETWORK_LOCAL;
 use predicates::{
     prelude::PredicateBooleanExt,
     str::{PredicateStrExt, contains},
 };
-use serial_test::serial;
 
 mod common;
 
 #[test]
-#[serial]
 fn sync_adapter_script_single() {
     let ctx = TestContext::new().with_dfx();
 
@@ -42,6 +41,7 @@ fn sync_adapter_script_single() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network
@@ -65,7 +65,6 @@ fn sync_adapter_script_single() {
 }
 
 #[test]
-#[serial]
 fn sync_adapter_script_multiple() {
     let ctx = TestContext::new().with_dfx();
 
@@ -100,6 +99,7 @@ fn sync_adapter_script_multiple() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network
@@ -123,7 +123,6 @@ fn sync_adapter_script_multiple() {
 }
 
 #[tokio::test]
-#[serial]
 async fn sync_adapter_static_assets() {
     let ctx = TestContext::new().with_dfx();
 
@@ -163,10 +162,14 @@ async fn sync_adapter_static_assets() {
     .expect("failed to write project manifest");
 
     // Start network
+    ctx.configure_icp_local_network_random_port(&project_dir);
     let _g = ctx.start_network_in(&project_dir);
 
     // Wait for network
     ctx.ping_until_healthy(&project_dir);
+    let network_port = ctx
+        .wait_for_network_descriptor(&project_dir, NETWORK_LOCAL)
+        .gateway_port;
 
     // Canister ID
     let cid = "tqzl2-p7777-77776-aaaaa-cai";
@@ -186,7 +189,7 @@ async fn sync_adapter_static_assets() {
         .success();
 
     // Verify that assets canister was synced
-    let resp = reqwest::get(format!("http://localhost:8000/?canisterId={cid}"))
+    let resp = reqwest::get(format!("http://localhost:{network_port}/?canisterId={cid}"))
         .await
         .expect("request failed");
 


### PR DESCRIPTION
`#[serial]` is not necessary if PocketIC is started on a random port. This should speed CI up noticeably