### PR TITLE
feat: canister id show/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * feat: `icp canister id set` to register a pre-existing canister ID for a canister in an environment. Use `--force` or `-f` to overwrite an existing ID
-* feat: `icp canister id show` to display the stored canister ID for a canister in an environment. Supports `--json`
+* feat: `icp canister id show` to display the stored canister ID for a canister in an environment. When no canister name is given, lists all canisters with their ID or `(not set)`. Supports `--json`
 * feat: `icp identity import` now takes `--seed-curve`, for seed phrases for non-k256 keys.
 * fix: `icp canister settings show` now outputs only the canister settings, consistent with the command name
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* feat: `icp canister id set` to register a pre-existing canister ID for a canister in an environment. Use `--force` or `-f` to overwrite an existing ID
+* feat: `icp canister id show` to display the stored canister ID for a canister in an environment. Supports `--json`
 * feat: `icp identity import` now takes `--seed-curve`, for seed phrases for non-k256 keys.
 * fix: `icp canister settings show` now outputs only the canister settings, consistent with the command name
 

--- a/crates/icp-cli/src/commands/canister/id/mod.rs
+++ b/crates/icp-cli/src/commands/canister/id/mod.rs
@@ -1,0 +1,11 @@
+use clap::Subcommand;
+
+pub(crate) mod set;
+pub(crate) mod show;
+
+/// Commands to manage canister IDs
+#[derive(Subcommand, Debug)]
+pub(crate) enum Command {
+    Set(set::SetArgs),
+    Show(show::ShowArgs),
+}

--- a/crates/icp-cli/src/commands/canister/id/set.rs
+++ b/crates/icp-cli/src/commands/canister/id/set.rs
@@ -28,8 +28,17 @@ pub(crate) struct SetArgs {
 
 pub(crate) async fn exec(ctx: &Context, args: &SetArgs) -> Result<(), anyhow::Error> {
     let environment: EnvironmentSelection = args.environment.clone().into();
-    let selection = CanisterSelection::Named(args.canister.clone());
 
+    let env = ctx.get_environment(&environment).await?;
+    if !env.canisters.contains_key(&args.canister) {
+        bail!(
+            "canister '{}' not found in environment '{}'",
+            args.canister,
+            environment.name()
+        );
+    }
+
+    let selection = CanisterSelection::Named(args.canister.clone());
     if let Ok(existing) = ctx.get_canister_id_for_env(&selection, &environment).await {
         if !args.force {
             bail!(

--- a/crates/icp-cli/src/commands/canister/id/set.rs
+++ b/crates/icp-cli/src/commands/canister/id/set.rs
@@ -1,0 +1,57 @@
+use anyhow::bail;
+use candid::Principal;
+use clap::Args;
+use icp::context::{CanisterSelection, Context, EnvironmentSelection};
+
+use crate::options::EnvironmentOpt;
+
+/// Set the canister ID for a canister in an environment.
+///
+/// Use this to register a pre-existing canister ID without creating a new
+/// canister on-chain. Fails if the canister already has an ID unless
+/// `--force` is given.
+#[derive(Debug, Args)]
+pub(crate) struct SetArgs {
+    /// Name of the canister as defined in icp.yaml.
+    canister: String,
+
+    /// The canister principal to set.
+    canister_id: Principal,
+
+    #[command(flatten)]
+    environment: EnvironmentOpt,
+
+    /// Overwrite the canister ID if one is already set.
+    #[arg(long, short)]
+    force: bool,
+}
+
+pub(crate) async fn exec(ctx: &Context, args: &SetArgs) -> Result<(), anyhow::Error> {
+    let environment: EnvironmentSelection = args.environment.clone().into();
+    let selection = CanisterSelection::Named(args.canister.clone());
+
+    if let Ok(existing) = ctx.get_canister_id_for_env(&selection, &environment).await {
+        if !args.force {
+            bail!(
+                "canister '{}' already has ID {} in environment '{}'. Use --force to overwrite",
+                args.canister,
+                existing,
+                environment.name()
+            );
+        }
+        ctx.remove_canister_id_for_env(&args.canister, &environment)
+            .await?;
+    }
+
+    ctx.set_canister_id_for_env(&args.canister, args.canister_id, &environment)
+        .await?;
+
+    println!(
+        "Set canister ID for {} to {} in environment {}",
+        args.canister,
+        args.canister_id,
+        environment.name()
+    );
+
+    Ok(())
+}

--- a/crates/icp-cli/src/commands/canister/id/show.rs
+++ b/crates/icp-cli/src/commands/canister/id/show.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::stdout;
 
+use anyhow::bail;
 use clap::Args;
 use icp::context::{CanisterSelection, Context, EnvironmentSelection, GetCanisterIdForEnvError};
 use icp::store_id::LookupIdError;
@@ -50,6 +51,15 @@ pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), anyhow::E
     let environment: EnvironmentSelection = args.environment.clone().into();
 
     if let Some(canister) = &args.canister {
+        let env = ctx.get_environment(&environment).await?;
+        if !env.canisters.contains_key(canister) {
+            bail!(
+                "canister '{}' not found in environment '{}'",
+                canister,
+                environment.name()
+            );
+        }
+
         let selection = CanisterSelection::Named(canister.clone());
         let canister_id = ctx
             .get_canister_id_for_env(&selection, &environment)
@@ -77,7 +87,7 @@ pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), anyhow::E
                     entries.insert(name.clone(), Some(id.to_string()));
                 }
                 Err(GetCanisterIdForEnvError::CanisterIdLookup { source, .. })
-                    if matches!(*source, LookupIdError::IdNotFound { .. }) =>
+                    if matches!(source.as_ref(), LookupIdError::IdNotFound { .. }) =>
                 {
                     entries.insert(name.clone(), None);
                 }

--- a/crates/icp-cli/src/commands/canister/id/show.rs
+++ b/crates/icp-cli/src/commands/canister/id/show.rs
@@ -1,0 +1,52 @@
+use std::io::stdout;
+
+use clap::Args;
+use icp::context::{CanisterSelection, Context, EnvironmentSelection};
+use serde::Serialize;
+
+use crate::options::EnvironmentOpt;
+
+/// Show the canister ID for a canister in an environment.
+#[derive(Debug, Args)]
+pub(crate) struct ShowArgs {
+    /// Name of the canister as defined in icp.yaml.
+    canister: String,
+
+    #[command(flatten)]
+    environment: EnvironmentOpt,
+
+    /// Output as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Serialize)]
+struct JsonOutput {
+    canister: String,
+    canister_id: String,
+    environment: String,
+}
+
+pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), anyhow::Error> {
+    let environment: EnvironmentSelection = args.environment.clone().into();
+    let selection = CanisterSelection::Named(args.canister.clone());
+
+    let canister_id = ctx
+        .get_canister_id_for_env(&selection, &environment)
+        .await?;
+
+    if args.json {
+        serde_json::to_writer(
+            stdout(),
+            &JsonOutput {
+                canister: args.canister.clone(),
+                canister_id: canister_id.to_string(),
+                environment: environment.name().to_string(),
+            },
+        )?;
+    } else {
+        println!("{canister_id}");
+    }
+
+    Ok(())
+}

--- a/crates/icp-cli/src/commands/canister/id/show.rs
+++ b/crates/icp-cli/src/commands/canister/id/show.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 use std::io::stdout;
 
 use clap::Args;
-use icp::context::{CanisterSelection, Context, EnvironmentSelection};
+use icp::context::{CanisterSelection, Context, EnvironmentSelection, GetCanisterIdForEnvError};
+use icp::store_id::LookupIdError;
 use serde::Serialize;
 
 use crate::options::EnvironmentOpt;
@@ -71,12 +72,17 @@ pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), anyhow::E
         let mut entries: BTreeMap<String, Option<String>> = BTreeMap::new();
         for name in env.canisters.keys() {
             let sel = CanisterSelection::Named(name.clone());
-            let id = ctx
-                .get_canister_id_for_env(&sel, &environment)
-                .await
-                .ok()
-                .map(|p| p.to_string());
-            entries.insert(name.clone(), id);
+            match ctx.get_canister_id_for_env(&sel, &environment).await {
+                Ok(id) => {
+                    entries.insert(name.clone(), Some(id.to_string()));
+                }
+                Err(GetCanisterIdForEnvError::CanisterIdLookup { source, .. })
+                    if matches!(*source, LookupIdError::IdNotFound { .. }) =>
+                {
+                    entries.insert(name.clone(), None);
+                }
+                Err(e) => return Err(e.into()),
+            }
         }
 
         if args.json {

--- a/crates/icp-cli/src/commands/canister/id/show.rs
+++ b/crates/icp-cli/src/commands/canister/id/show.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::stdout;
 
 use clap::Args;
@@ -6,11 +7,15 @@ use serde::Serialize;
 
 use crate::options::EnvironmentOpt;
 
-/// Show the canister ID for a canister in an environment.
+/// Show canister IDs in an environment.
+///
+/// When a canister name is given, prints its ID. Without a name, lists all
+/// canisters with their ID or "(not set)".
 #[derive(Debug, Args)]
 pub(crate) struct ShowArgs {
-    /// Name of the canister as defined in icp.yaml.
-    canister: String,
+    /// Name of the canister as defined in icp.yaml. If omitted, lists all
+    /// canisters with their ID or "(not set)".
+    canister: Option<String>,
 
     #[command(flatten)]
     environment: EnvironmentOpt,
@@ -27,25 +32,76 @@ struct JsonOutput {
     environment: String,
 }
 
+#[derive(Serialize)]
+struct JsonAllEntry {
+    canister: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canister_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct JsonAllOutput {
+    environment: String,
+    canisters: Vec<JsonAllEntry>,
+}
+
 pub(crate) async fn exec(ctx: &Context, args: &ShowArgs) -> Result<(), anyhow::Error> {
     let environment: EnvironmentSelection = args.environment.clone().into();
-    let selection = CanisterSelection::Named(args.canister.clone());
 
-    let canister_id = ctx
-        .get_canister_id_for_env(&selection, &environment)
-        .await?;
+    if let Some(canister) = &args.canister {
+        let selection = CanisterSelection::Named(canister.clone());
+        let canister_id = ctx
+            .get_canister_id_for_env(&selection, &environment)
+            .await?;
 
-    if args.json {
-        serde_json::to_writer(
-            stdout(),
-            &JsonOutput {
-                canister: args.canister.clone(),
-                canister_id: canister_id.to_string(),
-                environment: environment.name().to_string(),
-            },
-        )?;
+        if args.json {
+            serde_json::to_writer(
+                stdout(),
+                &JsonOutput {
+                    canister: canister.clone(),
+                    canister_id: canister_id.to_string(),
+                    environment: environment.name().to_string(),
+                },
+            )?;
+        } else {
+            println!("{canister_id}");
+        }
     } else {
-        println!("{canister_id}");
+        let env = ctx.get_environment(&environment).await?;
+        let mut entries: BTreeMap<String, Option<String>> = BTreeMap::new();
+        for name in env.canisters.keys() {
+            let sel = CanisterSelection::Named(name.clone());
+            let id = ctx
+                .get_canister_id_for_env(&sel, &environment)
+                .await
+                .ok()
+                .map(|p| p.to_string());
+            entries.insert(name.clone(), id);
+        }
+
+        if args.json {
+            let canisters = entries
+                .into_iter()
+                .map(|(name, id)| JsonAllEntry {
+                    canister: name,
+                    canister_id: id,
+                })
+                .collect();
+            serde_json::to_writer(
+                stdout(),
+                &JsonAllOutput {
+                    environment: environment.name().to_string(),
+                    canisters,
+                },
+            )?;
+        } else {
+            for (name, id) in &entries {
+                match id {
+                    Some(id) => println!("{name}\t{id}"),
+                    None => println!("{name}\t(not set)"),
+                }
+            }
+        }
     }
 
     Ok(())

--- a/crates/icp-cli/src/commands/canister/mod.rs
+++ b/crates/icp-cli/src/commands/canister/mod.rs
@@ -3,6 +3,7 @@ use clap::Subcommand;
 pub(crate) mod call;
 pub(crate) mod create;
 pub(crate) mod delete;
+pub(crate) mod id;
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod logs;
@@ -22,6 +23,8 @@ pub(crate) enum Command {
     Call(call::CallArgs),
     Create(create::CreateArgs),
     Delete(delete::DeleteArgs),
+    #[command(subcommand)]
+    Id(id::Command),
     Install(install::InstallArgs),
     List(list::ListArgs),
     Logs(logs::LogsArgs),

--- a/crates/icp-cli/src/main.rs
+++ b/crates/icp-cli/src/main.rs
@@ -205,6 +205,15 @@ async fn dispatch(ctx: &icp::context::Context, command: Command) -> Result<(), E
                 commands::canister::delete::exec(ctx, &args).await?
             }
 
+            commands::canister::Command::Id(cmd) => match cmd {
+                commands::canister::id::Command::Set(args) => {
+                    commands::canister::id::set::exec(ctx, &args).await?
+                }
+                commands::canister::id::Command::Show(args) => {
+                    commands::canister::id::show::exec(ctx, &args).await?
+                }
+            },
+
             commands::canister::Command::Install(args) => {
                 commands::canister::install::exec(ctx, &args).await?
             }

--- a/crates/icp-cli/tests/canister_id_tests.rs
+++ b/crates/icp-cli/tests/canister_id_tests.rs
@@ -1,0 +1,218 @@
+use predicates::{prelude::PredicateBooleanExt, str::contains};
+
+use crate::common::TestContext;
+use icp::fs::write_string;
+
+mod common;
+
+const PROJECT_MANIFEST: &str = r#"
+canisters:
+  - name: backend
+    build:
+      steps:
+        - type: pre-built
+          path: backend.wasm
+
+networks:
+  - name: local
+    mode: managed
+
+environments:
+  - name: local
+    network: local
+  - name: staging
+    network: local
+"#;
+
+fn setup_project(ctx: &TestContext) -> icp::prelude::PathBuf {
+    let project_dir = ctx.create_project_dir("myproject");
+    write_string(&project_dir.join("icp.yaml"), PROJECT_MANIFEST)
+        .expect("failed to write project manifest");
+    project_dir
+}
+
+#[tokio::test]
+async fn canister_id_set_and_show() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let canister_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+
+    // Set canister ID
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", canister_id])
+        .assert()
+        .success()
+        .stdout(contains(canister_id));
+
+    // Show canister ID
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend"])
+        .assert()
+        .success()
+        .stdout(contains(canister_id));
+}
+
+#[tokio::test]
+async fn canister_id_show_json() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let canister_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", canister_id])
+        .assert()
+        .success();
+
+    let output = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(json["canister"], "backend");
+    assert_eq!(json["canister_id"], canister_id);
+    assert_eq!(json["environment"], "local");
+}
+
+#[tokio::test]
+async fn canister_id_set_rejects_duplicate_without_force() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let first_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+    let second_id = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+
+    // First set succeeds
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", first_id])
+        .assert()
+        .success();
+
+    // Second set without --force fails
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", second_id])
+        .assert()
+        .failure()
+        .stderr(contains("already has ID").and(contains("--force")));
+
+    // Original ID is preserved
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend"])
+        .assert()
+        .success()
+        .stdout(contains(first_id));
+}
+
+#[tokio::test]
+async fn canister_id_set_force_overwrites() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let first_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+    let second_id = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", first_id])
+        .assert()
+        .success();
+
+    // Overwrite with --force
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", second_id, "--force"])
+        .assert()
+        .success();
+
+    // New ID is returned
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend"])
+        .assert()
+        .success()
+        .stdout(contains(second_id));
+}
+
+#[tokio::test]
+async fn canister_id_set_with_environment() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let local_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+    let staging_id = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+
+    // Set different IDs for different environments
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", local_id])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister", "id", "set", "backend", staging_id, "-e", "staging",
+        ])
+        .assert()
+        .success();
+
+    // Verify each environment has its own ID
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend"])
+        .assert()
+        .success()
+        .stdout(contains(local_id));
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend", "-e", "staging"])
+        .assert()
+        .success()
+        .stdout(contains(staging_id));
+}
+
+#[tokio::test]
+async fn canister_id_show_not_set() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "backend"])
+        .assert()
+        .failure()
+        .stderr(contains("could not find ID"));
+}
+
+#[tokio::test]
+async fn canister_id_set_unknown_canister() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "id",
+            "set",
+            "nonexistent",
+            "rrkah-fqaaa-aaaaa-aaaaq-cai",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("not found in environment"));
+}

--- a/crates/icp-cli/tests/canister_id_tests.rs
+++ b/crates/icp-cli/tests/canister_id_tests.rs
@@ -204,6 +204,19 @@ async fn canister_id_show_not_set() {
 }
 
 #[tokio::test]
+async fn canister_id_show_unknown_canister() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(contains("not found in environment"));
+}
+
+#[tokio::test]
 async fn canister_id_set_unknown_canister() {
     let ctx = TestContext::new();
     let project_dir = setup_project(&ctx);

--- a/crates/icp-cli/tests/canister_id_tests.rs
+++ b/crates/icp-cli/tests/canister_id_tests.rs
@@ -12,6 +12,11 @@ canisters:
       steps:
         - type: pre-built
           path: backend.wasm
+  - name: frontend
+    build:
+      steps:
+        - type: pre-built
+          path: frontend.wasm
 
 networks:
   - name: local
@@ -215,4 +220,152 @@ async fn canister_id_set_unknown_canister() {
         .assert()
         .failure()
         .stderr(contains("not found in environment"));
+}
+
+#[tokio::test]
+async fn canister_id_show_all() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let backend_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+    let frontend_id = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", backend_id])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "frontend", frontend_id])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show"])
+        .assert()
+        .success()
+        .stdout(contains(backend_id).and(contains(frontend_id)));
+}
+
+#[tokio::test]
+async fn canister_id_show_all_json() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let backend_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+    let frontend_id = "ryjl3-tyaaa-aaaaa-aaaba-cai";
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", backend_id])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "frontend", frontend_id])
+        .assert()
+        .success();
+
+    let output = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(json["environment"], "local");
+
+    let canisters = json["canisters"]
+        .as_array()
+        .expect("canisters should be an array");
+    let backend = canisters
+        .iter()
+        .find(|c| c["canister"] == "backend")
+        .expect("backend entry missing");
+    assert_eq!(backend["canister_id"], backend_id);
+
+    let frontend = canisters
+        .iter()
+        .find(|c| c["canister"] == "frontend")
+        .expect("frontend entry missing");
+    assert_eq!(frontend["canister_id"], frontend_id);
+}
+
+#[tokio::test]
+async fn canister_id_show_all_partial() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let backend_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+
+    // Only set ID for backend, not frontend
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", backend_id])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show"])
+        .assert()
+        .success()
+        .stdout(
+            contains("backend")
+                .and(contains(backend_id))
+                .and(contains("frontend"))
+                .and(contains("(not set)")),
+        );
+}
+
+#[tokio::test]
+async fn canister_id_show_all_partial_json() {
+    let ctx = TestContext::new();
+    let project_dir = setup_project(&ctx);
+
+    let backend_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "set", "backend", backend_id])
+        .assert()
+        .success();
+
+    let output = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .args(["canister", "id", "show", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    let canisters = json["canisters"]
+        .as_array()
+        .expect("canisters should be an array");
+
+    let backend = canisters
+        .iter()
+        .find(|c| c["canister"] == "backend")
+        .expect("backend entry missing");
+    assert_eq!(backend["canister_id"], backend_id);
+
+    let frontend = canisters
+        .iter()
+        .find(|c| c["canister"] == "frontend")
+        .expect("frontend entry missing");
+    assert!(
+        frontend.get("canister_id").is_none(),
+        "frontend should have no canister_id"
+    );
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,9 @@ This document contains the help content for the `icp` command-line program.
 * [`icp canister call`↴](#icp-canister-call)
 * [`icp canister create`↴](#icp-canister-create)
 * [`icp canister delete`↴](#icp-canister-delete)
+* [`icp canister id`↴](#icp-canister-id)
+* [`icp canister id set`↴](#icp-canister-id-set)
+* [`icp canister id show`↴](#icp-canister-id-show)
 * [`icp canister install`↴](#icp-canister-install)
 * [`icp canister list`↴](#icp-canister-list)
 * [`icp canister logs`↴](#icp-canister-logs)
@@ -127,6 +130,7 @@ Perform canister operations against a network
 * `call` — Make a canister call
 * `create` — Create a canister on a network
 * `delete` — Delete a canister from a network
+* `id` — Commands to manage canister IDs
 * `install` — Install a built WASM to a canister on a network
 * `list` — List the canisters in an environment
 * `logs` — Fetch and display canister logs
@@ -267,6 +271,56 @@ Delete a canister from a network
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister call through
+
+
+
+## `icp canister id`
+
+Commands to manage canister IDs
+
+**Usage:** `icp canister id <COMMAND>`
+
+###### **Subcommands:**
+
+* `set` — Set the canister ID for a canister in an environment
+* `show` — Show the canister ID for a canister in an environment
+
+
+
+## `icp canister id set`
+
+Set the canister ID for a canister in an environment.
+
+Use this to register a pre-existing canister ID without creating a new canister on-chain. Fails if the canister already has an ID unless `--force` is given.
+
+**Usage:** `icp canister id set [OPTIONS] <CANISTER> <CANISTER_ID>`
+
+###### **Arguments:**
+
+* `<CANISTER>` — Name of the canister as defined in icp.yaml
+* `<CANISTER_ID>` — The canister principal to set
+
+###### **Options:**
+
+* `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
+* `-f`, `--force` — Overwrite the canister ID if one is already set
+
+
+
+## `icp canister id show`
+
+Show the canister ID for a canister in an environment
+
+**Usage:** `icp canister id show [OPTIONS] <CANISTER>`
+
+###### **Arguments:**
+
+* `<CANISTER>` — Name of the canister as defined in icp.yaml
+
+###### **Options:**
+
+* `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
+* `--json` — Output as JSON
 
 
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -283,7 +283,7 @@ Commands to manage canister IDs
 ###### **Subcommands:**
 
 * `set` — Set the canister ID for a canister in an environment
-* `show` — Show the canister ID for a canister in an environment
+* `show` — Show canister IDs in an environment
 
 
 
@@ -309,13 +309,15 @@ Use this to register a pre-existing canister ID without creating a new canister 
 
 ## `icp canister id show`
 
-Show the canister ID for a canister in an environment
+Show canister IDs in an environment.
 
-**Usage:** `icp canister id show [OPTIONS] <CANISTER>`
+When a canister name is given, prints its ID. Without a name, lists all canisters with their ID or "(not set)".
+
+**Usage:** `icp canister id show [OPTIONS] [CANISTER]`
 
 ###### **Arguments:**
 
-* `<CANISTER>` — Name of the canister as defined in icp.yaml
+* `<CANISTER>` — Name of the canister as defined in icp.yaml. If omitted, lists all canisters with their ID or "(not set)"
 
 ###### **Options:**
 


### PR DESCRIPTION
## Add `icp canister id` subcommands (`set` and `show`)

### Summary

- Adds `icp canister id set <canister> <principal>` to register a pre-existing canister ID for a canister in an environment, without creating one on-chain. Use `--force` / `-f` to overwrite an existing ID.
- Adds `icp canister id show [canister]` to display canister IDs. When a canister name is given, prints its ID. When omitted, lists all canisters in the environment with their ID or `(not set)`. Supports `--json`.
- Both commands accept `-e <environment>` to target a specific environment (defaults to `local`).

### Motivation

Previously, canister IDs were only set automatically by `icp canister create` and `icp deploy`, which both cost cycles. Users who bring their own pre-existing canister IDs had no way to configure them without manually editing internal `.icp/` files. These commands close that gap.

### Test plan

- [x] `canister_id_set_and_show` — set then show round-trip
- [x] `canister_id_show_json` — single canister JSON output
- [x] `canister_id_set_rejects_duplicate_without_force` — fails without `--force`, preserves original ID
- [x] `canister_id_set_force_overwrites` — `--force` replaces existing ID
- [x] `canister_id_set_with_environment` — different IDs per environment via `-e`
- [x] `canister_id_show_not_set` — error when querying a canister with no ID
- [x] `canister_id_set_unknown_canister` — error for canister not in icp.yaml
- [x] `canister_id_show_all` — lists all canisters when no name given
- [x] `canister_id_show_all_json` — JSON output for all canisters
- [x] `canister_id_show_all_partial` — shows set IDs and `(not set)` together
- [x] `canister_id_show_all_partial_json` — JSON: `canister_id` omitted for unset canisters
