### PR TITLE
refactor: remove network from store_id Key

### DIFF
--- a/crates/icp-cli/src/commands/canister/create.rs
+++ b/crates/icp-cli/src/commands/canister/create.rs
@@ -176,7 +176,6 @@ pub(crate) async fn exec(ctx: &Context, args: &CreateArgs) -> Result<(), Command
         .filter_map(|(_, c)| {
             ctx.ids
                 .lookup(&Key {
-                    network: env.network.name.to_owned(),
                     environment: env.name.to_owned(),
                     canister: c.name.to_owned(),
                 })
@@ -239,9 +238,8 @@ pub(crate) async fn exec(ctx: &Context, args: &CreateArgs) -> Result<(), Command
                 // Indicate to user that the canister is created
                 pb.set_message("Creating...");
 
-                // Create canister-network association-key
+                // Create canister-environment association-key
                 let k = Key {
-                    network: env_ref.network.name.to_owned(),
                     environment: env_ref.name.to_owned(),
                     canister: name.to_string(),
                 };

--- a/crates/icp-cli/src/commands/sync/mod.rs
+++ b/crates/icp-cli/src/commands/sync/mod.rs
@@ -132,7 +132,6 @@ pub(crate) async fn exec(ctx: &Context, args: &SyncArgs) -> Result<(), CommandEr
 
         // Get canister principal ID
         let cid = ctx.ids.lookup(&Key {
-            network: env.network.name.to_owned(),
             environment: env.name.to_owned(),
             canister: c.name.to_owned(),
         })?;

--- a/crates/icp/src/context/mod.rs
+++ b/crates/icp/src/context/mod.rs
@@ -168,7 +168,6 @@ impl Context {
         let cid = self
             .ids
             .lookup(&Key {
-                network: env.network.name.to_owned(),
                 environment: env.name.to_owned(),
                 canister: canister_name.to_owned(),
             })

--- a/crates/icp/src/context/tests.rs
+++ b/crates/icp/src/context/tests.rs
@@ -115,7 +115,6 @@ async fn test_get_canister_id_for_env_success() {
     ids_store
         .register(
             &Key {
-                network: "local".to_string(),
                 environment: "dev".to_string(),
                 canister: "backend".to_string(),
             },
@@ -337,7 +336,6 @@ async fn test_get_canister_id() {
     ids_store
         .register(
             &Key {
-                network: "local".to_string(),
                 environment: "dev".to_string(),
                 canister: "backend".to_string(),
             },

--- a/crates/icp/src/store_id.rs
+++ b/crates/icp/src/store_id.rs
@@ -26,9 +26,6 @@ pub trait Access: Sync + Send {
 /// An association-key, used for associating an existing canister to an ID on a network
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Key {
-    /// Network name
-    pub network: String,
-
     /// Environment name
     pub environment: String,
 
@@ -46,8 +43,8 @@ pub enum RegisterError {
     RegisterLoadStore { source: json::Error },
 
     #[snafu(display(
-        "canister '{}' in environment '{}', associated with network '{}' is already registered with id '{id}'",
-        key.canister, key.environment, key.network,
+        "canister '{}' in environment '{}' is already registered with id '{id}'",
+        key.canister, key.environment,
     ))]
     AlreadyRegistered { key: Key, id: Principal },
 
@@ -61,8 +58,8 @@ pub enum LookupIdError {
     LookupLoadStore { source: json::Error },
 
     #[snafu(display(
-        "could not find ID for canister '{}' in environment '{}', associated with network '{}'",
-        key.canister, key.environment, key.network
+        "could not find ID for canister '{}' in environment '{}'",
+        key.canister, key.environment
     ))]
     IdNotFound { key: Key },
 


### PR DESCRIPTION
The environment inherently includes the network.
An `(environment, canister_name)` pair can serve the unique key of the ID store.