### PR TITLE
chore: make the list commands consistent

### DIFF
--- a/crates/icp-cli/src/commands/args.rs
+++ b/crates/icp-cli/src/commands/args.rs
@@ -7,19 +7,6 @@ use icp::identity::IdentitySelection;
 
 use crate::options::{EnvironmentOpt, IdentityOpt, NetworkOpt};
 
-#[derive(Debug, Args, Clone)]
-pub(crate) struct ListArgsOptions {
-
-    /// Only print the names
-    #[arg(short, long, conflicts_with_all = ["yaml_format"])]
-    pub name_only: bool,
-
-    /// Format output in json
-    #[arg(long = "yaml")]
-    pub yaml_format: bool,
-
-}
-
 #[derive(Args, Debug)]
 pub(crate) struct CanisterCommandArgs {
     // Note: Could have flattened CanisterEnvironmentArg to avoid adding child field

--- a/crates/icp-cli/src/commands/canister/list.rs
+++ b/crates/icp-cli/src/commands/canister/list.rs
@@ -1,32 +1,20 @@
 use clap::Args;
 use icp::context::Context;
 
-use crate::{commands::args::ListArgsOptions, options::EnvironmentOpt};
+use crate::options::EnvironmentOpt;
 
 #[derive(Debug, Args)]
 pub(crate) struct ListArgs {
     #[command(flatten)]
     pub(crate) environment: EnvironmentOpt,
-
-    #[command(flatten)]
-    pub(crate) options: ListArgsOptions,
 }
 
 pub(crate) async fn exec(ctx: &Context, args: &ListArgs) -> Result<(), anyhow::Error> {
     let environment_selection = args.environment.clone().into();
     let env = ctx.get_environment(&environment_selection).await?;
 
-    if args.options.name_only {
-        for c in env.canisters.keys() {
-            ctx.term.write_line(c)?;
-        }
-        return Ok(());
-    }
-
-    if args.options.yaml_format {
-        let yaml = serde_yaml::to_string(&env.canisters).expect("Serializing to yaml failed");
-        ctx.term.write_line(&yaml)?;
-        return Ok(());
+    for c in env.canisters.keys() {
+        ctx.term.write_line(c)?;
     }
 
     Ok(())

--- a/crates/icp-cli/src/commands/environment/list.rs
+++ b/crates/icp-cli/src/commands/environment/list.rs
@@ -1,30 +1,15 @@
 use clap::Args;
 use icp::context::Context;
-use crate::commands::args::ListArgsOptions;
 
 #[derive(Args, Debug)]
-pub(crate) struct ListArgs {
+pub(crate) struct ListArgs;
 
-    #[command(flatten)]
-    pub(crate) options: ListArgsOptions,
-
-}
-
-pub(crate) async fn exec(ctx: &Context, args: &ListArgs) -> Result<(), anyhow::Error> {
+pub(crate) async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), anyhow::Error> {
     // Load project
     let pm = ctx.project.load().await?;
 
-    // List environments
-    if args.options.name_only {
-        for e in pm.environments.keys() {
-            ctx.term.write_line(e)?;
-        }
-        return Ok(());
-    }
-
-    if args.options.yaml_format {
-        let yaml = serde_yaml::to_string(&pm.environments).expect("Serializing to yaml failed");
-        ctx.term.write_line(&yaml)?;
+    for e in pm.environments.keys() {
+        ctx.term.write_line(e)?;
     }
 
     Ok(())

--- a/crates/icp-cli/src/commands/network/list.rs
+++ b/crates/icp-cli/src/commands/network/list.rs
@@ -1,31 +1,15 @@
 use clap::Args;
 use icp::context::Context;
-use crate::commands::args::ListArgsOptions;
 
 #[derive(Args, Debug)]
-pub(crate) struct ListArgs {
+pub(crate) struct ListArgs;
 
-    #[command(flatten)]
-    pub(crate) options: ListArgsOptions,
-
-}
-
-pub(crate) async fn exec(ctx: &Context, args: &ListArgs) -> Result<(), anyhow::Error> {
+pub(crate) async fn exec(ctx: &Context, _: &ListArgs) -> Result<(), anyhow::Error> {
     // Load project
     let pm = ctx.project.load().await?;
 
-    // List networks
-    if args.options.name_only {
-        for e in pm.networks.keys() {
-            ctx.term.write_line(e)?;
-        }
-        return Ok(());
-    }
-
-    if args.options.yaml_format {
-        let yaml = serde_yaml::to_string(&pm.networks).expect("Serializing to yaml failed");
-        ctx.term.write_line(&yaml)?;
-        return Ok(());
+    for e in pm.networks.keys() {
+        ctx.term.write_line(e)?;
     }
 
     Ok(())

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -590,7 +590,7 @@ Launch and manage local test networks
 
 ###### **Subcommands:**
 
-* `list` — List networks in the project
+* `list` — 
 * `ping` — Try to connect to a network, and print out its status
 * `run` — Run a given network
 * `stop` — Stop a background network
@@ -598,8 +598,6 @@ Launch and manage local test networks
 
 
 ## `icp-cli network list`
-
-List networks in the project
 
 **Usage:** `icp-cli network list`
 


### PR DESCRIPTION
I initially set out to do more than just this (see the first commit) but I didn't like it.

I think there should be some transforms from the "cooked" project manifest to some special structs for display.
We can add this later. For now, this is more useful that the huge debug data dump from before. We can also use `icp project show` to get the full data.