### PR TITLE
feat: add --query flag to canister call command

### DIFF
--- a/crates/icp-cli/src/commands/canister/call.rs
+++ b/crates/icp-cli/src/commands/canister/call.rs
@@ -51,6 +51,13 @@ pub(crate) struct CallArgs {
     /// Only used when --proxy is specified. Defaults to 0.
     #[arg(long, requires = "proxy", value_parser = parse_cycles_amount, default_value = "0")]
     pub(crate) cycles: u128,
+
+    /// Sends a query request to a canister instead of an update request.
+    ///
+    /// Query calls are faster but return uncertified responses.
+    /// Cannot be used with --proxy (proxy calls are always update calls).
+    #[arg(long, conflicts_with = "proxy")]
+    pub(crate) query: bool,
 }
 
 pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::Error> {
@@ -145,8 +152,24 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
             ProxyResult::Ok(ok) => ok.result,
             ProxyResult::Err(err) => bail!(err.format_error()),
         }
+    } else if args.query {
+        // Preemptive check: error if Candid shows this is an update method
+        if let Some((_, func)) = &candid_types
+            && !func.is_query()
+        {
+            bail!(
+                "`{}` is an update method, not a query method. \
+                 Run the command without `--query`.",
+                args.method
+            );
+        }
+        agent
+            .query(&cid, &args.method)
+            .with_arg(arg_bytes)
+            .call()
+            .await?
     } else {
-        // Direct call to the target canister
+        // Direct update call to the target canister
         agent.update(&cid, &args.method).with_arg(arg_bytes).await?
     };
 
@@ -241,6 +264,31 @@ mod tests {
         assert!(
             typed_str.contains("bitcoin_canister_id"),
             "typed decoding should contain 'bitcoin_canister_id': {typed_str}"
+        );
+    }
+
+    #[test]
+    fn is_query_detects_method_types() {
+        let did = r#"
+            service : {
+                "get_value" : () -> (text) query;
+                "set_value" : (text) -> ()
+            }
+        "#;
+        let source = CandidSource::Text(did);
+        let (type_env, ty) = source.load().unwrap();
+        let actor = ty.unwrap();
+
+        let query_func = type_env.get_method(&actor, "get_value").unwrap();
+        assert!(
+            query_func.is_query(),
+            "get_value should be detected as query"
+        );
+
+        let update_func = type_env.get_method(&actor, "set_value").unwrap();
+        assert!(
+            !update_func.is_query(),
+            "set_value should be detected as update"
         );
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -167,6 +167,9 @@ Make a canister call
    Only used when --proxy is specified. Defaults to 0.
 
   Default value: `0`
+* `--query` — Sends a query request to a canister instead of an update request.
+
+   Query calls are faster but return uncertified responses. Cannot be used with --proxy (proxy calls are always update calls).
 
 
 


### PR DESCRIPTION
## Summary
- Adds `--query` flag to `icp canister call` for making query calls instead of update calls
- Query calls are faster (single replica, no consensus) but return uncertified responses
- When Candid metadata is available and the method is an update method, errors preemptively with a clear message instead of letting the replica return a cryptic "Canister has no query method" error
- `--query` conflicts with `--proxy` at the clap level (proxy calls are inherently update calls due to cycle forwarding)
- Default behavior is unchanged: all calls remain update calls unless `--query` is explicitly passed