### PR TITLE
fix: When deleting a canister, also delete the id from id store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 # They are ignored here because we are developing icp-cli itself.
 .icpdata
 
-# pocket-ic binary
+# often-used binaries
 pocket-ic
+icp-cli-network-launcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* fix: When deleting a canister, also delete the id from the id store
+
 # v0.1.0-beta.1
 
 * feat!: Switch to using icp-cli-network-launcher instead of pocket-ic directly. Download it [here](https://github.com/dfinity/icp-cli-network-launcher/releases).

--- a/crates/icp-cli/src/commands/canister/delete.rs
+++ b/crates/icp-cli/src/commands/canister/delete.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use icp::context::Context;
+use icp::context::{CanisterSelection, Context};
 
 use crate::commands::args;
 
@@ -33,7 +33,11 @@ pub(crate) async fn exec(ctx: &Context, args: &DeleteArgs) -> Result<(), anyhow:
     // Instruct management canister to delete canister
     mgmt.delete_canister(&cid).await?;
 
-    // TODO(or.ricon): Remove the canister association with the network/environment
+    // Remove canister ID from the id store if it was referenced by name
+    if let CanisterSelection::Named(canister_name) = &selections.canister {
+        ctx.remove_canister_id_for_env(canister_name, &selections.environment)
+            .await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
IDs falsely still exist in the id store after a canister has been deleted

Fixes #227, [SDK-2458](https://dfinity.atlassian.net/browse/SDK-2458)

[SDK-2458]: https://dfinity.atlassian.net/browse/SDK-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ