### PR TITLE
refactor: switch to snafu except for canister/

### DIFF
--- a/crates/icp-cli/src/commands/identity/import.rs
+++ b/crates/icp-cli/src/commands/identity/import.rs
@@ -293,7 +293,7 @@ pub(crate) enum LoadKeyError {
     },
 
     #[snafu(display("failed to read file"))]
-    ReadFileError { source: icp::fs::Error },
+    ReadFileError { source: icp::fs::IoError },
 
     #[snafu(display("expected 1 key block in PEM file `{path}`, found {count}"))]
     TooManyKeyBlocks { path: PathBuf, count: usize },
@@ -345,7 +345,7 @@ pub(crate) enum LoadKeyError {
 #[derive(Debug, Snafu)]
 pub(crate) enum DeriveKeyError {
     #[snafu(display("failed to read seed file"))]
-    ReadSeedFile { source: icp::fs::Error },
+    ReadSeedFile { source: icp::fs::IoError },
 
     #[snafu(display("failed to read seed phrase from terminal"))]
     ReadSeedPhraseFromTerminal { source: dialoguer::Error },

--- a/crates/icp-cli/src/operations/build.rs
+++ b/crates/icp-cli/src/operations/build.rs
@@ -24,7 +24,7 @@ pub enum BuildOperationError {
     MissingWasmOutput,
 
     #[snafu(display("failed to read wasm output file"))]
-    ReadWasmOutput { source: icp::fs::Error },
+    ReadWasmOutput { source: icp::fs::IoError },
 
     #[snafu(display("failed to save wasm artifact"))]
     SaveWasmArtifact {

--- a/crates/icp/src/canister/recipe/handlebars.rs
+++ b/crates/icp/src/canister/recipe/handlebars.rs
@@ -38,7 +38,7 @@ pub enum HandlebarsError {
     Unknown { recipe: String },
 
     #[error("failed to read local recipe template file")]
-    ReadFile { source: crate::fs::Error },
+    ReadFile { source: crate::fs::IoError },
 
     #[error("failed to decode UTF-8 string")]
     DecodeUtf8 { source: FromUtf8Error },

--- a/crates/icp/src/context/tests.rs
+++ b/crates/icp/src/context/tests.rs
@@ -57,7 +57,7 @@ async fn test_get_identity_named_not_found() {
         result,
         Err(GetIdentityError::IdentityLoad {
             identity: IdentitySelection::Named(_),
-            source: crate::identity::LoadError::LoadIdentity(_)
+            source: crate::identity::LoadError::LoadIdentity { .. }
         })
     ));
 }
@@ -363,7 +363,7 @@ async fn test_get_agent_for_env_network_not_configured() {
     assert!(matches!(
         result,
         Err(GetAgentForEnvError::NetworkAccess {
-            source: crate::network::AccessError::Unexpected(_)
+            source: crate::network::AccessError::GetNetworkAccess { .. }
         })
     ));
 }
@@ -434,7 +434,7 @@ async fn test_get_agent_for_network_not_configured() {
     assert!(matches!(
         result,
         Err(GetAgentForNetworkError::NetworkAccess {
-            source: crate::network::AccessError::Unexpected(_)
+            source: crate::network::AccessError::GetNetworkAccess { .. }
         })
     ));
 }

--- a/crates/icp/src/fs/json.rs
+++ b/crates/icp/src/fs/json.rs
@@ -1,46 +1,37 @@
 use serde::{Deserialize, Serialize};
+use snafu::prelude::*;
 
 use crate::{
     fs::{read, write_string},
     prelude::*,
 };
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
 pub enum Error {
-    #[error(transparent)]
-    Io(#[from] crate::fs::Error),
+    #[snafu(transparent)]
+    Io { source: crate::fs::IoError },
 
-    #[error("failed to parse json file at {path}")]
+    #[snafu(display("failed to parse json file at {path}"))]
     Parse {
+        source: serde_json::Error,
         path: PathBuf,
-
-        #[source]
-        err: serde_json::Error,
     },
 
-    #[error("failed to serialize json file to {path}")]
+    #[snafu(display("failed to serialize json file to {path}"))]
     Serialize {
+        source: serde_json::Error,
         path: PathBuf,
-
-        #[source]
-        err: serde_json::Error,
     },
 }
 
 pub fn load<T: for<'a> Deserialize<'a>>(path: &Path) -> Result<T, Error> {
-    serde_json::from_slice(&read(path)?).map_err(|err| Error::Parse {
-        path: path.into(),
-        err,
-    })
+    serde_json::from_slice(&read(path)?).context(ParseSnafu { path })
 }
 
 pub fn save<T: Serialize>(path: &Path, value: &T) -> Result<(), Error> {
     write_string(
         path,
-        &serde_json::to_string_pretty(&value).map_err(|err| Error::Parse {
-            path: path.into(),
-            err,
-        })?,
+        &serde_json::to_string_pretty(&value).context(SerializeSnafu { path })?,
     )?;
 
     Ok(())

--- a/crates/icp/src/fs/lock.rs
+++ b/crates/icp/src/fs/lock.rs
@@ -125,7 +125,7 @@ impl<T: PathsAccess> DirectoryStructureLock<T> {
 #[derive(Debug, Snafu)]
 pub enum LockError {
     #[snafu(transparent)]
-    CreateDirFailed { source: crate::fs::Error },
+    CreateDirFailed { source: crate::fs::IoError },
     #[snafu(display("failed to create or open lock file '{path}'"))]
     OpenLockFileFailed { source: io::Error, path: PathBuf },
     #[snafu(display("failed to lock the file '{lock_path}'"))]

--- a/crates/icp/src/fs/mod.rs
+++ b/crates/icp/src/fs/mod.rs
@@ -1,7 +1,5 @@
-use std::{
-    fmt::Display,
-    io::{self, ErrorKind},
-};
+use snafu::prelude::*;
+use std::io::{self, ErrorKind};
 
 use crate::prelude::*;
 
@@ -9,71 +7,49 @@ pub mod json;
 pub mod lock;
 pub mod yaml;
 
-#[derive(Debug, thiserror::Error)]
-pub struct Error {
+#[derive(Debug, Snafu)]
+#[snafu(display("Filesystem operation failed at {path}"))]
+pub struct IoError {
+    source: io::Error,
     path: PathBuf,
-
-    #[source]
-    err: io::Error,
 }
 
-impl Error {
+impl IoError {
     pub fn kind(&self) -> ErrorKind {
-        self.err.kind()
+        self.source.kind()
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{}: {}", self.path, self.err))
-    }
+// impl Display for Error {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         f.write_fmt(format_args!("{}: {}", self.path, self.err))
+//     }
+// }
+
+pub fn create_dir_all(path: &Path) -> Result<(), IoError> {
+    std::fs::create_dir_all(path).context(IoSnafu { path })
 }
 
-pub fn create_dir_all(path: &Path) -> Result<(), Error> {
-    std::fs::create_dir_all(path).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
+pub fn read(path: &Path) -> Result<Vec<u8>, IoError> {
+    std::fs::read(path).context(IoSnafu { path })
 }
 
-pub fn read(path: &Path) -> Result<Vec<u8>, Error> {
-    std::fs::read(path).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
+pub fn read_to_string(path: &Path) -> Result<String, IoError> {
+    std::fs::read_to_string(path).context(IoSnafu { path })
 }
 
-pub fn read_to_string(path: &Path) -> Result<String, Error> {
-    std::fs::read_to_string(path).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
+pub fn remove_dir_all(path: &Path) -> Result<(), IoError> {
+    std::fs::remove_dir_all(path).context(IoSnafu { path })
 }
 
-pub fn remove_dir_all(path: &Path) -> Result<(), Error> {
-    std::fs::remove_dir_all(path).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
+pub fn remove_file(path: &Path) -> Result<(), IoError> {
+    std::fs::remove_file(path).context(IoSnafu { path })
 }
 
-pub fn remove_file(path: &Path) -> Result<(), Error> {
-    std::fs::remove_file(path).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
+pub fn write(path: &Path, contents: &[u8]) -> Result<(), IoError> {
+    std::fs::write(path, contents).context(IoSnafu { path })
 }
 
-pub fn write(path: &Path, contents: &[u8]) -> Result<(), Error> {
-    std::fs::write(path, contents).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
-}
-
-pub fn write_string(path: &Path, contents: &str) -> Result<(), Error> {
-    std::fs::write(path, contents.as_bytes()).map_err(|err| Error {
-        path: path.into(),
-        err,
-    })
+pub fn write_string(path: &Path, contents: &str) -> Result<(), IoError> {
+    std::fs::write(path, contents.as_bytes()).context(IoSnafu { path })
 }

--- a/crates/icp/src/identity/key.rs
+++ b/crates/icp/src/identity/key.rs
@@ -45,7 +45,7 @@ pub enum CreateFormat {
 #[derive(Debug, Snafu)]
 pub enum LoadIdentityError {
     #[snafu(transparent)]
-    ReadFileError { source: crate::fs::Error },
+    ReadFileError { source: crate::fs::IoError },
 
     #[snafu(display("failed to load PEM file `{path}`: failed to parse"))]
     ParsePemError {
@@ -249,10 +249,10 @@ pub fn create_identity(
 #[derive(Debug, Snafu)]
 pub enum WriteIdentityError {
     #[snafu(display("failed to write file"))]
-    WriteFileError { source: crate::fs::Error },
+    WriteFileError { source: crate::fs::IoError },
 
     #[snafu(display("failed to create directory"))]
-    CreateDirectoryError { source: crate::fs::Error },
+    CreateDirectoryError { source: crate::fs::IoError },
 
     #[snafu(transparent)]
     LockError { source: crate::fs::lock::LockError },

--- a/crates/icp/src/identity/manifest.rs
+++ b/crates/icp/src/identity/manifest.rs
@@ -32,7 +32,9 @@ impl IdentityDefaults {
 
         let defaults = json::load(&id_defaults_path).or_else(|err| match err {
             // Default fallback
-            json::Error::Io(err) if err.kind() == ErrorKind::NotFound => Ok(Self::default()),
+            json::Error::Io { source } if source.kind() == ErrorKind::NotFound => {
+                Ok(Self::default())
+            }
 
             // Other
             _ => Err(err),
@@ -84,7 +86,9 @@ impl IdentityList {
 
         let list = json::load(&id_list_file).or_else(|err| match err {
             // Default fallback
-            json::Error::Io(err) if err.kind() == ErrorKind::NotFound => Ok(Self::default()),
+            json::Error::Io { source } if source.kind() == ErrorKind::NotFound => {
+                Ok(Self::default())
+            }
 
             // Other
             _ => Err(err),
@@ -148,7 +152,7 @@ pub enum WriteIdentityManifestError {
     WriteJsonError { source: json::Error },
 
     #[snafu(transparent)]
-    CreateDirectoryError { source: crate::fs::Error },
+    CreateDirectoryError { source: crate::fs::IoError },
 
     #[snafu(transparent)]
     DirectoryLockError { source: crate::fs::lock::LockError },

--- a/crates/icp/src/manifest/environment.rs
+++ b/crates/icp/src/manifest/environment.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer};
+use snafu::prelude::*;
 
 use crate::{
     canister::Settings,
@@ -50,13 +51,10 @@ pub struct EnvironmentManifest {
     pub settings: Option<HashMap<String, Settings>>,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
 pub enum ParseError {
-    #[error("Overriding the local environment is not supported.")]
+    #[snafu(display("Overriding the local environment is not supported."))]
     OverrideLocal,
-
-    #[error(transparent)]
-    Unexpected(#[from] anyhow::Error),
 }
 
 impl TryFrom<EnvironmentInner> for EnvironmentManifest {

--- a/crates/icp/src/network/directory.rs
+++ b/crates/icp/src/network/directory.rs
@@ -47,7 +47,7 @@ pub enum LoadNetworkFileError {
 }
 
 impl NetworkDirectory {
-    pub fn ensure_exists(&self) -> Result<(), crate::fs::Error> {
+    pub fn ensure_exists(&self) -> Result<(), crate::fs::IoError> {
         // Network root
         create_dir_all(&self.network_root)?;
 
@@ -65,7 +65,7 @@ impl NetworkDirectory {
             .with_read(async |root| {
                 json::load(&root.network_descriptor_path()).or_else(|err| match err {
                     // Default to empty
-                    json::Error::Io(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+                    json::Error::Io { source } if source.kind() == ErrorKind::NotFound => Ok(None),
 
                     // Other
                     _ => Err(err.into()),
@@ -83,7 +83,7 @@ impl NetworkDirectory {
             .with_read(async |paths| {
                 json::load(&paths.descriptor_path()).or_else(|err| match err {
                     // Default to empty
-                    json::Error::Io(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+                    json::Error::Io { source } if source.kind() == ErrorKind::NotFound => Ok(None),
 
                     // Other
                     _ => Err(err.into()),
@@ -300,7 +300,7 @@ pub enum CleanupNetworkDescriptorError {
     #[snafu(transparent)]
     LockFileError { source: LockError },
     #[snafu(transparent)]
-    DeleteFileError { source: crate::fs::Error },
+    DeleteFileError { source: crate::fs::IoError },
 }
 
 #[derive(Debug, Snafu)]
@@ -309,14 +309,14 @@ pub enum SavePidError {
     LockFileError { source: LockError },
 
     #[snafu(transparent)]
-    WritePid { source: crate::fs::Error },
+    WritePid { source: crate::fs::IoError },
 }
 
 #[derive(Debug, Snafu)]
 pub enum LoadPidError {
     #[snafu(display("failed to read PID from {path}"))]
     ReadPid {
-        source: crate::fs::Error,
+        source: crate::fs::IoError,
         path: PathBuf,
     },
     #[snafu(transparent)]

--- a/crates/icp/src/network/managed/run.rs
+++ b/crates/icp/src/network/managed/run.rs
@@ -63,7 +63,7 @@ pub async fn run_network(
 #[derive(Debug, Snafu)]
 pub enum RunNetworkError {
     #[snafu(transparent)]
-    CreateDirFailed { source: crate::fs::Error },
+    CreateDirFailed { source: crate::fs::IoError },
 
     #[snafu(display("ICP_POCKET_IC_PATH environment variable is not set"))]
     NoPocketIcPath,
@@ -177,13 +177,13 @@ async fn run_pocketic(
 #[derive(Debug, Snafu)]
 pub enum RunPocketIcError {
     #[snafu(display("failed to create dir"))]
-    CreateDirAll { source: crate::fs::Error },
+    CreateDirAll { source: crate::fs::IoError },
 
     #[snafu(display("failed to remove dir"))]
-    RemoveDirAll { source: crate::fs::Error },
+    RemoveDirAll { source: crate::fs::IoError },
 
     #[snafu(display("failed to remove file"))]
-    RemoveFile { source: crate::fs::Error },
+    RemoveFile { source: crate::fs::IoError },
 
     #[snafu(transparent)]
     SaveNetworkDescriptor { source: SaveNetworkDescriptorError },

--- a/crates/icp/src/network/mod.rs
+++ b/crates/icp/src/network/mod.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use anyhow::Context as _;
+// use anyhow::Context as _;
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
+use snafu::prelude::*;
 
 pub use directory::{LoadPidError, NetworkDirectory, SavePidError};
 pub use managed::run::{RunNetworkError, run_network};
@@ -14,7 +15,10 @@ use crate::{
         ProjectRootLocate, ProjectRootLocateError,
         network::{Connected as ManifestConnected, Gateway as ManifestGateway, Mode},
     },
-    network::access::{NetworkAccess, get_connected_network_access, get_managed_network_access},
+    network::access::{
+        GetNetworkAccessError, NetworkAccess, get_connected_network_access,
+        get_managed_network_access,
+    },
     prelude::*,
 };
 
@@ -148,13 +152,13 @@ impl From<Mode> for Configuration {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
 pub enum AccessError {
-    #[error("failed to find project root")]
-    Project(#[from] ProjectRootLocateError),
+    #[snafu(display("failed to find project root"))]
+    ProjectRootLocate { source: ProjectRootLocateError },
 
-    #[error(transparent)]
-    Unexpected(#[from] anyhow::Error),
+    #[snafu(transparent)]
+    GetNetworkAccess { source: GetNetworkAccessError },
 }
 
 #[async_trait]
@@ -175,7 +179,10 @@ pub struct Accessor {
 impl Access for Accessor {
     /// The network directory is located at `<project_root>/.icp/cache/networks/<network_name>`.
     fn get_network_directory(&self, network: &Network) -> Result<NetworkDirectory, AccessError> {
-        let dir = self.project_root_locate.locate()?;
+        let dir = self
+            .project_root_locate
+            .locate()
+            .context(ProjectRootLocateSnafu)?;
         Ok(NetworkDirectory::new(
             &network.name,
             &dir.join(ICP_BASE)
@@ -189,13 +196,11 @@ impl Access for Accessor {
         match &network.configuration {
             Configuration::Managed { managed: _ } => {
                 let nd = self.get_network_directory(network)?;
-                Ok(get_managed_network_access(nd)
-                    .await
-                    .context("failed to load managed network access")?)
+                Ok(get_managed_network_access(nd).await?)
             }
-            Configuration::Connected { connected: cfg } => Ok(get_connected_network_access(cfg)
-                .await
-                .context("failed to load connected network access")?),
+            Configuration::Connected { connected: cfg } => {
+                Ok(get_connected_network_access(cfg).await?)
+            }
         }
     }
 }
@@ -243,11 +248,13 @@ impl Access for MockNetworkAccessor {
         })
     }
     async fn access(&self, network: &Network) -> Result<NetworkAccess, AccessError> {
-        self.networks.get(&network.name).cloned().ok_or_else(|| {
-            AccessError::Unexpected(anyhow::anyhow!(
-                "network '{}' not configured in mock",
-                network.name
-            ))
-        })
+        self.networks
+            .get(&network.name)
+            .cloned()
+            .ok_or_else(|| AccessError::GetNetworkAccess {
+                source: GetNetworkAccessError::NetworkNotRunning {
+                    network: network.name.clone(),
+                },
+            })
     }
 }

--- a/crates/icp/src/store_artifact.rs
+++ b/crates/icp/src/store_artifact.rs
@@ -27,7 +27,7 @@ pub trait Access: Sync + Send {
 #[derive(Debug, Snafu)]
 pub enum SaveError {
     #[snafu(display("failed to write artifact file"))]
-    SaveWriteFileError { source: crate::fs::Error },
+    SaveWriteFileError { source: crate::fs::IoError },
 
     #[snafu(transparent)]
     LockError { source: crate::fs::lock::LockError },
@@ -36,7 +36,7 @@ pub enum SaveError {
 #[derive(Debug, Snafu)]
 pub enum LookupArtifactError {
     #[snafu(display("failed to read artifact file"))]
-    LookupReadFileError { source: crate::fs::Error },
+    LookupReadFileError { source: crate::fs::IoError },
 
     #[snafu(display("could not find artifact for canister '{name}'"))]
     LookupArtifactNotFound { name: String },

--- a/crates/icp/src/store_id.rs
+++ b/crates/icp/src/store_id.rs
@@ -21,7 +21,7 @@ pub type IdMapping = BTreeMap<String, Principal>;
 fn load_mapping(fpath: &Path) -> Result<IdMapping, json::Error> {
     json::load(fpath).or_else(|err| match err {
         // Default to empty
-        json::Error::Io(err) if err.kind() == ErrorKind::NotFound => Ok(BTreeMap::new()),
+        json::Error::Io { source } if source.kind() == ErrorKind::NotFound => Ok(BTreeMap::new()),
 
         // Other
         _ => Err(err),
@@ -66,7 +66,7 @@ pub enum RegisterError {
 
     #[snafu(display("failed to create directory for canister id store at '{path}'"))]
     CreateDirAll {
-        source: crate::fs::Error,
+        source: crate::fs::IoError,
         path: PathBuf,
     },
 
@@ -107,7 +107,7 @@ pub enum CleanupError {
     ProjectRootLocate { source: ProjectRootLocateError },
 
     #[snafu(transparent)]
-    DeleteFile { source: crate::fs::Error },
+    DeleteFile { source: crate::fs::IoError },
 }
 
 /// Store of canister ID mappings for environments.


### PR DESCRIPTION
The `icp/src/canister/` module needs more substantial refactoring than just the snafu migration.
It will be done in another PR.