### PR TITLE
chore: Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Unreleased
 
+# v0.2.0
+
 * feat: Added 'friendly name' domains for canisters - instead of `<frontend principal>.localhost` you can access `frontend.local.localhost`.
-
-# v0.2.0-beta.0
-
 * feat: Added `bind` key to network gateway config to pick your network interface (previous documentation mentioned a `host` key, but it did not do anything)
 * feat: check for Candid incompatibility when upgrading a canister
 * feat: Add `bitcoind-addr` and `dogecoind-addr` options for managed networks to connect to Bitcoin and Dogecoin nodes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.0-beta.0"
+version = "0.2.0"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.0-beta.0"
+version = "0.2.0"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.0-beta.0"
+version = "0.2.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5477,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.0-beta.0"
+version = "0.2.0"
 dependencies = [
  "icp",
  "schemars 1.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.0-beta.0"
+version = "0.2.0"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

This PR bumps the workspace version from `0.2.0-beta.0` to `0.2.0` and consolidates the changelog.

### Changes
- `Cargo.toml`: version `0.2.0-beta.0` → `0.2.0`
- `Cargo.lock`: updated to reflect version bump
- `CHANGELOG.md`: merged unreleased items and beta items under `# v0.2.0`

### Review checklist
- [x] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct