### PR TITLE
chore: Release v0.1.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+# v0.1.0-beta.6
+
+* feat: `icp identity export` to print the PEM file for the identity
+
 # v0.1.0-beta.5
 
 * fix: Fix error when loading network descriptors from v0.1.0-beta.3
 * feat: `icp identity delete` and `icp identity rename`
-* feat: `icp identity export` to print the PEM file for the identity
 
 # v0.1.0-beta.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 dependencies = [
  "icp",
  "schemars 1.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -21,7 +21,7 @@ This guide covers:
 **macOS / Linux / WSL:**
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/icp-cli/releases/download/v0.1.0-beta.5/icp-cli-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/icp-cli/releases/download/v0.1.0-beta.6/icp-cli-installer.sh | sh
 ```
 
 Restart your shell or follow the instructions shown by the installer.
@@ -29,7 +29,7 @@ Restart your shell or follow the instructions shown by the installer.
 **Windows:**
 
 ```ps1
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/dfinity/icp-cli/releases/download/v0.1.0-beta.5/icp-cli-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/dfinity/icp-cli/releases/download/v0.1.0-beta.6/icp-cli-installer.ps1 | iex"
 ```
 
 Restart your terminal after installation.


### PR DESCRIPTION
The npm publishing workflow requires a release containing the `npm/` directory.