### PR TITLE
chore: change pub to pub(crate) in icp-cli crate

### DIFF
--- a/crates/icp-cli/src/commands/build/mod.rs
+++ b/crates/icp-cli/src/commands/build/mod.rs
@@ -15,13 +15,13 @@ use crate::{
 };
 
 #[derive(Args, Debug)]
-pub struct BuildArgs {
+pub(crate) struct BuildArgs {
     /// The names of the canisters within the current project
-    pub names: Vec<String>,
+    pub(crate) names: Vec<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error("project does not contain a canister named '{name}'")]
     CanisterNotFound { name: String },
 
@@ -45,7 +45,7 @@ pub enum CommandError {
 }
 
 /// Executes the build command, compiling canisters defined in the project manifest.
-pub async fn exec(ctx: &Context, args: &BuildArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &BuildArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/binding_env_vars.rs
+++ b/crates/icp-cli/src/commands/canister/binding_env_vars.rs
@@ -20,19 +20,19 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Args)]
-pub struct BindingArgs {
+pub(crate) struct BindingArgs {
     /// The names of the canisters within the current project
-    pub names: Vec<String>,
+    pub(crate) names: Vec<String>,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -76,7 +76,7 @@ pub enum CommandError {
     InstallAgent(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &BindingArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &BindingArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/call.rs
+++ b/crates/icp-cli/src/commands/canister/call.rs
@@ -12,15 +12,15 @@ use crate::{
 };
 
 #[derive(Args, Debug)]
-pub struct CallArgs {
+pub(crate) struct CallArgs {
     /// Name of canister to call to
-    pub name: String,
+    pub(crate) name: String,
 
     /// Name of canister method to call into
-    pub method: String,
+    pub(crate) method: String,
 
     /// String representation of canister call arguments
-    pub args: String,
+    pub(crate) args: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -30,7 +30,7 @@ pub struct CallArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -68,7 +68,7 @@ pub enum CommandError {
     Call(#[from] ic_agent::AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");
@@ -131,7 +131,7 @@ pub async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), CommandError> {
 }
 
 /// Pretty-prints IDLArgs detecting the terminal's width to avoid the 80-column default.
-pub fn print_candid_for_term(term: &mut Term, args: &IDLArgs) -> io::Result<()> {
+pub(crate) fn print_candid_for_term(term: &mut Term, args: &IDLArgs) -> io::Result<()> {
     if term.is_term() {
         let width = term.size().1 as usize;
         let pp_args = candid_parser::pretty::candid::value::pp_args(args);

--- a/crates/icp-cli/src/commands/canister/create.rs
+++ b/crates/icp-cli/src/commands/canister/create.rs
@@ -23,61 +23,61 @@ use crate::{
     store_id::{Key, LookupError, RegisterError},
 };
 
-pub const DEFAULT_CANISTER_CYCLES: u128 = 2 * TRILLION;
+pub(crate) const DEFAULT_CANISTER_CYCLES: u128 = 2 * TRILLION;
 
 #[derive(Clone, Debug, Default, Args)]
-pub struct CanisterSettings {
+pub(crate) struct CanisterSettings {
     /// Optional compute allocation (0 to 100). Represents guaranteed compute capacity.
     #[arg(long)]
-    pub compute_allocation: Option<u64>,
+    pub(crate) compute_allocation: Option<u64>,
 
     /// Optional memory allocation in bytes. If unset, memory is allocated dynamically.
     #[arg(long)]
-    pub memory_allocation: Option<u64>,
+    pub(crate) memory_allocation: Option<u64>,
 
     /// Optional freezing threshold in seconds. Controls how long a canister can be inactive before being frozen.
     #[arg(long)]
-    pub freezing_threshold: Option<u64>,
+    pub(crate) freezing_threshold: Option<u64>,
 
     /// Optional reserved cycles limit. If set, the canister cannot consume more than this many cycles.
     #[arg(long)]
-    pub reserved_cycles_limit: Option<u64>,
+    pub(crate) reserved_cycles_limit: Option<u64>,
 }
 
 #[derive(Clone, Debug, Args)]
-pub struct CreateArgs {
+pub(crate) struct CreateArgs {
     /// The names of the canister within the current project
-    pub names: Vec<String>,
+    pub(crate) names: Vec<String>,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 
     /// One or more controllers for the canister. Repeat `--controller` to specify multiple.
     #[arg(long)]
-    pub controller: Vec<Principal>,
+    pub(crate) controller: Vec<Principal>,
 
     // Resource-related settings and thresholds for the new canister.
     #[command(flatten)]
-    pub settings: CanisterSettings,
+    pub(crate) settings: CanisterSettings,
 
     /// Suppress human-readable output; print only canister IDs, one per line, to stdout.
     #[arg(long, short = 'q')]
-    pub quiet: bool,
+    pub(crate) quiet: bool,
 
     /// Cycles to fund canister creation (in raw cycles).
     #[arg(long, default_value_t = DEFAULT_CANISTER_CYCLES)]
-    pub cycles: u128,
+    pub(crate) cycles: u128,
 
     /// The subnet to create canisters on.
     #[arg(long)]
-    pub subnet: Option<Principal>,
+    pub(crate) subnet: Option<Principal>,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -130,7 +130,7 @@ pub enum CommandError {
 // Creates canister(s) by asking the cycles ledger to create them.
 // The cycles ledger will take cycles out of the user's account, and attaches them to a call to CMC::create_canister.
 // The CMC will then pick a subnet according to the user's preferences and permissions, and create a canister on that subnet.
-pub async fn exec(ctx: &Context, args: &CreateArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &CreateArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/delete.rs
+++ b/crates/icp-cli/src/commands/canister/delete.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct DeleteArgs {
+pub(crate) struct DeleteArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -21,7 +21,7 @@ pub struct DeleteArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -50,7 +50,7 @@ pub enum CommandError {
     Delete(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &DeleteArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &DeleteArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/info.rs
+++ b/crates/icp-cli/src/commands/canister/info.rs
@@ -11,9 +11,9 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct InfoArgs {
+pub(crate) struct InfoArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -23,7 +23,7 @@ pub struct InfoArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -52,7 +52,7 @@ pub enum CommandError {
     Status(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &InfoArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &InfoArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");
@@ -111,7 +111,7 @@ pub async fn exec(ctx: &Context, args: &InfoArgs) -> Result<(), CommandError> {
     Ok(())
 }
 
-pub fn print_info(result: &CanisterStatusResult) {
+pub(crate) fn print_info(result: &CanisterStatusResult) {
     let controllers: Vec<String> = result
         .settings
         .controllers

--- a/crates/icp-cli/src/commands/canister/install.rs
+++ b/crates/icp-cli/src/commands/canister/install.rs
@@ -16,23 +16,23 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Args)]
-pub struct InstallArgs {
+pub(crate) struct InstallArgs {
     /// The names of the canisters within the current project
-    pub names: Vec<String>,
+    pub(crate) names: Vec<String>,
 
     /// Specifies the mode of canister installation.
     #[arg(long, short, default_value = "auto", value_parser = ["auto", "install", "reinstall", "upgrade"])]
-    pub mode: String,
+    pub(crate) mode: String,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -70,7 +70,7 @@ pub enum CommandError {
     InstallAgent(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &InstallArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &InstallArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/list.rs
+++ b/crates/icp-cli/src/commands/canister/list.rs
@@ -6,13 +6,13 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct ListArgs {
+pub(crate) struct ListArgs {
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -20,7 +20,7 @@ pub enum CommandError {
     EnvironmentNotFound { name: String },
 }
 
-pub async fn exec(ctx: &Context, args: &ListArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &ListArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/mod.rs
+++ b/crates/icp-cli/src/commands/canister/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod stop;
 pub(crate) mod top_up;
 
 #[derive(Debug, Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     Call(call::CallArgs),
     Create(create::CreateArgs),
     Delete(delete::DeleteArgs),

--- a/crates/icp-cli/src/commands/canister/settings/mod.rs
+++ b/crates/icp-cli/src/commands/canister/settings/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod update;
 
 #[derive(Subcommand, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum Command {
+pub(crate) enum Command {
     Show(show::ShowArgs),
     Update(update::UpdateArgs),
 }

--- a/crates/icp-cli/src/commands/canister/settings/show.rs
+++ b/crates/icp-cli/src/commands/canister/settings/show.rs
@@ -10,9 +10,9 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct ShowArgs {
+pub(crate) struct ShowArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -22,7 +22,7 @@ pub struct ShowArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -51,7 +51,7 @@ pub enum CommandError {
     Status(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");
@@ -108,7 +108,7 @@ pub async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), CommandError> {
     Ok(())
 }
 
-pub fn print_settings(result: &CanisterStatusResult) {
+pub(crate) fn print_settings(result: &CanisterStatusResult) {
     eprintln!("Canister Settings:");
 
     let settings = &result.settings;

--- a/crates/icp-cli/src/commands/canister/settings/update.rs
+++ b/crates/icp-cli/src/commands/canister/settings/update.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Default, Args)]
-pub struct ControllerOpt {
+pub(crate) struct ControllerOpt {
     #[arg(long, action = ArgAction::Append, conflicts_with("set_controller"))]
     add_controller: Option<Vec<Principal>>,
 
@@ -25,13 +25,13 @@ pub struct ControllerOpt {
 }
 
 impl ControllerOpt {
-    pub fn require_current_settings(&self) -> bool {
+    pub(crate) fn require_current_settings(&self) -> bool {
         self.add_controller.is_some() || self.remove_controller.is_some()
     }
 }
 
 #[derive(Clone, Debug, Default, Args)]
-pub struct LogVisibilityOpt {
+pub(crate) struct LogVisibilityOpt {
     #[arg(
         long,
         value_parser = log_visibility_parser,
@@ -52,13 +52,13 @@ pub struct LogVisibilityOpt {
 }
 
 impl LogVisibilityOpt {
-    pub fn require_current_settings(&self) -> bool {
+    pub(crate) fn require_current_settings(&self) -> bool {
         self.add_log_viewer.is_some() || self.remove_log_viewer.is_some()
     }
 }
 
 #[derive(Clone, Debug, Default, Args)]
-pub struct EnvironmentVariableOpt {
+pub(crate) struct EnvironmentVariableOpt {
     #[arg(long, value_parser = environment_variable_parser, action = ArgAction::Append)]
     add_environment_variable: Option<Vec<EnvironmentVariable>>,
 
@@ -67,15 +67,15 @@ pub struct EnvironmentVariableOpt {
 }
 
 impl EnvironmentVariableOpt {
-    pub fn require_current_settings(&self) -> bool {
+    pub(crate) fn require_current_settings(&self) -> bool {
         self.add_environment_variable.is_some() || self.remove_environment_variable.is_some()
     }
 }
 
 #[derive(Debug, Args)]
-pub struct UpdateArgs {
+pub(crate) struct UpdateArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -112,7 +112,7 @@ pub struct UpdateArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -144,7 +144,7 @@ pub enum CommandError {
     Update(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &UpdateArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &UpdateArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/show.rs
+++ b/crates/icp-cli/src/commands/canister/show.rs
@@ -7,16 +7,16 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct ShowArgs {
+pub(crate) struct ShowArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -33,7 +33,7 @@ pub enum CommandError {
     LookupCanisterId(#[from] LookupIdError),
 }
 
-pub async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/start.rs
+++ b/crates/icp-cli/src/commands/canister/start.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct StartArgs {
+pub(crate) struct StartArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -21,7 +21,7 @@ pub struct StartArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -50,7 +50,7 @@ pub enum CommandError {
     Start(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &StartArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &StartArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/status.rs
+++ b/crates/icp-cli/src/commands/canister/status.rs
@@ -10,9 +10,9 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct StatusArgs {
+pub(crate) struct StatusArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -22,7 +22,7 @@ pub struct StatusArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -51,7 +51,7 @@ pub enum CommandError {
     Status(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");
@@ -110,7 +110,7 @@ pub async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), CommandError> 
     Ok(())
 }
 
-pub fn print_status(result: &CanisterStatusResult) {
+pub(crate) fn print_status(result: &CanisterStatusResult) {
     eprintln!("Canister Status Report:");
     eprintln!("  Status: {:?}", result.status);
 

--- a/crates/icp-cli/src/commands/canister/stop.rs
+++ b/crates/icp-cli/src/commands/canister/stop.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct StopArgs {
+pub(crate) struct StopArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -21,7 +21,7 @@ pub struct StopArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -50,7 +50,7 @@ pub enum CommandError {
     Stop(#[from] AgentError),
 }
 
-pub async fn exec(ctx: &Context, args: &StopArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &StopArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/canister/top_up.rs
+++ b/crates/icp-cli/src/commands/canister/top_up.rs
@@ -14,13 +14,13 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct TopUpArgs {
+pub(crate) struct TopUpArgs {
     /// The name of the canister within the current project
-    pub name: String,
+    pub(crate) name: String,
 
     /// Amount of cycles to top up
     #[arg(long)]
-    pub amount: u128,
+    pub(crate) amount: u128,
 
     #[command(flatten)]
     identity: IdentityOpt,
@@ -30,7 +30,7 @@ pub struct TopUpArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -65,7 +65,7 @@ pub enum CommandError {
     Withdraw { err: WithdrawError, amount: u128 },
 }
 
-pub async fn exec(ctx: &Context, args: &TopUpArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &TopUpArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/cycles/balance.rs
+++ b/crates/icp-cli/src/commands/cycles/balance.rs
@@ -1,12 +1,15 @@
 use crate::{commands::Context, commands::token};
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Balance(#[from] token::balance::CommandError),
 }
 
-pub async fn exec(ctx: &Context, args: &token::balance::BalanceArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(
+    ctx: &Context,
+    args: &token::balance::BalanceArgs,
+) -> Result<(), CommandError> {
     token::balance::exec(ctx, "cycles", args)
         .await
         .map_err(Into::into)

--- a/crates/icp-cli/src/commands/cycles/mint.rs
+++ b/crates/icp-cli/src/commands/cycles/mint.rs
@@ -21,24 +21,24 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct MintArgs {
+pub(crate) struct MintArgs {
     /// Amount of ICP to mint to cycles.
     #[arg(long, conflicts_with = "cycles")]
-    pub icp: Option<BigDecimal>,
+    pub(crate) icp: Option<BigDecimal>,
 
     /// Amount of cycles to mint. Automatically determines the amount of ICP needed.
     #[arg(long, conflicts_with = "icp")]
-    pub cycles: Option<u128>,
+    pub(crate) cycles: Option<u128>,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -82,7 +82,7 @@ pub enum CommandError {
     NotifyMintError { src: NotifyMintErr },
 }
 
-pub async fn exec(ctx: &Context, args: &MintArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &MintArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/cycles/mod.rs
+++ b/crates/icp-cli/src/commands/cycles/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod balance;
 pub(crate) mod mint;
 
 #[derive(Subcommand, Debug)]
-pub enum Command {
+pub(crate) enum Command {
     Balance(token::balance::BalanceArgs),
     Mint(mint::MintArgs),
 }

--- a/crates/icp-cli/src/commands/deploy/mod.rs
+++ b/crates/icp-cli/src/commands/deploy/mod.rs
@@ -15,35 +15,35 @@ use crate::{
 };
 
 #[derive(Args, Debug)]
-pub struct DeployArgs {
+pub(crate) struct DeployArgs {
     /// Canister names
-    pub names: Vec<String>,
+    pub(crate) names: Vec<String>,
 
     /// Specifies the mode of canister installation.
     #[arg(long, short, default_value = "auto", value_parser = ["auto", "install", "reinstall", "upgrade"])]
-    pub mode: String,
+    pub(crate) mode: String,
 
     /// The subnet id to use for the canisters being deployed.
     #[clap(long)]
-    pub subnet_id: Option<Principal>,
+    pub(crate) subnet_id: Option<Principal>,
 
     /// One or more controllers for the canisters being deployed. Repeat `--controller` to specify multiple.
     #[arg(long)]
-    pub controller: Vec<Principal>,
+    pub(crate) controller: Vec<Principal>,
 
     /// Cycles to fund canister creation (in cycles).
     #[arg(long, default_value_t = create::DEFAULT_CANISTER_CYCLES)]
-    pub cycles: u128,
+    pub(crate) cycles: u128,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -75,7 +75,7 @@ pub enum CommandError {
     Sync(#[from] sync::CommandError),
 }
 
-pub async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/environment/list.rs
+++ b/crates/icp-cli/src/commands/environment/list.rs
@@ -3,15 +3,15 @@ use clap::Args;
 use crate::commands::{Context, Mode};
 
 #[derive(Debug, Args)]
-pub struct ListArgs;
+pub(crate) struct ListArgs;
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 }
 
-pub async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/environment/mod.rs
+++ b/crates/icp-cli/src/commands/environment/mod.rs
@@ -3,6 +3,6 @@ use clap::Subcommand;
 pub(crate) mod list;
 
 #[derive(Subcommand, Debug)]
-pub enum Command {
+pub(crate) enum Command {
     List(list::ListArgs),
 }

--- a/crates/icp-cli/src/commands/identity/default.rs
+++ b/crates/icp-cli/src/commands/identity/default.rs
@@ -7,12 +7,12 @@ use icp::identity::manifest::{
 use crate::commands::{Context, Mode};
 
 #[derive(Debug, Args)]
-pub struct DefaultArgs {
+pub(crate) struct DefaultArgs {
     name: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     ChangeDefault(#[from] ChangeDefaultsError),
 
@@ -20,7 +20,7 @@ pub enum CommandError {
     LoadList(#[from] LoadIdentityManifestError),
 }
 
-pub async fn exec(ctx: &Context, args: &DefaultArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &DefaultArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global | Mode::Project(_) => {
             // Load project directories

--- a/crates/icp-cli/src/commands/identity/import.rs
+++ b/crates/icp-cli/src/commands/identity/import.rs
@@ -21,7 +21,7 @@ use crate::commands::{Context, Mode};
 
 #[derive(Debug, Args)]
 #[command(group(ArgGroup::new("import-from").required(true)))]
-pub struct ImportArgs {
+pub(crate) struct ImportArgs {
     name: String,
 
     #[arg(long, value_name = "FILE", group = "import-from")]
@@ -40,7 +40,7 @@ pub struct ImportArgs {
     assert_key_type: Option<IdentityKeyAlgorithm>,
 }
 
-pub async fn exec(ctx: &Context, args: &ImportArgs) -> Result<(), ImportCmdError> {
+pub(crate) async fn exec(ctx: &Context, args: &ImportArgs) -> Result<(), ImportCmdError> {
     match &ctx.mode {
         Mode::Global | Mode::Project(_) => {
             if let Some(from_pem) = &args.from_pem {
@@ -73,7 +73,7 @@ pub async fn exec(ctx: &Context, args: &ImportArgs) -> Result<(), ImportCmdError
 }
 
 #[derive(Snafu, Debug)]
-pub enum ImportCmdError {
+pub(crate) enum ImportCmdError {
     #[snafu(transparent)]
     PemImport { source: LoadKeyError },
 
@@ -285,7 +285,7 @@ fn import_from_seed_phrase(ctx: &Context, name: &str, phrase: &str) -> Result<()
 }
 
 #[derive(Debug, Snafu)]
-pub enum LoadKeyError {
+pub(crate) enum LoadKeyError {
     #[snafu(display("unknown PEM formats: expected {}; found {}", expected.join(", "), found.join(", ")))]
     UnknownPemFormat {
         expected: Vec<&'static str>,
@@ -340,7 +340,7 @@ pub enum LoadKeyError {
 }
 
 #[derive(Debug, Snafu)]
-pub enum DeriveKeyError {
+pub(crate) enum DeriveKeyError {
     #[snafu(display("failed to read seed file"))]
     ReadSeedFile { source: icp::fs::Error },
 

--- a/crates/icp-cli/src/commands/identity/list.rs
+++ b/crates/icp-cli/src/commands/identity/list.rs
@@ -7,15 +7,15 @@ use itertools::Itertools;
 use crate::commands::{Context, Mode};
 
 #[derive(Debug, Args)]
-pub struct ListArgs;
+pub(crate) struct ListArgs;
 
 #[derive(Debug, thiserror::Error)]
-pub enum ListKeysError {
+pub(crate) enum ListKeysError {
     #[error(transparent)]
     LoadIdentity(#[from] LoadIdentityManifestError),
 }
 
-pub async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), ListKeysError> {
+pub(crate) async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), ListKeysError> {
     match &ctx.mode {
         Mode::Global | Mode::Project(_) => {
             let dir = ctx.dirs.identity();

--- a/crates/icp-cli/src/commands/identity/mod.rs
+++ b/crates/icp-cli/src/commands/identity/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod new;
 pub(crate) mod principal;
 
 #[derive(Debug, Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     Default(default::DefaultArgs),
     Import(import::ImportArgs),
     List(list::ListArgs),

--- a/crates/icp-cli/src/commands/identity/new.rs
+++ b/crates/icp-cli/src/commands/identity/new.rs
@@ -12,14 +12,14 @@ use icp::{
 use crate::commands::{Context, Mode};
 
 #[derive(Debug, Args)]
-pub struct NewArgs {
+pub(crate) struct NewArgs {
     name: String,
     #[arg(long, value_name = "FILE")]
     output_seed: Option<PathBuf>,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     CreateIdentityError(#[from] CreateIdentityError),
 
@@ -27,7 +27,7 @@ pub enum CommandError {
     WriteSeedFileError(#[from] icp::fs::Error),
 }
 
-pub async fn exec(ctx: &Context, args: &NewArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &NewArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global | Mode::Project(_) => {
             let mnemonic = Mnemonic::new(

--- a/crates/icp-cli/src/commands/identity/principal.rs
+++ b/crates/icp-cli/src/commands/identity/principal.rs
@@ -7,13 +7,13 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct PrincipalArgs {
+pub(crate) struct PrincipalArgs {
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum PrincipalError {
+pub(crate) enum PrincipalError {
     #[error(transparent)]
     Identity(#[from] identity::LoadError),
 
@@ -21,7 +21,7 @@ pub enum PrincipalError {
     Sender { message: String },
 }
 
-pub async fn exec(ctx: &Context, args: &PrincipalArgs) -> Result<(), PrincipalError> {
+pub(crate) async fn exec(ctx: &Context, args: &PrincipalArgs) -> Result<(), PrincipalError> {
     match &ctx.mode {
         Mode::Global | Mode::Project(_) => {
             let id = ctx.identity.load(args.identity.clone().into()).await?;

--- a/crates/icp-cli/src/commands/mod.rs
+++ b/crates/icp-cli/src/commands/mod.rs
@@ -10,26 +10,26 @@ use icp::{
 
 use crate::{store_artifact::ArtifactStore, store_id::IdStore};
 
-pub mod build;
-pub mod canister;
-pub mod cycles;
-pub mod deploy;
-pub mod environment;
-pub mod identity;
-pub mod network;
-pub mod project;
-pub mod sync;
-pub mod token;
+pub(crate) mod build;
+pub(crate) mod canister;
+pub(crate) mod cycles;
+pub(crate) mod deploy;
+pub(crate) mod environment;
+pub(crate) mod identity;
+pub(crate) mod network;
+pub(crate) mod project;
+pub(crate) mod sync;
+pub(crate) mod token;
 
 #[derive(Debug, PartialEq)]
-pub enum Mode {
+pub(crate) enum Mode {
     Global,
     Project(PathBuf),
 }
 
 #[derive(Subcommand, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum Command {
+pub(crate) enum Command {
     /// Build a project
     Build(build::BuildArgs),
 
@@ -68,40 +68,40 @@ pub enum Command {
     Token(token::Command),
 }
 
-pub struct Context {
+pub(crate) struct Context {
     /// Command exection mode
-    pub mode: Mode,
+    pub(crate) mode: Mode,
 
     /// Terminal for printing messages for the user to see
-    pub term: Term,
+    pub(crate) term: Term,
 
     /// Various cli-related directories (cache, configuration, etc).
-    pub dirs: Directories,
+    pub(crate) dirs: Directories,
 
     /// Canisters ID Store for lookup and storage
-    pub ids: IdStore,
+    pub(crate) ids: IdStore,
 
     /// An artifact store for canister build artifacts
-    pub artifacts: ArtifactStore,
+    pub(crate) artifacts: ArtifactStore,
 
     /// Project loader
-    pub project: Arc<dyn icp::Load>,
+    pub(crate) project: Arc<dyn icp::Load>,
 
     /// Identity loader
-    pub identity: Arc<dyn icp::identity::Load>,
+    pub(crate) identity: Arc<dyn icp::identity::Load>,
 
     /// NetworkAccess loader
-    pub network: Arc<dyn icp::network::Access>,
+    pub(crate) network: Arc<dyn icp::network::Access>,
 
     /// Agent creator
-    pub agent: Arc<dyn icp::agent::Create>,
+    pub(crate) agent: Arc<dyn icp::agent::Create>,
 
     /// Canister builder
-    pub builder: Arc<dyn Build>,
+    pub(crate) builder: Arc<dyn Build>,
 
     /// Canister synchronizer
-    pub syncer: Arc<dyn Synchronize>,
+    pub(crate) syncer: Arc<dyn Synchronize>,
 
     /// Whether debug is enabled
-    pub debug: bool,
+    pub(crate) debug: bool,
 }

--- a/crates/icp-cli/src/commands/network/list.rs
+++ b/crates/icp-cli/src/commands/network/list.rs
@@ -4,10 +4,10 @@ use crate::commands::{Context, Mode};
 
 /// List networks in the project
 #[derive(Args, Debug)]
-pub struct ListArgs;
+pub(crate) struct ListArgs;
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -15,7 +15,7 @@ pub enum CommandError {
     Unexpected(#[from] anyhow::Error),
 }
 
-pub async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/network/mod.rs
+++ b/crates/icp-cli/src/commands/network/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod ping;
 pub(crate) mod run;
 
 #[derive(Subcommand, Debug)]
-pub enum Command {
+pub(crate) enum Command {
     List(list::ListArgs),
     Ping(ping::PingArgs),
     Run(run::RunArgs),

--- a/crates/icp-cli/src/commands/network/ping.rs
+++ b/crates/icp-cli/src/commands/network/ping.rs
@@ -13,7 +13,7 @@ use crate::commands::{Context, Mode};
 
 /// Try to connect to a network, and print out its status.
 #[derive(Args, Debug)]
-pub struct PingArgs {
+pub(crate) struct PingArgs {
     /// The compute network to connect to. By default, ping the local network.
     #[arg(value_name = "NETWORK", default_value = "local")]
     network: String,
@@ -24,7 +24,7 @@ pub struct PingArgs {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -50,7 +50,7 @@ pub enum CommandError {
     Unexpected(#[from] anyhow::Error),
 }
 
-pub async fn exec(ctx: &Context, args: &PingArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &PingArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global | Mode::Project(_) => {
             // Load Project

--- a/crates/icp-cli/src/commands/network/run.rs
+++ b/crates/icp-cli/src/commands/network/run.rs
@@ -9,14 +9,14 @@ use crate::commands::{Context, Mode};
 
 /// Run a given network
 #[derive(Args, Debug)]
-pub struct RunArgs {
+pub(crate) struct RunArgs {
     /// Name of the network to run
     #[arg(default_value = "local")]
     name: String,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -36,7 +36,7 @@ pub enum CommandError {
     RunNetwork(#[from] RunNetworkError),
 }
 
-pub async fn exec(ctx: &Context, args: &RunArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &RunArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/project/mod.rs
+++ b/crates/icp-cli/src/commands/project/mod.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 pub(crate) mod show;
 
 #[derive(Debug, Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     /// Outputs the project's effective yaml configuration.
     Show(show::ShowArgs),
 }

--- a/crates/icp-cli/src/commands/project/show.rs
+++ b/crates/icp-cli/src/commands/project/show.rs
@@ -4,17 +4,17 @@ use clap::Args;
 use crate::commands::{Context, Mode};
 
 #[derive(Args, Debug)]
-pub struct ShowArgs;
+pub(crate) struct ShowArgs;
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Unexpected(#[from] anyhow::Error),
 }
 
 /// Loads the project's configuration and output the effective yaml config
 /// after resolving recipes
-pub async fn exec(ctx: &Context, _: &ShowArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, _: &ShowArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/sync/mod.rs
+++ b/crates/icp-cli/src/commands/sync/mod.rs
@@ -17,19 +17,19 @@ use crate::{
 };
 
 #[derive(Args, Debug)]
-pub struct SyncArgs {
+pub(crate) struct SyncArgs {
     /// Canister names
-    pub names: Vec<String>,
+    pub(crate) names: Vec<String>,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -64,7 +64,7 @@ pub enum CommandError {
     Synchronize(#[from] SynchronizeError),
 }
 
-pub async fn exec(ctx: &Context, args: &SyncArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(ctx: &Context, args: &SyncArgs) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/token/balance.rs
+++ b/crates/icp-cli/src/commands/token/balance.rs
@@ -11,16 +11,16 @@ use crate::{
 };
 
 #[derive(Args, Clone, Debug)]
-pub struct BalanceArgs {
+pub(crate) struct BalanceArgs {
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -51,7 +51,11 @@ pub enum CommandError {
 /// The balance is checked against a ledger canister. Support two user flows:
 /// (1) Specifying token name, and checking against known or stored mappings
 /// (2) Specifying compatible ledger canister id
-pub async fn exec(ctx: &Context, token: &str, args: &BalanceArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(
+    ctx: &Context,
+    token: &str,
+    args: &BalanceArgs,
+) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/commands/token/mod.rs
+++ b/crates/icp-cli/src/commands/token/mod.rs
@@ -18,16 +18,16 @@ static TOKEN_LEDGER_CIDS: phf::Map<&'static str, &'static str> = phf_map! {
 };
 
 #[derive(Debug, Parser)]
-pub struct Command {
+pub(crate) struct Command {
     #[arg(default_value = "icp")]
-    pub token: String,
+    pub(crate) token: String,
 
     #[command(subcommand)]
-    pub command: Commands,
+    pub(crate) command: Commands,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum Commands {
+pub(crate) enum Commands {
     Balance(balance::BalanceArgs),
     Transfer(transfer::TransferArgs),
 }

--- a/crates/icp-cli/src/commands/token/transfer.rs
+++ b/crates/icp-cli/src/commands/token/transfer.rs
@@ -14,22 +14,22 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
-pub struct TransferArgs {
+pub(crate) struct TransferArgs {
     /// Token amount to transfer
-    pub amount: BigDecimal,
+    pub(crate) amount: BigDecimal,
 
     /// The receiver of the token transfer
-    pub receiver: Principal,
+    pub(crate) receiver: Principal,
 
     #[command(flatten)]
-    pub identity: IdentityOpt,
+    pub(crate) identity: IdentityOpt,
 
     #[command(flatten)]
-    pub environment: EnvironmentOpt,
+    pub(crate) environment: EnvironmentOpt,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+pub(crate) enum CommandError {
     #[error(transparent)]
     Project(#[from] icp::LoadError),
 
@@ -68,7 +68,11 @@ pub enum CommandError {
     },
 }
 
-pub async fn exec(ctx: &Context, token: &str, args: &TransferArgs) -> Result<(), CommandError> {
+pub(crate) async fn exec(
+    ctx: &Context,
+    token: &str,
+    args: &TransferArgs,
+) -> Result<(), CommandError> {
     match &ctx.mode {
         Mode::Global => {
             unimplemented!("global mode is not implemented yet");

--- a/crates/icp-cli/src/logging.rs
+++ b/crates/icp-cli/src/logging.rs
@@ -12,9 +12,9 @@ use tracing_subscriber::{
 };
 
 #[derive(Debug)]
-pub struct TermWriter<W: Write + AsRawFd> {
-    pub debug: bool,
-    pub writer: Box<W>,
+pub(crate) struct TermWriter<W: Write + AsRawFd> {
+    pub(crate) debug: bool,
+    pub(crate) writer: Box<W>,
 }
 
 impl<W: Write + AsRawFd> Write for TermWriter<W> {
@@ -46,7 +46,7 @@ type DebugLayer<S> = Filtered<
     S,
 >;
 
-pub fn debug_layer<S: Subscriber + for<'a> LookupSpan<'a>>() -> DebugLayer<S> {
+pub(crate) fn debug_layer<S: Subscriber + for<'a> LookupSpan<'a>>() -> DebugLayer<S> {
     let workspace_targets = Targets::new()
         .with_target("icp-cli", Level::DEBUG)
         .with_target("icp", Level::DEBUG);

--- a/crates/icp-cli/src/options.rs
+++ b/crates/icp-cli/src/options.rs
@@ -2,7 +2,7 @@ use clap::{ArgGroup, Args};
 use icp::identity::IdentitySelection;
 
 #[derive(Args, Clone, Debug, Default)]
-pub struct IdentityOpt {
+pub(crate) struct IdentityOpt {
     /// The user identity to run this command as.
     #[arg(long, global = true)]
     identity: Option<String>,
@@ -25,7 +25,7 @@ impl From<IdentityOpt> for IdentitySelection {
 
 #[derive(Args, Clone, Debug, Default)]
 #[clap(group(ArgGroup::new("environment-select").multiple(false)))]
-pub struct EnvironmentOpt {
+pub(crate) struct EnvironmentOpt {
     /// Override the environment to connect to. By default, the local environment is used.
     #[arg(
         long,
@@ -41,7 +41,7 @@ pub struct EnvironmentOpt {
 }
 
 impl EnvironmentOpt {
-    pub fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         // Support --ic
         if self.ic {
             return "ic";

--- a/crates/icp-cli/src/progress.rs
+++ b/crates/icp-cli/src/progress.rs
@@ -7,7 +7,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::debug;
 
 /// The maximum number of lines to display for a step output
-pub const MAX_LINES_PER_STEP: usize = 10_000;
+pub(crate) const MAX_LINES_PER_STEP: usize = 10_000;
 
 // Animation frames for the spinner - creates a rotating star effect
 const TICKS: &[&str] = &["✶", "✸", "✹", "✺", "✹", "✷"];
@@ -37,20 +37,20 @@ fn make_style(end_tick: &str, color: &str) -> ProgressStyle {
 
 /// A fixed-capacity rolling buffer that always holds the last `capacity` items.
 #[derive(Debug)]
-pub struct RollingLines {
+pub(crate) struct RollingLines {
     buf: VecDeque<String>,
     capacity: usize,
 }
 
 impl RollingLines {
     /// Create a new buffer with a fixed capacity.
-    pub fn new(capacity: usize) -> Self {
+    pub(crate) fn new(capacity: usize) -> Self {
         let buf = VecDeque::with_capacity(capacity);
         Self { buf, capacity }
     }
 
     /// Push a new line, evicting the oldest if full.
-    pub fn push(&mut self, line: String) {
+    pub(crate) fn push(&mut self, line: String) {
         if self.buf.len() == self.capacity {
             self.buf.pop_front();
         }
@@ -59,29 +59,29 @@ impl RollingLines {
     }
 
     /// Get an iterator over the current contents (in order).
-    pub fn iter(&self) -> impl Iterator<Item = &str> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
         self.buf.iter().map(|s| s.as_str())
     }
 
     /// Convert the buffer into an iterator (in order).
-    pub fn into_iter(self) -> impl Iterator<Item = String> {
+    pub(crate) fn into_iter(self) -> impl Iterator<Item = String> {
         self.buf.into_iter()
     }
 }
 
 /// Settings for the progress manager
-pub struct ProgressManagerSettings {
+pub(crate) struct ProgressManagerSettings {
     /// Whether to hide the progress bars
-    pub hidden: bool,
+    pub(crate) hidden: bool,
 }
 
 /// Shared progress bar utilities for build and sync commands
-pub struct ProgressManager {
-    pub multi_progress: MultiProgress,
+pub(crate) struct ProgressManager {
+    pub(crate) multi_progress: MultiProgress,
 }
 
 impl ProgressManager {
-    pub fn new(settings: ProgressManagerSettings) -> Self {
+    pub(crate) fn new(settings: ProgressManagerSettings) -> Self {
         let multi_progress = MultiProgress::new();
 
         if settings.hidden {
@@ -92,7 +92,7 @@ impl ProgressManager {
     }
 
     /// Create a new progress bar with standard configuration
-    pub fn create_progress_bar(&self, canister_name: &str) -> SimpleProgressBar {
+    pub(crate) fn create_progress_bar(&self, canister_name: &str) -> SimpleProgressBar {
         let pb = self
             .multi_progress
             .add(SimpleProgressBar::new_spinner().with_style(make_style(
@@ -110,7 +110,7 @@ impl ProgressManager {
     }
 
     /// Create a new progress bar for a multi-step operation.
-    pub fn create_multi_step_progress_bar(
+    pub(crate) fn create_multi_step_progress_bar(
         &self,
         canister_name: &str,
         output_label: &str,
@@ -125,7 +125,7 @@ impl ProgressManager {
     }
 
     /// Execute a task with progress tracking and automatic style updates
-    pub async fn execute_with_progress<F, R, E, P>(
+    pub(crate) async fn execute_with_progress<F, R, E, P>(
         progress_bar: &P,
         task: F,
         success_message: impl Fn() -> String,
@@ -147,7 +147,7 @@ impl ProgressManager {
     }
 
     /// Execute a task with custom progress handling for errors that should display as success
-    pub async fn execute_with_custom_progress<F, R, E, P>(
+    pub(crate) async fn execute_with_custom_progress<F, R, E, P>(
         progress_bar: &P,
         task: F,
         success_message: impl Fn() -> String,
@@ -188,7 +188,7 @@ struct StepInProgress {
     receiver: JoinHandle<Vec<String>>,
 }
 
-pub struct MultiStepProgressBar {
+pub(crate) struct MultiStepProgressBar {
     progress_bar: SimpleProgressBar,
     canister_name: String,
     output_label: String,
@@ -197,7 +197,7 @@ pub struct MultiStepProgressBar {
 }
 
 impl MultiStepProgressBar {
-    pub fn begin_step(&mut self, title: String) -> mpsc::Sender<String> {
+    pub(crate) fn begin_step(&mut self, title: String) -> mpsc::Sender<String> {
         if self.in_progress.is_some() {
             panic!("step already in progress");
         }
@@ -243,7 +243,7 @@ impl MultiStepProgressBar {
         tx
     }
 
-    pub async fn end_step(&mut self) {
+    pub(crate) async fn end_step(&mut self) {
         let StepInProgress { title, receiver } =
             self.in_progress.take().expect("no step in progress");
         let output = receiver.await.unwrap();
@@ -251,7 +251,7 @@ impl MultiStepProgressBar {
         self.finished_steps.push(StepOutput { title, output });
     }
 
-    pub fn dump_output(&self) -> Vec<String> {
+    pub(crate) fn dump_output(&self) -> Vec<String> {
         let mut lines = Vec::new();
 
         lines.push(format!(
@@ -282,7 +282,7 @@ impl MultiStepProgressBar {
     }
 }
 
-pub trait ProgressBar {
+pub(crate) trait ProgressBar {
     fn set_style(&self, style: ProgressStyle);
     fn set_message(&self, message: String);
     fn finish(&self);

--- a/crates/icp-cli/src/store_artifact.rs
+++ b/crates/icp-cli/src/store_artifact.rs
@@ -7,7 +7,7 @@ use icp::{
 use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
-pub enum SaveError {
+pub(crate) enum SaveError {
     #[snafu(display("failed to create artifacts directory"))]
     ArtifactsDir { source: icp::fs::Error },
 
@@ -16,7 +16,7 @@ pub enum SaveError {
 }
 
 #[derive(Debug, Snafu)]
-pub enum LookupError {
+pub(crate) enum LookupError {
     #[snafu(display("failed to read artifact file"))]
     LookupReadFileError { source: icp::fs::Error },
 
@@ -24,13 +24,13 @@ pub enum LookupError {
     LookupArtifactNotFound { name: String },
 }
 
-pub struct ArtifactStore {
+pub(crate) struct ArtifactStore {
     path: PathBuf,
     lock: Mutex<()>,
 }
 
 impl ArtifactStore {
-    pub fn new(path: &Path) -> Self {
+    pub(crate) fn new(path: &Path) -> Self {
         Self {
             path: path.to_owned(),
             lock: Mutex::new(()),
@@ -39,7 +39,7 @@ impl ArtifactStore {
 }
 
 impl ArtifactStore {
-    pub fn save(&self, name: &str, wasm: &[u8]) -> Result<(), SaveError> {
+    pub(crate) fn save(&self, name: &str, wasm: &[u8]) -> Result<(), SaveError> {
         // Lock Artifact Store
         let _g = self
             .lock
@@ -55,7 +55,7 @@ impl ArtifactStore {
         Ok(())
     }
 
-    pub fn lookup(&self, name: &str) -> Result<Vec<u8>, LookupError> {
+    pub(crate) fn lookup(&self, name: &str) -> Result<Vec<u8>, LookupError> {
         // Lock Artifact Store
         let _g = self
             .lock

--- a/crates/icp-cli/src/store_id.rs
+++ b/crates/icp-cli/src/store_id.rs
@@ -7,15 +7,15 @@ use snafu::{ResultExt, Snafu};
 
 /// An association-key, used for associating an existing canister to an ID on a network
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Key {
+pub(crate) struct Key {
     /// Network name
-    pub network: String,
+    pub(crate) network: String,
 
     /// Environment name
-    pub environment: String,
+    pub(crate) environment: String,
 
     /// Canister name
-    pub canister: String,
+    pub(crate) canister: String,
 }
 
 /// Association of a canister name and an ID
@@ -23,7 +23,7 @@ pub struct Key {
 struct Association(Key, Principal);
 
 #[derive(Debug, Snafu)]
-pub enum RegisterError {
+pub(crate) enum RegisterError {
     #[snafu(display("failed to load canister id store"))]
     RegisterLoadStore { source: json::Error },
 
@@ -38,7 +38,7 @@ pub enum RegisterError {
 }
 
 #[derive(Debug, Snafu)]
-pub enum LookupError {
+pub(crate) enum LookupError {
     #[snafu(display("failed to load canister id store"))]
     LookupLoadStore { source: json::Error },
 
@@ -52,13 +52,13 @@ pub enum LookupError {
     EnvironmentNotFound { name: String },
 }
 
-pub struct IdStore {
+pub(crate) struct IdStore {
     path: PathBuf,
     lock: Mutex<()>,
 }
 
 impl IdStore {
-    pub fn new(path: &Path) -> Self {
+    pub(crate) fn new(path: &Path) -> Self {
         Self {
             path: path.to_owned(),
             lock: Mutex::new(()),
@@ -67,7 +67,7 @@ impl IdStore {
 }
 
 impl IdStore {
-    pub fn register(&self, key: &Key, cid: &Principal) -> Result<(), RegisterError> {
+    pub(crate) fn register(&self, key: &Key, cid: &Principal) -> Result<(), RegisterError> {
         // Lock ID Store
         let _g = self.lock.lock().expect("failed to acquire id store lock");
 
@@ -101,7 +101,7 @@ impl IdStore {
         Ok(())
     }
 
-    pub fn lookup(&self, key: &Key) -> Result<Principal, LookupError> {
+    pub(crate) fn lookup(&self, key: &Key) -> Result<Principal, LookupError> {
         // Lock ID Store
         let _g = self.lock.lock().expect("failed to acquire id store lock");
 
@@ -129,7 +129,7 @@ impl IdStore {
         })
     }
 
-    pub fn lookup_by_environment(
+    pub(crate) fn lookup_by_environment(
         &self,
         environment: &str,
     ) -> Result<Vec<(String, Principal)>, LookupError> {

--- a/crates/icp-cli/src/telemetry.rs
+++ b/crates/icp-cli/src/telemetry.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::{Layer, layer};
 /// A visitor that collects field-value pairs from tracing events and spans
 /// into a HashMap where both keys and values are strings.
 #[derive(Default)]
-pub struct FieldCollector(HashMap<String, String>);
+pub(crate) struct FieldCollector(HashMap<String, String>);
 
 impl Visit for FieldCollector {
     /// Records a field and its debug representation as a string.
@@ -24,7 +24,7 @@ impl Visit for FieldCollector {
 
 /// A tracing layer that processes events by collecting their fields
 /// and printing them to stdout.
-pub struct EventLayer;
+pub(crate) struct EventLayer;
 
 impl<S: Subscriber> Layer<S> for EventLayer {
     /// Called when a tracing event occurs. Collects all fields from the event

--- a/crates/icp-cli/src/version.rs
+++ b/crates/icp-cli/src/version.rs
@@ -8,11 +8,11 @@ lazy_static! {
 /// Returns the version of icp-cli that was built.
 /// In debug, add a timestamp of the upstream compilation at the end of version to ensure all
 /// debug runs are unique.
-pub fn icp_cli_version_str() -> &'static str {
+pub(crate) fn icp_cli_version_str() -> &'static str {
     &VERSION_STR
 }
 
 /// Returns the git sha of the build.
-pub fn git_sha() -> &'static str {
+pub(crate) fn git_sha() -> &'static str {
     &GIT_SHA
 }

--- a/crates/icp-cli/tests/common/clients.rs
+++ b/crates/icp-cli/tests/common/clients.rs
@@ -2,13 +2,13 @@ use icp::prelude::*;
 
 use crate::common::TestContext;
 
-pub mod cmc;
-pub mod cycles_ledger;
-pub mod icp_cli;
-pub mod ledger;
-pub mod registry;
+pub(crate) mod cmc;
+pub(crate) mod cycles_ledger;
+pub(crate) mod icp_cli;
+pub(crate) mod ledger;
+pub(crate) mod registry;
 
-pub fn icp(
+pub(crate) fn icp(
     ctx: &TestContext,
     current_dir: impl Into<PathBuf>,
     environment: Option<String>,
@@ -16,18 +16,18 @@ pub fn icp(
     icp_cli::Client::new(ctx, current_dir.into(), environment)
 }
 
-pub fn ledger(ctx: &TestContext) -> ledger::Client<'_> {
+pub(crate) fn ledger(ctx: &TestContext) -> ledger::Client<'_> {
     ledger::Client::new(ctx)
 }
 
-pub fn cycles_ledger(ctx: &TestContext) -> cycles_ledger::Client<'_> {
+pub(crate) fn cycles_ledger(ctx: &TestContext) -> cycles_ledger::Client<'_> {
     cycles_ledger::Client::new(ctx)
 }
 
-pub fn registry(ctx: &TestContext) -> registry::Client<'_> {
+pub(crate) fn registry(ctx: &TestContext) -> registry::Client<'_> {
     registry::Client::new(ctx)
 }
 
-pub fn cmc(ctx: &TestContext) -> cmc::Client<'_> {
+pub(crate) fn cmc(ctx: &TestContext) -> cmc::Client<'_> {
     cmc::Client::new(ctx)
 }

--- a/crates/icp-cli/tests/common/clients/cmc.rs
+++ b/crates/icp-cli/tests/common/clients/cmc.rs
@@ -6,18 +6,18 @@ use pocket_ic::nonblocking::PocketIc;
 
 use crate::common::TestContext;
 
-pub struct Client<'a> {
+pub(crate) struct Client<'a> {
     pic: &'a PocketIc,
 }
 
 impl<'a> Client<'a> {
-    pub fn new(ctx: &'a TestContext) -> Self {
+    pub(crate) fn new(ctx: &'a TestContext) -> Self {
         Self {
             pic: ctx.pocketic(),
         }
     }
 
-    pub async fn get_default_subnets(&self) -> Vec<Principal> {
+    pub(crate) async fn get_default_subnets(&self) -> Vec<Principal> {
         let bytes = Encode!(&()).unwrap();
         let result = &self
             .pic

--- a/crates/icp-cli/tests/common/clients/cycles_ledger.rs
+++ b/crates/icp-cli/tests/common/clients/cycles_ledger.rs
@@ -5,18 +5,18 @@ use pocket_ic::nonblocking::PocketIc;
 
 use crate::common::TestContext;
 
-pub struct Client<'a> {
+pub(crate) struct Client<'a> {
     pic: &'a PocketIc,
 }
 
 impl<'a> Client<'a> {
-    pub fn new(ctx: &'a TestContext) -> Self {
+    pub(crate) fn new(ctx: &'a TestContext) -> Self {
         Self {
             pic: ctx.pocketic(),
         }
     }
 
-    pub async fn balance_of(&self, owner: Principal, subaccount: Option<Subaccount>) -> Nat {
+    pub(crate) async fn balance_of(&self, owner: Principal, subaccount: Option<Subaccount>) -> Nat {
         let args = Account { owner, subaccount };
         let bytes = Encode!(&args).unwrap();
         let result = &self

--- a/crates/icp-cli/tests/common/clients/icp_cli.rs
+++ b/crates/icp-cli/tests/common/clients/icp_cli.rs
@@ -3,14 +3,18 @@ use icp::prelude::*;
 
 use crate::common::TestContext;
 
-pub struct Client<'a> {
+pub(crate) struct Client<'a> {
     ctx: &'a TestContext,
     current_dir: PathBuf,
     environment: String,
 }
 
 impl<'a> Client<'a> {
-    pub fn new(ctx: &'a TestContext, current_dir: PathBuf, environment: Option<String>) -> Self {
+    pub(crate) fn new(
+        ctx: &'a TestContext,
+        current_dir: PathBuf,
+        environment: Option<String>,
+    ) -> Self {
         Self {
             ctx,
             current_dir,
@@ -18,7 +22,7 @@ impl<'a> Client<'a> {
         }
     }
 
-    pub fn active_principal(&self) -> Principal {
+    pub(crate) fn active_principal(&self) -> Principal {
         let stdout = String::from_utf8(
             self.ctx
                 .icp()
@@ -33,7 +37,7 @@ impl<'a> Client<'a> {
         Principal::from_text(stdout.trim()).unwrap()
     }
 
-    pub fn create_identity(&self, name: &str) {
+    pub(crate) fn create_identity(&self, name: &str) {
         self.ctx
             .icp()
             .current_dir(&self.current_dir)
@@ -42,7 +46,7 @@ impl<'a> Client<'a> {
             .success();
     }
 
-    pub fn get_principal(&self, name: &str) -> Principal {
+    pub(crate) fn get_principal(&self, name: &str) -> Principal {
         let stdout = String::from_utf8(
             self.ctx
                 .icp()
@@ -57,7 +61,7 @@ impl<'a> Client<'a> {
         Principal::from_text(stdout.trim()).unwrap()
     }
 
-    pub fn use_identity(&self, name: &str) {
+    pub(crate) fn use_identity(&self, name: &str) {
         self.ctx
             .icp()
             .current_dir(&self.current_dir)
@@ -66,14 +70,14 @@ impl<'a> Client<'a> {
             .success();
     }
 
-    pub fn use_new_random_identity(&self) -> Principal {
+    pub(crate) fn use_new_random_identity(&self) -> Principal {
         let random_name = format!("alice-{}", rand::random::<u64>());
         self.create_identity(&random_name);
         self.use_identity(&random_name);
         self.active_principal()
     }
 
-    pub fn mint_cycles(&self, amount: u128) {
+    pub(crate) fn mint_cycles(&self, amount: u128) {
         self.ctx
             .icp()
             .current_dir(&self.current_dir)
@@ -89,7 +93,7 @@ impl<'a> Client<'a> {
             .success();
     }
 
-    pub fn get_canister_id(&self, canister_name: &str) -> Principal {
+    pub(crate) fn get_canister_id(&self, canister_name: &str) -> Principal {
         let output = self
             .ctx
             .icp()

--- a/crates/icp-cli/tests/common/clients/ledger.rs
+++ b/crates/icp-cli/tests/common/clients/ledger.rs
@@ -8,18 +8,18 @@ use pocket_ic::nonblocking::PocketIc;
 
 use crate::common::TestContext;
 
-pub struct Client<'a> {
+pub(crate) struct Client<'a> {
     pic: &'a PocketIc,
 }
 
 impl<'a> Client<'a> {
-    pub fn new(ctx: &'a TestContext) -> Self {
+    pub(crate) fn new(ctx: &'a TestContext) -> Self {
         Self {
             pic: ctx.pocketic(),
         }
     }
 
-    pub async fn balance_of(&self, owner: Principal, subaccount: Option<Subaccount>) -> Nat {
+    pub(crate) async fn balance_of(&self, owner: Principal, subaccount: Option<Subaccount>) -> Nat {
         let arg = Account { owner, subaccount };
         let bytes = Encode!(&arg).unwrap();
         let result = &self
@@ -35,7 +35,7 @@ impl<'a> Client<'a> {
         Decode!(result, Nat).unwrap()
     }
 
-    pub async fn mint_icp(
+    pub(crate) async fn mint_icp(
         &self,
         owner: Principal,
         subaccount: Option<Subaccount>,

--- a/crates/icp-cli/tests/common/clients/registry.rs
+++ b/crates/icp-cli/tests/common/clients/registry.rs
@@ -6,18 +6,18 @@ use pocket_ic::nonblocking::PocketIc;
 
 use crate::common::TestContext;
 
-pub struct Client<'a> {
+pub(crate) struct Client<'a> {
     pic: &'a PocketIc,
 }
 
 impl<'a> Client<'a> {
-    pub fn new(ctx: &'a TestContext) -> Self {
+    pub(crate) fn new(ctx: &'a TestContext) -> Self {
         Self {
             pic: ctx.pocketic(),
         }
     }
 
-    pub async fn get_subnet_for_canister(&self, canister: Principal) -> Principal {
+    pub(crate) async fn get_subnet_for_canister(&self, canister: Principal) -> Principal {
         let arg = GetSubnetForCanisterRequest {
             principal: Some(canister),
         };

--- a/crates/icp-cli/tests/common/mod.rs
+++ b/crates/icp-cli/tests/common/mod.rs
@@ -5,19 +5,19 @@ use url::Url;
 
 use httptest::{Expectation, Server, matchers::*, responders::*};
 
-pub mod clients;
+pub(crate) mod clients;
 mod context;
 
-pub use context::TestContext;
+pub(crate) use context::TestContext;
 
 #[cfg(unix)]
-pub const PATH_SEPARATOR: &str = ":";
+pub(crate) const PATH_SEPARATOR: &str = ":";
 
 #[cfg(windows)]
-pub const PATH_SEPARATOR: &str = ";";
+pub(crate) const PATH_SEPARATOR: &str = ";";
 
 /// A network manifest for a network using a random port
-pub const NETWORK_RANDOM_PORT: &str = r#"
+pub(crate) const NETWORK_RANDOM_PORT: &str = r#"
 network:
   name: my-network
   mode: managed
@@ -26,7 +26,7 @@ network:
 "#;
 
 /// An environment manifest utilizing the above network
-pub const ENVIRONMENT_RANDOM_PORT: &str = r#"
+pub(crate) const ENVIRONMENT_RANDOM_PORT: &str = r#"
 environment:
   name: my-environment
   network: my-network
@@ -37,10 +37,11 @@ environment:
 /// References:
 /// - http://localhost:8000/_/topology
 /// - http://localhost:8000/_/dashboard
-pub const SUBNET_ID: &str = "cok7q-nnbiu-4xwf6-7gpqg-kwzft-mqypn-uepxh-mx2hy-q4wuy-5s5my-eae";
+pub(crate) const SUBNET_ID: &str =
+    "cok7q-nnbiu-4xwf6-7gpqg-kwzft-mqypn-uepxh-mx2hy-q4wuy-5s5my-eae";
 
 // Spawns a test server that expects a single request and responds with a 200 status code and the given body
-pub fn spawn_test_server(method: &str, path: &str, body: &[u8]) -> httptest::Server {
+pub(crate) fn spawn_test_server(method: &str, path: &str, body: &[u8]) -> httptest::Server {
     // Run the server
     let server = Server::run();
 
@@ -57,19 +58,19 @@ pub fn spawn_test_server(method: &str, path: &str, body: &[u8]) -> httptest::Ser
 
 // A network run by icp-cli for a test. These fields are read from the network descriptor
 // after starting the network.
-pub struct TestNetwork {
-    pub pocketic_url: Url,
-    pub pocketic_instance_id: usize,
-    pub gateway_port: u16,
-    pub root_key: String,
+pub(crate) struct TestNetwork {
+    pub(crate) pocketic_url: Url,
+    pub(crate) pocketic_instance_id: usize,
+    pub(crate) gateway_port: u16,
+    pub(crate) root_key: String,
 }
 
-pub struct ChildGuard {
+pub(crate) struct ChildGuard {
     child: Child,
 }
 
 impl ChildGuard {
-    pub fn spawn(cmd: &mut Command) -> std::io::Result<Self> {
+    pub(crate) fn spawn(cmd: &mut Command) -> std::io::Result<Self> {
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;


### PR DESCRIPTION
This changes all the `pub`s to `pub(crate)`s in the `icp-cli` crate. This is done to start standardizing on differentating between things that should be public within their crate, vs things that need to be exported to other crates. A follow-up should be done for the `icp` crate as well, although for that one it's expected that more care will be needed, whereas the `icp-cli` is not expected to expose anything to other crates.