### PR TITLE
docs: fix guides and references

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,7 +47,7 @@ icp help
 
 
 # if the manifest types change regenerate the schema:
-./scripts/generate-config-schema.sh
+./scripts/generate-config-schemas.sh
 
 # After making changes and if the tests pass run cargo fmt and cargo clippy:
 cargo fmt && cargo clippy

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cargo test
 ./scripts/generate-cli-docs.sh
 
 # Update the yaml file schemas
-./scripts/config-schemas.sh
+./scripts/generate-config-schemas.sh
 ```
 
 ## License

--- a/docs/concepts/build-deploy-sync.md
+++ b/docs/concepts/build-deploy-sync.md
@@ -113,8 +113,7 @@ For frontend canisters, sync uploads your built assets:
 sync:
   steps:
     - type: assets
-      source: dist
-      target: /
+      dir: dist
 ```
 
 ### When Sync Runs

--- a/docs/guides/creating-templates.md
+++ b/docs/guides/creating-templates.md
@@ -40,7 +40,7 @@ canisters:
     recipe:
       type: "@dfinity/motoko"
       configuration:
-        entry: src/main.mo
+        main: src/main.mo
 ```
 
 Filenames with handlebar placeholders like `{{project-name}}.did` will be renamed with value.
@@ -90,9 +90,9 @@ canisters:
   {{#if include_frontend}}
   - name: {{project-name}}-frontend
     recipe:
-      type: "@dfinity/assets"
+      type: "@dfinity/asset-canister"
       configuration:
-        source: dist
+        dir: dist
   {{/if}}
 
 ```
@@ -161,7 +161,7 @@ canisters:
     recipe:
       type: "@dfinity/motoko"
       configuration:
-        entry: src/backend/main.mo
+        main: src/backend/main.mo
     {{/if}}
 ```
 

--- a/docs/guides/managing-environments.md
+++ b/docs/guides/managing-environments.md
@@ -147,8 +147,7 @@ canisters:
     sync:
       steps:
         - type: assets
-          source: dist
-          target: /
+          dir: dist
 
   - name: backend
     build:

--- a/docs/guides/using-recipes.md
+++ b/docs/guides/using-recipes.md
@@ -40,7 +40,7 @@ canisters:
     recipe:
       type: "@dfinity/motoko"
       configuration:
-        entry: src/main.mo
+        main: src/main.mo
 ```
 
 ### Assets Canister
@@ -53,7 +53,7 @@ canisters:
     recipe:
       type: "@dfinity/asset-canister"
       configuration:
-        source: dist
+        dir: dist
 ```
 
 ### Pre-built WASM

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,8 +33,7 @@ canisters:
     sync:
       steps:
         - type: assets
-          source: www
-          target: /
+          dir: www
     settings:
       compute_allocation: 5
     init_args: "()"
@@ -96,30 +95,6 @@ build:
 | `path` | string | Yes | Path to WASM file |
 | `sha256` | string | No | SHA256 hash for verification |
 
-### Assets Step
-
-Bundle static files:
-
-```yaml
-build:
-  steps:
-    - type: assets
-      source: www
-      target: /
-      include_patterns:
-        - "*.html"
-        - "*.js"
-      exclude_patterns:
-        - "*.map"
-```
-
-| Property | Type | Required | Description |
-|----------|------|----------|-------------|
-| `source` | string | Yes | Source directory |
-| `target` | string | Yes | Target path in canister |
-| `include_patterns` | array | No | Glob patterns to include |
-| `exclude_patterns` | array | No | Glob patterns to exclude |
-
 ## Sync Steps
 
 ### Assets Sync
@@ -130,11 +105,8 @@ Upload files to asset canister:
 sync:
   steps:
     - type: assets
-      source: dist
-      target: /
+      dir: dist
 ```
-
-Same properties as assets build step.
 
 ## Recipes
 
@@ -301,9 +273,9 @@ init_args: "4449444c016d7b0100010203"
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/assets"
+      type: "@dfinity/asset-canister"
       configuration:
-        source: dist
+        dir: dist
     settings:
       memory_allocation: 1073741824
 


### PR DESCRIPTION
This PR fixes critical documentation errors discovered through comprehensive verification against the source code. All examples and configuration references now accurately reflect the actual implementation.

### Critical Fixes

#### Recipe Parameter Corrections
Fixed incorrect parameter names across multiple documentation files to match official recipe implementations:

- **Motoko recipe**: Changed `entry:` → `main:`
  - `docs/guides/using-recipes.md`
  - `docs/guides/creating-templates.md` (3 occurrences)
  
- **Asset canister recipe**: Changed `source:` → `dir:` and standardized recipe type to `@dfinity/asset-canister`
  - `docs/guides/using-recipes.md`
  - `docs/guides/creating-templates.md`

**Verification**: Confirmed against [official recipe templates](https://github.com/dfinity/icp-cli-recipes)

#### Sync Step Configuration Fixes
Corrected assets sync step field names to match the actual adapter implementation:

- **Before**: `source: dist` and `target: /`
- **After**: `dir: dist`

Files updated:
- `docs/reference/configuration.md` (inline example)
- `docs/concepts/build-deploy-sync.md`
- `docs/guides/managing-environments.md`

**Verification**: Source code at `crates/icp/src/manifest/adapter/assets.rs` confirms the adapter only supports `dir` or `dirs` fields.

#### Removed Non-Existent Build Adapter Documentation
Removed entire "Assets Step" section from Build Steps in `docs/reference/configuration.md`.

**Reason**: The assets adapter only exists for **sync steps**, not build steps. The `BuildStep` enum only supports `Script` and `Prebuilt` variants. The documented fields (`source`, `target`, `include_patterns`, `exclude_patterns`) do not exist in the codebase.

#### Script Name Corrections
Fixed references to schema generation script:

- **Before**: `./scripts/config-schemas.sh` (README) and `./scripts/generate-config-schema.sh` (CLAUDE.md - singular)
- **After**: `./scripts/generate-config-schemas.sh` (correct plural form)

Files: `README.md`, `.claude/CLAUDE.md`

### Enhanced Migration Guide (`docs/migration/from-dfx.md`)

Major improvements with +128 net lines:

1. **Corrected identity storage paths** with OS-specific locations:
   - macOS: `~/Library/Application Support/org.dfinity.icp-cli/identity/`
   - Linux: `~/.local/share/icp-cli/identity/`
   - Windows: `%APPDATA%\icp-cli\data\identity\`

2. **Comprehensive identity migration instructions** covering all three storage modes:
   - Keyring (default)
   - Password-protected
   - Plaintext

3. **Asset canister build commands** explaining dfx auto-builds vs icp-cli explicit configuration

4. **Side-by-side tool usage** with port conflict warning and solutions

5. **Canister ID storage paths** clarification for connected vs managed networks

### Impact

Users will no longer encounter errors from following documentation examples. All YAML configuration examples now match:
- Source code implementation
- Official recipe templates
- Working examples in `examples/` directory
- JSON schemas in `docs/schemas/`