### PR TITLE
docs: document identity export, rename, and delete commands

### DIFF
--- a/docs/guides/managing-identities.md
+++ b/docs/guides/managing-identities.md
@@ -5,6 +5,8 @@ This is a detailed reference for identity management. If you're deploying to mai
 This guide covers:
 - Understanding identity storage and security
 - Creating and importing identities
+- Exporting identities for backup or migration
+- Renaming and deleting identities
 - Using multiple identities
 - Account identifiers for exchange compatibility
 - Advanced identity management
@@ -128,6 +130,50 @@ Or enter interactively:
 ```bash
 icp identity import my-identity --read-seed-phrase
 ```
+
+## Exporting Identities
+
+Export an identity as a plaintext PEM file for backup or migration purposes:
+
+```bash
+icp identity export my-identity > backup.pem
+```
+
+This works with all storage types (plaintext, password-protected, keyring). The exported PEM file can be imported on another machine or used as a backup.
+
+### Exporting Password-Protected Identities
+
+For password-protected identities, you can provide the password via file to avoid interactive prompts:
+
+```bash
+icp identity export my-identity --password-file ./password.txt > backup.pem
+```
+
+If you don't provide a password file, you'll be prompted to enter the password interactively.
+
+**Security Note:** The exported PEM file contains your private key in plaintext. Store it securely and delete it after importing if no longer needed.
+
+## Renaming and Deleting Identities
+
+### Renaming an Identity
+
+Change the name of an existing identity:
+
+```bash
+icp identity rename old-name new-name
+```
+
+This updates the identity's name while preserving all its keys and configuration.
+
+### Deleting an Identity
+
+Remove an identity you no longer need:
+
+```bash
+icp identity delete my-old-identity
+```
+
+**Warning:** This permanently deletes the identity. Make sure you have a backup (using `icp identity export`) if you might need to restore it later.
 
 ## Storage Options
 

--- a/docs/migration/from-dfx.md
+++ b/docs/migration/from-dfx.md
@@ -99,6 +99,9 @@ icp-cli assumes users will use canister environment variables to connect caniste
 | Create identity | `dfx identity new my_id` | `icp identity new my_id` |
 | Use identity | `dfx identity use my_id` | `icp identity default my_id` |
 | Show principal | `dfx identity get-principal` | `icp identity principal` |
+| Export identity | `dfx identity export my_id` | `icp identity export my_id` |
+| Rename identity | `dfx identity rename old_id new_id` | `icp identity rename old_id new_id` |
+| Delete identity | `dfx identity remove my_id` | `icp identity delete my_id` |
 | Get account ID | `dfx ledger account-id` | `icp identity account-id` |
 
 ## Converting dfx.json to icp.yaml


### PR DESCRIPTION
## Summary

Updates documentation to reflect the new identity management commands added in #319 and #315:
- `icp identity export` - Export identities as PEM files
- `icp identity rename` - Rename existing identities  
- `icp identity delete` - Delete identities

## Changes

### `docs/guides/managing-identities.md`
- Added "Exporting Identities" section with examples for exporting identities (including password-protected ones)
- Added "Renaming and Deleting Identities" section documenting both commands
- Updated table of contents to include the new sections

### `docs/migration/from-dfx.md`
- Updated command mapping table to include:
  - Export identity: `dfx identity export` → `icp identity export`
  - Rename identity: `dfx identity rename` → `icp identity rename`
  - Delete identity: `dfx identity remove` → `icp identity delete`