### PR TITLE
feat: add `icp identity account-id` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   * The `--mainnet` and `--ic` flags are removed. Use `-n/--network ic`, `-e/--environment ic` instead.
 * feat: Allow overriding the implicit `local` network and environment.
 * feat: Allow installing WASMs that are larger than 2MB
+* feat: Add `icp identity account-id` command to display the ICP ledger account identifier
+  * Supports `--of-principal` flag to convert a specific principal instead of the current identity
 
 # v0.1.0-beta.3
 

--- a/crates/icp-cli/src/commands/identity/account_id.rs
+++ b/crates/icp-cli/src/commands/identity/account_id.rs
@@ -1,0 +1,32 @@
+use candid::Principal;
+use clap::Args;
+use ic_ledger_types::{AccountIdentifier, Subaccount};
+use icp::context::Context;
+
+use crate::options::IdentityOpt;
+
+#[derive(Debug, Args)]
+pub(crate) struct AccountIdArgs {
+    #[command(flatten)]
+    pub(crate) identity: IdentityOpt,
+
+    /// Convert this Principal instead of the current identity's Principal
+    #[arg(long = "of-principal", conflicts_with = "identity")]
+    pub(crate) of_principal: Option<Principal>,
+}
+
+pub(crate) async fn exec(ctx: &Context, args: &AccountIdArgs) -> Result<(), anyhow::Error> {
+    let principal = if let Some(p) = &args.of_principal {
+        *p
+    } else {
+        let id = ctx.get_identity(&args.identity.clone().into()).await?;
+        id.sender()
+            .map_err(|e| anyhow::anyhow!("failed to load identity principal: {e}"))?
+    };
+
+    let account_id = AccountIdentifier::new(&principal, &Subaccount([0; 32]));
+
+    println!("{account_id}");
+
+    Ok(())
+}

--- a/crates/icp-cli/src/commands/identity/mod.rs
+++ b/crates/icp-cli/src/commands/identity/mod.rs
@@ -1,5 +1,6 @@
 use clap::{Subcommand, ValueEnum};
 
+pub(crate) mod account_id;
 pub(crate) mod default;
 pub(crate) mod import;
 pub(crate) mod list;
@@ -8,6 +9,9 @@ pub(crate) mod principal;
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Command {
+    /// Display the ICP ledger account identifier for the current identity
+    AccountId(account_id::AccountIdArgs),
+
     /// Display the currently selected identity
     Default(default::DefaultArgs),
 

--- a/crates/icp-cli/src/main.rs
+++ b/crates/icp-cli/src/main.rs
@@ -298,6 +298,12 @@ async fn main() -> Result<(), Error> {
 
         // Identity
         Command::Identity(cmd) => match cmd {
+            commands::identity::Command::AccountId(args) => {
+                commands::identity::account_id::exec(&ctx, &args)
+                    .instrument(trace_span)
+                    .await?
+            }
+
             commands::identity::Command::Default(args) => {
                 commands::identity::default::exec(&ctx, &args)
                     .instrument(trace_span)

--- a/crates/icp-cli/tests/identity_tests.rs
+++ b/crates/icp-cli/tests/identity_tests.rs
@@ -405,3 +405,34 @@ async fn identity_storage_forms() {
         .success()
         .stdout(eq("(\"Hello, password!\")").trim());
 }
+
+#[test]
+fn identity_account_id() {
+    let ctx = TestContext::new();
+
+    // Test account-id for anonymous identity (default in test context)
+    ctx.icp()
+        .args(["identity", "account-id"])
+        .assert()
+        .success()
+        .stdout(eq("1c7a48ba6a562aa9eaa2481a9049cdf0433b9738c992d698c31d8abf89cadc79").trim());
+
+    // Test account-id with --of-principal flag
+    ctx.icp()
+        .args(["identity", "account-id", "--of-principal", "aaaaa-aa"])
+        .assert()
+        .success()
+        .stdout(eq("2d0e897f7e862d2b57d9bc9ea5c65f9a24ac6c074575f47898314b8d6cb0929d").trim());
+
+    // Import an identity and test its account-id
+    ctx.icp()
+        .args(["identity", "import", "alice", "--from-pem"])
+        .arg(ctx.make_asset("decrypted_sec1_k256.pem"))
+        .assert()
+        .success();
+    ctx.icp()
+        .args(["identity", "account-id", "--identity", "alice"])
+        .assert()
+        .success()
+        .stdout(eq("4f3d4b40cdb852732601fccf8bd24dffe44957a647cb867913e982d98cf85676").trim());
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,6 +28,7 @@ This document contains the help content for the `icp` command-line program.
 * [`icp environment`↴](#icp-environment)
 * [`icp environment list`↴](#icp-environment-list)
 * [`icp identity`↴](#icp-identity)
+* [`icp identity account-id`↴](#icp-identity-account-id)
 * [`icp identity default`↴](#icp-identity-default)
 * [`icp identity import`↴](#icp-identity-import)
 * [`icp identity list`↴](#icp-identity-list)
@@ -508,11 +509,25 @@ Manage your identities
 
 ###### **Subcommands:**
 
+* `account-id` — Display the ICP ledger account identifier for the current identity
 * `default` — Display the currently selected identity
 * `import` — Import a new identity
 * `list` — List the identities
 * `new` — Create a new identity
 * `principal` — Display the principal for the current identity
+
+
+
+## `icp identity account-id`
+
+Display the ICP ledger account identifier for the current identity
+
+**Usage:** `icp identity account-id [OPTIONS]`
+
+###### **Options:**
+
+* `--identity <IDENTITY>` — The user identity to run this command as
+* `--of-principal <OF_PRINCIPAL>` — Convert this Principal instead of the current identity's Principal
 
 
 


### PR DESCRIPTION
Add a new subcommand to display the ICP ledger account identifier for the current identity or a specified principal.

- Supports `--of-principal` flag to convert a specific principal
- Conflicts with `--identity` flag when `--of-principal` is used