### PR TITLE
fix: Change containerization to a new network mode

### DIFF
--- a/crates/icp-cli/src/commands/network/start.rs
+++ b/crates/icp-cli/src/commands/network/start.rs
@@ -32,14 +32,13 @@ pub(crate) async fn exec(ctx: &Context, args: &StartArgs) -> Result<(), anyhow::
         .get(&args.name)
         .ok_or_else(|| anyhow!("project does not contain a network named '{}'", args.name))?;
 
-    let cfg = match &network.configuration {
-        // Locally-managed network
-        Configuration::Managed { managed: cfg } => cfg,
-
+    let cfg = &network.configuration;
+    match cfg {
         // Non-managed networks cannot be started
-        Configuration::Connected { connected: _ } => {
+        Configuration::Connected { .. } => {
             bail!("network '{}' is not a managed network", args.name)
         }
+        Configuration::Managed { .. } | Configuration::ManagedContainer { .. } => {}
     };
 
     let pdir = &p.dir;

--- a/crates/icp-cli/tests/common/mod.rs
+++ b/crates/icp-cli/tests/common/mod.rs
@@ -34,7 +34,7 @@ environments:
 pub(crate) const NETWORK_DOCKER: &str = r#"
 networks:
   - name: docker-network
-    mode: managed
+    mode: managed-container
     image: ghcr.io/dfinity/icp-cli-network-launcher:v11.0.0
     port-mapping:
       - 0:4943

--- a/crates/icp/src/context/mod.rs
+++ b/crates/icp/src/context/mod.rs
@@ -219,6 +219,7 @@ impl Context {
                 let env = self.get_environment(environment).await?;
                 let is_cache = match env.network.configuration {
                     NetworkConfiguration::Managed { .. } => true,
+                    NetworkConfiguration::ManagedContainer { .. } => true,
                     NetworkConfiguration::Connected { .. } => false,
                 };
 
@@ -262,6 +263,7 @@ impl Context {
         let env = self.get_environment(environment).await?;
         let is_cache = match env.network.configuration {
             NetworkConfiguration::Managed { .. } => true,
+            NetworkConfiguration::ManagedContainer { .. } => true,
             NetworkConfiguration::Connected { .. } => false,
         };
 
@@ -293,6 +295,7 @@ impl Context {
         let env = self.get_environment(environment).await?;
         let is_cache = match env.network.configuration {
             NetworkConfiguration::Managed { .. } => true,
+            NetworkConfiguration::ManagedContainer { .. } => true,
             NetworkConfiguration::Connected { .. } => false,
         };
 
@@ -436,6 +439,7 @@ impl Context {
         let env = self.get_environment(environment).await?;
         let is_cache = match env.network.configuration {
             NetworkConfiguration::Managed { .. } => true,
+            NetworkConfiguration::ManagedContainer { .. } => true,
             NetworkConfiguration::Connected { .. } => false,
         };
         self.ids

--- a/crates/icp/src/context/tests.rs
+++ b/crates/icp/src/context/tests.rs
@@ -3,8 +3,7 @@ use crate::{
     Environment, MockProjectLoader, Network, Project,
     identity::MockIdentityLoader,
     network::{
-        Configuration, Gateway, Managed, ManagedMode, MockNetworkAccessor, Port,
-        access::NetworkAccess,
+        Configuration, ManagedLauncherConfig, MockNetworkAccessor, Port, access::NetworkAccess,
     },
     project::{DEFAULT_LOCAL_NETWORK_NAME, DEFAULT_LOCAL_NETWORK_URL},
     store_id::{Access as IdAccess, mock::MockInMemoryIdStore},
@@ -596,13 +595,9 @@ async fn test_get_agent_defaults_inside_project_with_default_local() {
     let local_network = Network {
         name: DEFAULT_LOCAL_NETWORK_NAME.to_string(),
         configuration: Configuration::Managed {
-            managed: Managed {
-                mode: ManagedMode::Launcher {
-                    gateway: Gateway {
-                        host: "localhost".to_string(),
-                        port: Port::Fixed(8000),
-                    },
-                },
+            launcher: ManagedLauncherConfig {
+                host: "localhost".to_string(),
+                port: Port::Fixed(8000),
             },
         },
     };
@@ -660,13 +655,9 @@ async fn test_get_agent_defaults_with_overridden_local_network() {
     let custom_local_network = Network {
         name: DEFAULT_LOCAL_NETWORK_NAME.to_string(),
         configuration: Configuration::Managed {
-            managed: Managed {
-                mode: ManagedMode::Launcher {
-                    gateway: Gateway {
-                        host: "localhost".to_string(),
-                        port: Port::Fixed(9000),
-                    },
-                },
+            launcher: ManagedLauncherConfig {
+                host: "localhost".to_string(),
+                port: Port::Fixed(9000),
             },
         },
     };
@@ -726,13 +717,9 @@ async fn test_get_agent_defaults_with_overridden_local_environment() {
     let default_local_network = Network {
         name: DEFAULT_LOCAL_NETWORK_NAME.to_string(),
         configuration: Configuration::Managed {
-            managed: Managed {
-                mode: ManagedMode::Launcher {
-                    gateway: Gateway {
-                        host: "localhost".to_string(),
-                        port: Port::Fixed(8000),
-                    },
-                },
+            launcher: ManagedLauncherConfig {
+                host: "localhost".to_string(),
+                port: Port::Fixed(8000),
             },
         },
     };
@@ -740,13 +727,9 @@ async fn test_get_agent_defaults_with_overridden_local_environment() {
     let custom_network = Network {
         name: "custom".to_string(),
         configuration: Configuration::Managed {
-            managed: Managed {
-                mode: ManagedMode::Launcher {
-                    gateway: Gateway {
-                        host: "localhost".to_string(),
-                        port: Port::Fixed(7000),
-                    },
-                },
+            launcher: ManagedLauncherConfig {
+                host: "localhost".to_string(),
+                port: Port::Fixed(7000),
             },
         },
     };

--- a/crates/icp/src/lib.rs
+++ b/crates/icp/src/lib.rs
@@ -215,9 +215,11 @@ impl MockProjectLoader {
     /// - Environment: "default" (uses local network, includes backend canister)
     pub fn minimal() -> Self {
         use crate::{
-            manifest::adapter::prebuilt::{Adapter as PrebuiltAdapter, LocalSource, SourceField},
-            manifest::canister::{BuildStep, BuildSteps, SyncSteps},
-            network::{Configuration, Managed},
+            manifest::{
+                adapter::prebuilt::{Adapter as PrebuiltAdapter, LocalSource, SourceField},
+                canister::{BuildStep, BuildSteps, SyncSteps},
+            },
+            network::{Configuration, ManagedLauncherConfig},
         };
 
         let backend_canister = Canister {
@@ -237,7 +239,7 @@ impl MockProjectLoader {
         let local_network = Network {
             name: "local".to_string(),
             configuration: Configuration::Managed {
-                managed: Managed::default(),
+                launcher: ManagedLauncherConfig::default(),
             },
         };
 
@@ -291,7 +293,7 @@ impl MockProjectLoader {
         use crate::{
             manifest::adapter::prebuilt::{Adapter as PrebuiltAdapter, LocalSource, SourceField},
             manifest::canister::{BuildStep, BuildSteps, SyncSteps},
-            network::{Configuration, Connected, Gateway, Managed, ManagedMode, Port},
+            network::{Configuration, Connected, ManagedLauncherConfig, Port},
         };
 
         // Create canisters
@@ -341,13 +343,9 @@ impl MockProjectLoader {
         let local_network = Network {
             name: "local".to_string(),
             configuration: Configuration::Managed {
-                managed: Managed {
-                    mode: ManagedMode::Launcher {
-                        gateway: Gateway {
-                            host: "localhost".to_string(),
-                            port: Port::Fixed(8000),
-                        },
-                    },
+                launcher: ManagedLauncherConfig {
+                    host: "localhost".to_string(),
+                    port: Port::Fixed(8000),
                 },
             },
         };
@@ -355,13 +353,9 @@ impl MockProjectLoader {
         let staging_network = Network {
             name: "staging".to_string(),
             configuration: Configuration::Managed {
-                managed: Managed {
-                    mode: ManagedMode::Launcher {
-                        gateway: Gateway {
-                            host: "localhost".to_string(),
-                            port: Port::Fixed(8001),
-                        },
-                    },
+                launcher: ManagedLauncherConfig {
+                    host: "localhost".to_string(),
+                    port: Port::Fixed(8001),
                 },
             },
         };

--- a/crates/icp/src/manifest/project.rs
+++ b/crates/icp/src/manifest/project.rs
@@ -33,7 +33,7 @@ mod tests {
             adapter::script,
             canister::{BuildStep, BuildSteps, Instructions},
             environment::CanisterSelection,
-            network::{Managed, ManagedMode, Mode},
+            network::{Managed, Mode},
         },
     };
 
@@ -256,9 +256,7 @@ mod tests {
                 canisters: vec![],
                 networks: vec![Item::Manifest(NetworkManifest {
                     name: "my-network".to_string(),
-                    configuration: Mode::Managed(Managed {
-                        mode: Box::new(ManagedMode::Launcher { gateway: None }),
-                    }),
+                    configuration: Mode::Managed(Managed::default()),
                 })],
                 environments: vec![],
             },

--- a/crates/icp/src/network/managed/docker.rs
+++ b/crates/icp/src/network/managed/docker.rs
@@ -19,16 +19,16 @@ use snafu::{OptionExt, Snafu};
 use tokio::select;
 
 use crate::network::{
-    ManagedImageConfig,
+    ManagedContainerConfig,
     config::ChildLocator,
     managed::launcher::{NetworkInstance, wait_for_launcher_status},
 };
 use crate::prelude::*;
 
 pub async fn spawn_docker_launcher(
-    image_config: &ManagedImageConfig,
+    container_config: &ManagedContainerConfig,
 ) -> Result<(AsyncDropper<DockerDropGuard>, NetworkInstance, ChildLocator), DockerLauncherError> {
-    let ManagedImageConfig {
+    let ManagedContainerConfig {
         image,
         port_mapping,
         rm_on_exit,
@@ -41,7 +41,7 @@ pub async fn spawn_docker_launcher(
         shm_size,
         status_dir,
         mounts,
-    } = image_config;
+    } = container_config;
     let host_status_dir = Utf8TempDir::new().context(CreateStatusDirSnafu)?;
     let socket = match std::env::var("DOCKER_HOST").ok() {
         Some(sock) => sock,

--- a/crates/icp/src/project.rs
+++ b/crates/icp/src/project.rs
@@ -13,7 +13,7 @@ use crate::{
         load_manifest_from_path,
         recipe::RecipeType,
     },
-    network::{Configuration, Connected, Gateway, Managed, ManagedMode, Port},
+    network::{Configuration, Connected, ManagedLauncherConfig, Port},
     prelude::*,
 };
 
@@ -94,13 +94,9 @@ fn default_networks() -> Vec<Network> {
             // The local network at localhost:8000
             name: DEFAULT_LOCAL_NETWORK_NAME.to_string(),
             configuration: Configuration::Managed {
-                managed: Managed {
-                    mode: ManagedMode::Launcher {
-                        gateway: Gateway {
-                            host: DEFAULT_LOCAL_NETWORK_HOST.to_string(),
-                            port: Port::Fixed(DEFAULT_LOCAL_NETWORK_PORT),
-                        },
-                    },
+                launcher: ManagedLauncherConfig {
+                    host: DEFAULT_LOCAL_NETWORK_HOST.to_string(),
+                    port: Port::Fixed(DEFAULT_LOCAL_NETWORK_PORT),
                 },
             },
         },

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -6,7 +6,7 @@
 # icp.yaml
 networks:
   - name: my-network
-    mode: managed
+    mode: managed-container
     image: ghcr.io/dfinity/icp-cli-network-launcher
     port-mapping:
       - 0:4943

--- a/docs/project-configuration.md
+++ b/docs/project-configuration.md
@@ -289,7 +289,7 @@ gateway:
 **Managed Docker Networks:**
 ```yaml
 name: local-dev
-mode: managed
+mode: managed-container
 image: ghcr.io/dfinity/icp-cli-network-launcher
 port-mapping:
   4943:4943

--- a/docs/schemas/icp-yaml-schema.json
+++ b/docs/schemas/icp-yaml-schema.json
@@ -264,26 +264,6 @@
       ],
       "type": "object"
     },
-    "Gateway": {
-      "properties": {
-        "host": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "port": {
-          "format": "uint16",
-          "maximum": 65535,
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
     "Item": {
       "anyOf": [
         {
@@ -333,128 +313,128 @@
       "type": "object"
     },
     "Managed": {
-      "anyOf": [
-        {
-          "properties": {
-            "args": {
-              "description": "Command line arguments to pass to the container's entrypoint",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "entrypoint": {
-              "description": "Entrypoint to use for the container",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "environment": {
-              "description": "Environment variables to set in the container in VAR=VALUE format (or VAR to inherit from host)",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "image": {
-              "description": "The docker image to use for the network",
-              "type": "string"
-            },
-            "mounts": {
-              "description": "Bind mounts to add to the container in the format relative_host_path:container_path[:options]",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "platform": {
-              "description": "The platform to use for the container (e.g. linux/amd64)",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "port-mapping": {
-              "description": "Port mappings in the format \"host_port:container_port\"",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "rm-on-exit": {
-              "description": "Whether to delete the container when the network stops",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "shm-size": {
-              "description": "The size of /dev/shm in bytes",
-              "format": "int64",
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "status-dir": {
-              "description": "The status directory inside the container. Defaults to /app/status",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "user": {
-              "description": "The user to run the container as in the format user[:group]",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "volumes": {
-              "description": "Volumes to mount into the container in the format name:container_path[:options]",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "image",
-            "port-mapping"
-          ],
-          "type": "object"
+      "properties": {
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        {
-          "properties": {
-            "gateway": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Gateway"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "type": "object"
+        "port": {
+          "format": "uint16",
+          "maximum": 65535,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
         }
+      },
+      "type": "object"
+    },
+    "ManagedContainer": {
+      "properties": {
+        "args": {
+          "description": "Command line arguments to pass to the container's entrypoint",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "entrypoint": {
+          "description": "Entrypoint to use for the container",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "environment": {
+          "description": "Environment variables to set in the container in VAR=VALUE format (or VAR to inherit from host)",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "The docker image to use for the network",
+          "type": "string"
+        },
+        "mounts": {
+          "description": "Bind mounts to add to the container in the format relative_host_path:container_path[:options]",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "platform": {
+          "description": "The platform to use for the container (e.g. linux/amd64)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "port-mapping": {
+          "description": "Port mappings in the format \"host_port:container_port\"",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rm-on-exit": {
+          "description": "Whether to delete the container when the network stops",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "shm-size": {
+          "description": "The size of /dev/shm in bytes",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "status-dir": {
+          "description": "The status directory inside the container. Defaults to /app/status",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user": {
+          "description": "The user to run the container as in the format user[:group]",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volumes": {
+          "description": "Volumes to mount into the container in the format name:container_path[:options]",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "image",
+        "port-mapping"
       ],
       "type": "object"
     },
@@ -466,6 +446,19 @@
           "properties": {
             "mode": {
               "const": "managed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "mode"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/ManagedContainer",
+          "properties": {
+            "mode": {
+              "const": "managed-container",
               "type": "string"
             }
           },

--- a/docs/schemas/network-yaml-schema.json
+++ b/docs/schemas/network-yaml-schema.json
@@ -20,7 +20,7 @@
       ],
       "type": "object"
     },
-    "Gateway": {
+    "Managed": {
       "properties": {
         "host": {
           "type": [
@@ -40,129 +40,109 @@
       },
       "type": "object"
     },
-    "Managed": {
-      "anyOf": [
-        {
-          "properties": {
-            "args": {
-              "description": "Command line arguments to pass to the container's entrypoint",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "entrypoint": {
-              "description": "Entrypoint to use for the container",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "environment": {
-              "description": "Environment variables to set in the container in VAR=VALUE format (or VAR to inherit from host)",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "image": {
-              "description": "The docker image to use for the network",
-              "type": "string"
-            },
-            "mounts": {
-              "description": "Bind mounts to add to the container in the format relative_host_path:container_path[:options]",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "platform": {
-              "description": "The platform to use for the container (e.g. linux/amd64)",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "port-mapping": {
-              "description": "Port mappings in the format \"host_port:container_port\"",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "rm-on-exit": {
-              "description": "Whether to delete the container when the network stops",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "shm-size": {
-              "description": "The size of /dev/shm in bytes",
-              "format": "int64",
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "status-dir": {
-              "description": "The status directory inside the container. Defaults to /app/status",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "user": {
-              "description": "The user to run the container as in the format user[:group]",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "volumes": {
-              "description": "Volumes to mount into the container in the format name:container_path[:options]",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            }
+    "ManagedContainer": {
+      "properties": {
+        "args": {
+          "description": "Command line arguments to pass to the container's entrypoint",
+          "items": {
+            "type": "string"
           },
-          "required": [
-            "image",
-            "port-mapping"
-          ],
-          "type": "object"
+          "type": [
+            "array",
+            "null"
+          ]
         },
-        {
-          "properties": {
-            "gateway": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Gateway"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
+        "entrypoint": {
+          "description": "Entrypoint to use for the container",
+          "items": {
+            "type": "string"
           },
-          "type": "object"
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "environment": {
+          "description": "Environment variables to set in the container in VAR=VALUE format (or VAR to inherit from host)",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "The docker image to use for the network",
+          "type": "string"
+        },
+        "mounts": {
+          "description": "Bind mounts to add to the container in the format relative_host_path:container_path[:options]",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "platform": {
+          "description": "The platform to use for the container (e.g. linux/amd64)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "port-mapping": {
+          "description": "Port mappings in the format \"host_port:container_port\"",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rm-on-exit": {
+          "description": "Whether to delete the container when the network stops",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "shm-size": {
+          "description": "The size of /dev/shm in bytes",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "status-dir": {
+          "description": "The status directory inside the container. Defaults to /app/status",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user": {
+          "description": "The user to run the container as in the format user[:group]",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volumes": {
+          "description": "Volumes to mount into the container in the format name:container_path[:options]",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         }
+      },
+      "required": [
+        "image",
+        "port-mapping"
       ],
       "type": "object"
     }
@@ -176,6 +156,19 @@
       "properties": {
         "mode": {
           "const": "managed",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "type": "object"
+    },
+    {
+      "$ref": "#/$defs/ManagedContainer",
+      "properties": {
+        "mode": {
+          "const": "managed-container",
           "type": "string"
         }
       },


### PR DESCRIPTION
Removing the flattened untagged enum improves error messages.