### PR TITLE
ci: auto-sync docs/vX.Y branch when a release tag is pushed

### DIFF
--- a/.claude/skills/release/task6-docs.md
+++ b/.claude/skills/release/task6-docs.md
@@ -6,7 +6,7 @@ The tag push triggers two automated workflows:
 
 1. **`docs.yml` (`publish-versioned-docs` job):** Builds and publishes the versioned docs to `/X.Y/` on the `docs-deployment` branch (served at `https://cli.internetcomputer.org/X.Y/`). The `versions.json` PR must not be merged until that deployment succeeds, otherwise the root redirect will point to a path that does not exist yet.
 
-2. **`sync-docs-branch.yml`:** Opens a PR to reset `docs/vX.Y` to the new tag, preventing the branch from drifting behind the latest patch release. **Merge this PR (squash) after CI passes.** If there are docs-only improvements on `main` that should be backported to this version's docs, cherry-pick them onto `docs/vX.Y` after merging.
+2. **`sync-docs-branch.yml`:** Force-resets `docs/vX.Y` directly to the new tag commit — no manual action required. If there are docs-only improvements on `main` (not yet in the tag) that should be backported to this version's docs, cherry-pick them onto `docs/vX.Y` after the reset completes.
 
 Once the `versions.json` PR merges to `main`, the `publish-root-files` CI job runs automatically and copies `og-image.png`, `llms.txt`, `llms-full.txt`, and `feed.xml` from the new version's folder to the deployment root — no manual step needed.
 

--- a/.claude/skills/release/task6-docs.md
+++ b/.claude/skills/release/task6-docs.md
@@ -2,7 +2,11 @@
 
 *Skip if `$ARGUMENTS` is a beta release. Requires Task 2. Runs concurrently with Task 3.*
 
-The tag push triggers a docs deployment workflow that builds and publishes the versioned docs to `/X.Y/` on the `docs-deployment` branch (served at `https://cli.internetcomputer.org/X.Y/`). The `versions.json` PR must not be merged until that deployment succeeds, otherwise the root redirect will point to a path that does not exist yet.
+The tag push triggers two automated workflows:
+
+1. **`docs.yml` (`publish-versioned-docs` job):** Builds and publishes the versioned docs to `/X.Y/` on the `docs-deployment` branch (served at `https://cli.internetcomputer.org/X.Y/`). The `versions.json` PR must not be merged until that deployment succeeds, otherwise the root redirect will point to a path that does not exist yet.
+
+2. **`sync-docs-branch.yml`:** Opens a PR to reset `docs/vX.Y` to the new tag, preventing the branch from drifting behind the latest patch release. **Merge this PR (squash) after CI passes.** If there are docs-only improvements on `main` that should be backported to this version's docs, cherry-pick them onto `docs/vX.Y` after merging.
 
 Once the `versions.json` PR merges to `main`, the `publish-root-files` CI job runs automatically and copies `og-image.png`, `llms.txt`, `llms-full.txt`, and `feed.xml` from the new version's folder to the deployment root — no manual step needed.
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -257,7 +257,9 @@ jobs:
 
   # Publish versioned docs - runs on tags (v*) or docs branches (docs/v*)
   publish-versioned-docs:
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/docs/v'))
+    # Skip when github-actions[bot] force-pushes docs/vX.Y after a tag: that push
+    # resets the branch to the tag state, which was already deployed by the tag run.
+    if: github.event_name == 'push' && github.actor != 'github-actions[bot]' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/docs/v'))
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-docs-branch.yml
+++ b/.github/workflows/sync-docs-branch.yml
@@ -48,11 +48,12 @@ jobs:
 
       - name: Force-reset docs branch to tag
         run: |
-          git checkout -b "${DOCS_BRANCH}" "${TAG}"
           if git ls-remote --exit-code --heads origin "${DOCS_BRANCH}" > /dev/null 2>&1; then
+            git checkout -b "${DOCS_BRANCH}" "${TAG}"
             git push origin "${DOCS_BRANCH}" --force
             echo "Reset ${DOCS_BRANCH} to ${TAG}"
           else
+            git checkout -b "${DOCS_BRANCH}" "${TAG}"
             git push origin "${DOCS_BRANCH}"
             echo "Created ${DOCS_BRANCH} from ${TAG}"
           fi

--- a/.github/workflows/sync-docs-branch.yml
+++ b/.github/workflows/sync-docs-branch.yml
@@ -1,12 +1,18 @@
 name: Sync docs branch after release
 
-# When a release tag is pushed, open a PR to reset the corresponding docs/vX.Y
-# branch to that tag commit. This prevents the branch from drifting behind the
-# latest patch release and avoids accidentally deploying stale docs.
+# When a release tag is pushed, force-reset the corresponding docs/vX.Y branch
+# to that exact tag commit. This keeps docs/vX.Y in sync with the latest patch
+# and prevents stale content from being deployed if someone later pushes a
+# hotfix to a branch that has drifted behind the tag.
 #
-# - If docs/vX.Y does not exist: creates it directly from the tag (no PR needed).
-# - If docs/vX.Y exists: opens a PR from a temporary sync branch so CI validates
-#   the build before the branch is updated. Merge with "Squash and merge".
+# Prerequisites: the branch protection rule for docs/v* must allow
+# github-actions[bot] to bypass the force-push restriction. Without this,
+# the push step will fail with a "Cannot force-push" error.
+#
+# The force-push to docs/vX.Y would normally re-trigger publish-versioned-docs
+# in docs.yml, re-deploying identical content (already deployed from the tag).
+# docs.yml skips that job when the actor is github-actions[bot] to avoid the
+# redundant build.
 
 on:
   push:
@@ -16,7 +22,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   sync-docs-branch:
@@ -36,43 +41,18 @@ jobs:
         run: |
           TAG=${GITHUB_REF_NAME}          # e.g. v0.2.3
           PATCH=${TAG#v}                  # e.g. 0.2.3
-          MINOR=${PATCH%.*}               # e.g. 0.2
+          MINOR=${PATCH%.*}              # e.g. 0.2
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "MINOR=${MINOR}" >> $GITHUB_ENV
           echo "DOCS_BRANCH=docs/v${MINOR}" >> $GITHUB_ENV
-          echo "SYNC_BRANCH=sync/docs-v${MINOR}-from-${TAG}" >> $GITHUB_ENV
 
-      - name: Create or sync docs branch
+      - name: Force-reset docs branch to tag
         run: |
+          git checkout -b "${DOCS_BRANCH}" "${TAG}"
           if git ls-remote --exit-code --heads origin "${DOCS_BRANCH}" > /dev/null 2>&1; then
-            # Branch exists — open a PR so CI validates before merging.
-            git checkout -b "${SYNC_BRANCH}" "${TAG}"
-            git push origin "${SYNC_BRANCH}"
-
-            gh pr create \
-              --base "${DOCS_BRANCH}" \
-              --head "${SYNC_BRANCH}" \
-              --title "chore(docs): sync ${DOCS_BRANCH} to ${TAG}" \
-              --body "$(cat <<EOF
-Automated sync of \`${DOCS_BRANCH}\` to the \`${TAG}\` release tag.
-
-**Why:** Both \`v*\` tags and \`docs/v*\` branches trigger the same \`publish-versioned-docs\` CI job and deploy to the same \`/${MINOR}/\` folder. If the branch drifts behind the tag, any future push to it would silently overwrite the live docs with older content.
-
-**What to do:**
-1. Wait for CI to pass.
-2. Merge with **Squash and merge** to keep the branch history clean.
-3. If there are docs-only improvements on \`main\` (not in \`${TAG}\`) that should be backported, cherry-pick them onto \`${DOCS_BRANCH}\` after this PR merges.
-
-*Opened automatically by the sync-docs-branch workflow.*
-EOF
-)"
-
-            echo "Opened sync PR: ${DOCS_BRANCH} ← ${SYNC_BRANCH}"
+            git push origin "${DOCS_BRANCH}" --force
+            echo "Reset ${DOCS_BRANCH} to ${TAG}"
           else
-            # Branch doesn't exist — create it directly from the tag.
-            git checkout -b "${DOCS_BRANCH}" "${TAG}"
             git push origin "${DOCS_BRANCH}"
             echo "Created ${DOCS_BRANCH} from ${TAG}"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-docs-branch.yml
+++ b/.github/workflows/sync-docs-branch.yml
@@ -1,0 +1,78 @@
+name: Sync docs branch after release
+
+# When a release tag is pushed, open a PR to reset the corresponding docs/vX.Y
+# branch to that tag commit. This prevents the branch from drifting behind the
+# latest patch release and avoids accidentally deploying stale docs.
+#
+# - If docs/vX.Y does not exist: creates it directly from the tag (no PR needed).
+# - If docs/vX.Y exists: opens a PR from a temporary sync branch so CI validates
+#   the build before the branch is updated. Merge with "Squash and merge".
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!v*-*'    # exclude pre-release tags (e.g. v0.2.0-beta.0)
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-docs-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version info
+        run: |
+          TAG=${GITHUB_REF_NAME}          # e.g. v0.2.3
+          PATCH=${TAG#v}                  # e.g. 0.2.3
+          MINOR=${PATCH%.*}               # e.g. 0.2
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "MINOR=${MINOR}" >> $GITHUB_ENV
+          echo "DOCS_BRANCH=docs/v${MINOR}" >> $GITHUB_ENV
+          echo "SYNC_BRANCH=sync/docs-v${MINOR}-from-${TAG}" >> $GITHUB_ENV
+
+      - name: Create or sync docs branch
+        run: |
+          if git ls-remote --exit-code --heads origin "${DOCS_BRANCH}" > /dev/null 2>&1; then
+            # Branch exists — open a PR so CI validates before merging.
+            git checkout -b "${SYNC_BRANCH}" "${TAG}"
+            git push origin "${SYNC_BRANCH}"
+
+            gh pr create \
+              --base "${DOCS_BRANCH}" \
+              --head "${SYNC_BRANCH}" \
+              --title "chore(docs): sync ${DOCS_BRANCH} to ${TAG}" \
+              --body "$(cat <<EOF
+Automated sync of \`${DOCS_BRANCH}\` to the \`${TAG}\` release tag.
+
+**Why:** Both \`v*\` tags and \`docs/v*\` branches trigger the same \`publish-versioned-docs\` CI job and deploy to the same \`/${MINOR}/\` folder. If the branch drifts behind the tag, any future push to it would silently overwrite the live docs with older content.
+
+**What to do:**
+1. Wait for CI to pass.
+2. Merge with **Squash and merge** to keep the branch history clean.
+3. If there are docs-only improvements on \`main\` (not in \`${TAG}\`) that should be backported, cherry-pick them onto \`${DOCS_BRANCH}\` after this PR merges.
+
+*Opened automatically by the sync-docs-branch workflow.*
+EOF
+)"
+
+            echo "Opened sync PR: ${DOCS_BRANCH} ← ${SYNC_BRANCH}"
+          else
+            # Branch doesn't exist — create it directly from the tag.
+            git checkout -b "${DOCS_BRANCH}" "${TAG}"
+            git push origin "${DOCS_BRANCH}"
+            echo "Created ${DOCS_BRANCH} from ${TAG}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds automation to keep \`docs/vX.Y\` branches in sync with release tags, and prevents a redundant docs re-deployment after the sync.

**Files changed:**
- \`.github/workflows/sync-docs-branch.yml\` — new workflow that force-resets \`docs/vX.Y\` on every release tag
- \`.github/workflows/docs.yml\` — skips \`publish-versioned-docs\` when \`github-actions[bot]\` pushes (avoids redundant re-deploy)
- \`.claude/skills/release/task6-docs.md\` — updated release playbook to document the automation

## The problem

Both \`v*\` tags and \`docs/v*\` branches trigger the same \`publish-versioned-docs\` job and deploy to the same \`/X.Y/\` folder on the live site. Without sync automation, \`docs/vX.Y\` silently drifts behind the tag — and any future push to it (e.g. a docs hotfix) would overwrite the live docs with older content. This happened: \`docs/v0.2\` was sitting at its March 30 state while the live \`/0.2/\` docs were correctly deployed from the April 8 \`v0.2.3\` tag.

## How it works

### `sync-docs-branch.yml`

Triggers on every \`v*\` release tag push (pre-release tags excluded via \`!v*-*\`).

```
Tag v0.2.3 pushed
  └─ Extract minor version: 0.2 → DOCS_BRANCH=docs/v0.2
  └─ docs/v0.2 exists remotely?
       YES → git checkout -b docs/v0.2 v0.2.3 && git push --force
       NO  → git checkout -b docs/v0.2 v0.2.3 && git push
```

The force-push is an atomic reset — no merge commits, no conflict resolution, no manual steps. The branch ends up pointing exactly at the tag commit.

### Skip guard in `docs.yml`

The force-push to \`docs/vX.Y\` triggers \`docs.yml\` again (because docs files changed). Without a guard, \`publish-versioned-docs\` would re-deploy content that is identical to what was just deployed from the tag — wasting CI minutes.

The added condition:
```yaml
if: github.event_name == 'push' && github.actor != 'github-actions[bot]' && (...)
```

skips \`publish-versioned-docs\` only when \`github-actions[bot]\` pushes to \`docs/v*\`. It does **not** affect:
- Tag pushes (always done by humans or release tooling, not the bot)
- Human pushes to \`docs/v*\` (docs hotfixes still deploy normally)
- \`workflow_dispatch\` (condition requires \`event_name == 'push'\`)

### Sequence for a release tag push

```
v0.2.3 tag pushed
  ├─ docs.yml triggered (actor: human)
  │    └─ publish-versioned-docs: RUNS → deploys /0.2/ from v0.2.3 ✓
  │
  └─ sync-docs-branch.yml triggered
       └─ force-pushes docs/v0.2 to v0.2.3 state
            └─ docs.yml triggered again (actor: github-actions[bot])
                 └─ publish-versioned-docs: SKIPPED (actor guard) ✓
```

## ⚠️ Required: branch protection configuration

**This workflow will fail until configured:**

GitHub → Settings → Branches → protection rule for \`docs/v*\`:
> **Allow force pushes** → Specify who can force push → add \`github-actions[bot]\`

Without this, the \`git push --force\` step exits with `"Cannot force-push to this branch"`.

## Behavior table

| Scenario | Result |
|---|---|
| First release of a new minor (e.g. \`v0.3.0\`, no \`docs/v0.3\` yet) | Branch created from tag (normal push) |
| Patch release (\`v0.2.4\`, \`docs/v0.2\` exists) | Branch force-reset to tag |
| Docs-only improvements on \`main\` to backport | Cherry-pick manually onto \`docs/vX.Y\` after the reset |
| Human pushes a docs hotfix to \`docs/v0.2\` | \`publish-versioned-docs\` runs normally (actor check doesn't apply) |

## Test plan

- [ ] Configure branch protection bypass for \`github-actions[bot]\` on \`docs/v*\`
- [ ] On next release tag push, verify \`sync-docs-branch.yml\` runs and force-resets \`docs/vX.Y\`
- [ ] Verify the second \`docs.yml\` run (triggered by the bot's push) skips \`publish-versioned-docs\`
- [ ] Push a manual docs hotfix to \`docs/vX.Y\` and verify \`publish-versioned-docs\` still runs normally