### PR TITLE
chore: warn of insecure identity

### DIFF
--- a/crates/icp-cli/src/commands/identity/import.rs
+++ b/crates/icp-cli/src/commands/identity/import.rs
@@ -107,6 +107,12 @@ pub(crate) async fn exec(ctx: &Context, args: &ImportArgs) -> Result<(), anyhow:
 
     println!("Identity \"{}\" created", args.name);
 
+    if matches!(args.storage, StorageMode::Plaintext) {
+        eprintln!(
+            "WARNING: This identity is stored in plaintext and is not secure. Do not use it for anything of significant value."
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/icp-cli/src/commands/identity/new.rs
+++ b/crates/icp-cli/src/commands/identity/new.rs
@@ -74,6 +74,12 @@ pub(crate) async fn exec(ctx: &Context, args: &NewArgs) -> Result<(), anyhow::Er
         })
         .await??;
 
+    if matches!(args.storage, StorageMode::Plaintext) {
+        eprintln!(
+            "WARNING: This identity is stored in plaintext and is not secure. Do not use it for anything of significant value."
+        );
+    }
+
     match &args.output_seed {
         Some(path) => {
             write_string(path, mnemonic.as_ref()).context("failed to write seed file")?;


### PR DESCRIPTION
warn about insecure identities when creating a plaintext identity