### PR TITLE
docs: remove unnecessary `mops toolchain init` from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A command-line tool for building and deploying applications on the [Internet Com
 npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
 # Motoko toolchain (for Motoko projects)
-npm install -g ic-mops && mops toolchain init
+npm install -g ic-mops
 ```
 
 > **Alternative methods:** See the [Installation Guide](docs/guides/installation.md) for Homebrew, shell script, Rust setup, or platform-specific instructions.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -35,7 +35,7 @@ npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 **Motoko:**
 
 ```bash
-npm install -g ic-mops && mops toolchain init
+npm install -g ic-mops
 ```
 
 **Rust** (if not already installed):
@@ -118,7 +118,7 @@ Learn more: [ic-wasm repository](https://github.com/dfinity/ic-wasm)
 **Motoko:**
 
 ```bash
-curl -fsSL cli.mops.one/install.sh | sh && mops toolchain init
+curl -fsSL cli.mops.one/install.sh | sh
 ```
 
 > **Note:** Requires [Node.js](https://nodejs.org/) and a package manager (npm, pnpm, or bun). The shell script installs the latest Mops version stored onchain on ICP.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ Deploy a full-stack app to a local network in under 5 minutes.
 npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
 # Motoko toolchain (for Motoko projects)
-npm install -g ic-mops && mops toolchain init
+npm install -g ic-mops
 ```
 
 > **Alternative methods:** See the [Installation Guide](guides/installation.md) for Homebrew, shell script, or other options.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -25,7 +25,7 @@ Install the required tools:
 npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm
 
 # Motoko toolchain (for Motoko projects)
-npm install -g ic-mops && mops toolchain init
+npm install -g ic-mops
 ```
 
 This installs:


### PR DESCRIPTION
`mops toolchain init` only sets `DFX_MOC_PATH` for dfx-based workflows.

icp-cli resolves the Motoko compiler directly via the recipe by running `mops toolchain bin moc`, so the command is not needed. Installing mops alone is sufficient.