### PR TITLE
refactor: apply trace span once at dispatch call site

### DIFF
--- a/crates/icp-cli/src/main.rs
+++ b/crates/icp-cli/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> Result<(), Error> {
     let ctx = icp::context::initialize(cli.project_root_override, term, cli.debug, password_func)?;
 
     let telemetry_session = telemetry::setup(&ctx, &raw_args, &Cli::command()).await;
-    let result = dispatch(&ctx, command, trace_span).await;
+    let result = dispatch(&ctx, command).instrument(trace_span).await;
 
     if let Some(session) = telemetry_session {
         session.finish(result.is_ok(), &ctx.telemetry_data);
@@ -180,335 +180,223 @@ async fn main() -> Result<(), Error> {
 }
 
 /// Dispatch the command to its handler.
-async fn dispatch(
-    ctx: &icp::context::Context,
-    command: Command,
-    trace_span: tracing::Span,
-) -> Result<(), Error> {
+async fn dispatch(ctx: &icp::context::Context, command: Command) -> Result<(), Error> {
     match command {
         // Build
-        Command::Build(args) => {
-            commands::build::exec(ctx, &args)
-                .instrument(trace_span)
-                .await?
-        }
+        Command::Build(args) => commands::build::exec(ctx, &args).await?,
 
         // Canister
         Command::Canister(cmd) => match cmd {
             commands::canister::Command::Call(args) => {
-                commands::canister::call::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::call::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Create(args) => {
-                commands::canister::create::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::create::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Delete(args) => {
-                commands::canister::delete::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::delete::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Install(args) => {
-                commands::canister::install::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::install::exec(ctx, &args).await?
             }
 
             commands::canister::Command::List(args) => {
-                commands::canister::list::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::list::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Logs(args) => {
-                commands::canister::logs::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::logs::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Metadata(args) => {
-                commands::canister::metadata::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::metadata::exec(ctx, &args).await?
             }
 
             commands::canister::Command::MigrateId(args) => {
-                commands::canister::migrate_id::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::migrate_id::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Settings(cmd) => match cmd {
                 commands::canister::settings::Command::Show(args) => {
-                    commands::canister::settings::show::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::settings::show::exec(ctx, &args).await?
                 }
 
                 commands::canister::settings::Command::Update(args) => {
-                    commands::canister::settings::update::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::settings::update::exec(ctx, &args).await?
                 }
 
                 commands::canister::settings::Command::Sync(args) => {
-                    commands::canister::settings::sync::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::settings::sync::exec(ctx, &args).await?
                 }
             },
 
             commands::canister::Command::Snapshot(cmd) => match cmd {
                 commands::canister::snapshot::Command::Create(args) => {
-                    commands::canister::snapshot::create::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::snapshot::create::exec(ctx, &args).await?
                 }
 
                 commands::canister::snapshot::Command::Delete(args) => {
-                    commands::canister::snapshot::delete::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::snapshot::delete::exec(ctx, &args).await?
                 }
 
                 commands::canister::snapshot::Command::Download(args) => {
-                    commands::canister::snapshot::download::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::snapshot::download::exec(ctx, &args).await?
                 }
 
                 commands::canister::snapshot::Command::List(args) => {
-                    commands::canister::snapshot::list::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::snapshot::list::exec(ctx, &args).await?
                 }
 
                 commands::canister::snapshot::Command::Restore(args) => {
-                    commands::canister::snapshot::restore::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::snapshot::restore::exec(ctx, &args).await?
                 }
 
                 commands::canister::snapshot::Command::Upload(args) => {
-                    commands::canister::snapshot::upload::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::canister::snapshot::upload::exec(ctx, &args).await?
                 }
             },
 
             commands::canister::Command::Start(args) => {
-                commands::canister::start::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::start::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Status(args) => {
-                commands::canister::status::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::status::exec(ctx, &args).await?
             }
 
             commands::canister::Command::Stop(args) => {
-                commands::canister::stop::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::stop::exec(ctx, &args).await?
             }
 
             commands::canister::Command::TopUp(args) => {
-                commands::canister::top_up::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::canister::top_up::exec(ctx, &args).await?
             }
         },
 
         // Cycles
         Command::Cycles(cmd) => match cmd {
             commands::cycles::Command::Balance(args) => {
-                commands::cycles::balance::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::cycles::balance::exec(ctx, &args).await?
             }
 
             commands::cycles::Command::Mint(args) => {
-                commands::cycles::mint::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::cycles::mint::exec(ctx, &args).await?
             }
 
             commands::cycles::Command::Transfer(args) => {
-                commands::cycles::transfer::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::cycles::transfer::exec(ctx, &args).await?
             }
         },
 
         // Deploy
-        Command::Deploy(args) => {
-            commands::deploy::exec(ctx, &args)
-                .instrument(trace_span)
-                .await?
-        }
+        Command::Deploy(args) => commands::deploy::exec(ctx, &args).await?,
 
         // Environment
         Command::Environment(cmd) => match cmd {
             commands::environment::Command::List(args) => {
-                commands::environment::list::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::environment::list::exec(ctx, &args).await?
             }
         },
 
         // Identity
         Command::Identity(cmd) => match cmd {
             commands::identity::Command::AccountId(args) => {
-                commands::identity::account_id::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::account_id::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Default(args) => {
-                commands::identity::default::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::default::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Delete(args) => {
-                commands::identity::delete::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::delete::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Export(args) => {
-                commands::identity::export::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::export::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Import(args) => {
-                commands::identity::import::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::import::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Link(cmd) => match cmd {
                 commands::identity::link::Command::Hsm(args) => {
-                    commands::identity::link::hsm::exec(ctx, &args)
-                        .instrument(trace_span)
-                        .await?
+                    commands::identity::link::hsm::exec(ctx, &args).await?
                 }
             },
 
             commands::identity::Command::List(args) => {
-                commands::identity::list::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::list::exec(ctx, &args).await?
             }
 
             commands::identity::Command::New(args) => {
-                commands::identity::new::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::new::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Principal(args) => {
-                commands::identity::principal::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::principal::exec(ctx, &args).await?
             }
 
             commands::identity::Command::Rename(args) => {
-                commands::identity::rename::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::identity::rename::exec(ctx, &args).await?
             }
         },
 
         // Network
         Command::Network(cmd) => match cmd {
             commands::network::Command::List(args) => {
-                commands::network::list::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::network::list::exec(ctx, &args).await?
             }
 
             commands::network::Command::Ping(args) => {
-                commands::network::ping::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::network::ping::exec(ctx, &args).await?
             }
 
             commands::network::Command::Start(args) => {
-                commands::network::start::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::network::start::exec(ctx, &args).await?
             }
 
             commands::network::Command::Status(args) => {
-                commands::network::status::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::network::status::exec(ctx, &args).await?
             }
 
             commands::network::Command::Stop(args) => {
-                commands::network::stop::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::network::stop::exec(ctx, &args).await?
             }
 
             commands::network::Command::Update(args) => {
-                commands::network::update::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::network::update::exec(ctx, &args).await?
             }
         },
 
         // New
-        Command::New(args) => {
-            commands::new::exec(ctx, &args)
-                .instrument(trace_span)
-                .await?
-        }
+        Command::New(args) => commands::new::exec(ctx, &args).await?,
 
         // Project
         Command::Project(cmd) => match cmd {
             commands::project::Command::Show(args) => {
-                commands::project::show::exec(ctx, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::project::show::exec(ctx, &args).await?
             }
         },
 
         // Settings
-        Command::Settings(args) => {
-            commands::settings::exec(ctx, &args)
-                .instrument(trace_span)
-                .await?
-        }
+        Command::Settings(args) => commands::settings::exec(ctx, &args).await?,
 
         // Sync
-        Command::Sync(args) => {
-            commands::sync::exec(ctx, &args)
-                .instrument(trace_span)
-                .await?
-        }
+        Command::Sync(args) => commands::sync::exec(ctx, &args).await?,
 
         // Token
         Command::Token(cmd) => match cmd.command {
             commands::token::Commands::Balance(args) => {
-                commands::token::balance::exec(ctx, &cmd.token_name_or_ledger_id, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::token::balance::exec(ctx, &cmd.token_name_or_ledger_id, &args).await?
             }
 
             commands::token::Commands::Transfer(args) => {
-                commands::token::transfer::exec(ctx, &cmd.token_name_or_ledger_id, &args)
-                    .instrument(trace_span)
-                    .await?
+                commands::token::transfer::exec(ctx, &cmd.token_name_or_ledger_id, &args).await?
             }
         },
     }


### PR DESCRIPTION
## Summary

- Removes the `trace_span` parameter from `dispatch` and replaces 30+ per-arm `.instrument(trace_span)` calls with a single `.instrument(trace_span)` at the call site in `main`
- The span context propagates automatically through the entire async call tree, so behavior is identical
- Debug output is unchanged: `version`, `git_sha`, and `command` details are still logged at the start of every invocation

## Test plan

- [x] `cargo build --bin icp` compiles cleanly
- [x] `icp <any-command> --debug` still shows `version`, `git_sha`, and command details in the first debug line

🤖 Generated with [Claude Code](https://claude.com/claude-code)