### PR TITLE
chore: release v0.2.1-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.2.1-beta.0
+
 * feat: Added support for creating canisters on cloud engine subnets. Note that local networks cannot yet create these subnets.
 * feat: Upgrading canisters now stops them before the upgrade and starts them again afterwards
 * feat: `icp canister logs` supports filtering by timestamp (`--since`, `--until`) and log index (`--since-index`, `--until-index`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.0"
+version = "0.2.1-beta.0"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.0"
+version = "0.2.1-beta.0"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.0"
+version = "0.2.1-beta.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.0"
+version = "0.2.1-beta.0"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.0"
+version = "0.2.1-beta.0"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.2.1-beta.0`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.2.1-beta.0`

### Review checklist
- [x] CI passes
- [x] Changelog entries look correct
- [ ] Version number is correct