### PR TITLE
chore: docs use 404 asset canister

### DIFF
--- a/icp.yaml
+++ b/icp.yaml
@@ -5,5 +5,5 @@ canisters:
     recipe:
       type: "@dfinity/asset-canister@v2.1.0"
       configuration:
-        version: 0.29.2
+        version: asset-canister-404-support
         dir: .


### PR DESCRIPTION
Switch to an asset canister that supports 404.html