### PR TITLE
chore: remove redundant messages about sync step

### DIFF
--- a/crates/icp-cli/src/commands/deploy/mod.rs
+++ b/crates/icp-cli/src/commands/deploy/mod.rs
@@ -294,8 +294,6 @@ pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), anyhow:
             ctx.debug,
         )
         .await?;
-
-        let _ = ctx.term.write_line("\nCanisters synced successfully");
     }
 
     // Print URLs for deployed canisters

--- a/crates/icp-cli/src/commands/sync.rs
+++ b/crates/icp-cli/src/commands/sync.rs
@@ -87,7 +87,5 @@ pub(crate) async fn exec(ctx: &Context, args: &SyncArgs) -> Result<(), anyhow::E
     )
     .await?;
 
-    let _ = ctx.term.write_line("\nCanisters synced successfully");
-
     Ok(())
 }


### PR DESCRIPTION
If there are canisters to sync it will show in the summary so no need to print it again.  This makes it consistent with the rest of the steps:

```
❯ icp deploy
Building canisters:
[backend] ✔ Built successfully
[frontend] ✔ Built successfully

Creating canisters:
All canisters already exist


Setting environment variables:
[backend] ✔ Environment variables updated successfully
[frontend] ✔ Environment variables updated successfully
[backend] ✔ Canister settings updated successfully
[frontend] ✔ Canister settings updated successfully

Installing canisters:
[backend] ✔ Installed successfully
[frontend] ✔ Installed successfully

Syncing canisters:
[frontend] ✔ Synced successfully: txyno-ch777-77776-aaaaq-cai

Deployed canisters:
  backend (Candid UI): http://tqzl2-p7777-77776-aaaaa-cai.localhost:55001/?id=t63gs-up777-77776-aaaba-cai
  frontend: http://txyno-ch777-77776-aaaaq-cai.localhost:55001

my-project on  main [?] took 11s
❯ icp sync
Syncing canisters:
[frontend] ✔ Synced successfully: txyno-ch777-77776-aaaaq-cai
```