### PR TITLE
chore: make pocketic icp_features explicit

### DIFF
--- a/crates/icp/src/network/managed/pocketic.rs
+++ b/crates/icp/src/network/managed/pocketic.rs
@@ -36,7 +36,7 @@ pub fn default_instance_config(state_dir: &Path) -> InstanceConfig {
             // Same as above
             ii: Some(IcpFeaturesConfig::DefaultConfig),
 
-            // The rest of the features are disabled by default
+            // The rest of the features are disabled for now
             nns_governance: None,
             sns: None,
             nns_ui: None,


### PR DESCRIPTION
Make the selection of `IcpFeatures` explicit so that we do not miss new features becoming available