### PR TITLE
ci: auto-delete docs/vX.Y branch after each release

### DIFF
--- a/.claude/docs-guidelines.md
+++ b/.claude/docs-guidelines.md
@@ -30,6 +30,27 @@ Documentation follows the Diátaxis framework:
 - When referencing alternatives in other docs, maintain this order: "Homebrew, shell script, ..." (e.g., "See the Installation Guide for Homebrew, shell script, or other options")
 - Both `icp-cli` and `ic-wasm` are available as official Homebrew formulas: `brew install icp-cli` and `brew install ic-wasm`
 
+## Docs-Only Fixes for Released Versions
+
+To fix or improve docs for an already-released version without cutting a new code release:
+
+**Rule: always merge the change to `main` first.** The `docs/vX.Y` branch is only for immediate deployment — it is automatically deleted when the next patch release is tagged. Any commit that exists only on the branch (not in `main`) will be lost at that point.
+
+**Workflow:**
+
+```bash
+# 1. Merge the fix to main via a normal PR (always required)
+
+# 2. To immediately deploy the fix to /X.Y/ without waiting for a release:
+git fetch origin
+git checkout -b docs/vX.Y vX.Y.Z    # fresh branch from the latest release tag
+git cherry-pick <commit-sha-from-main>
+
+git push origin docs/vX.Y           # triggers re-deploy of /X.Y/
+```
+
+On the next release, `delete-docs-branch.yml` deletes `docs/vX.Y` automatically. Because the fix was already merged to `main`, the release will contain it.
+
 ## Writing Guidelines
 
 - Use "canister environment variables" (not just "environment variables") when referring to runtime variables stored in canister settings — this distinguishes them from shell/build environment variables

--- a/.claude/skills/release/rollback.md
+++ b/.claude/skills/release/rollback.md
@@ -9,6 +9,7 @@ If something fails mid-release, here's how to clean up depending on how far you 
   git tag -d v$ARGUMENTS
   ```
   If a GitHub Release was already created, delete it first via `gh release delete v$ARGUMENTS --yes`, then delete the tag.
+  Note: `delete-docs-branch.yml` may have already deleted the `docs/vX.Y` branch as part of this release. The live docs at `/X.Y/` are deployed independently and are unaffected. If a docs-only fix branch needs to be restored, create a fresh one from the previous release tag.
 - **Task 3 failed (Release workflow)**: Investigate the failure. The tag still exists. Once fixed, you can re-run the workflow from the GitHub Actions UI. Do **not** delete and re-push the tag — that creates duplicate runs.
 - **Task 4 failed (NPM publish)**: NPM publishes are not easily reversible. If the publish partially succeeded, check `npm info @icp-sdk/icp-cli versions` and coordinate with the team. The workflow can be re-triggered from the GitHub Actions UI.
 - **Task 5 failed (homebrew-tap)**: If the workflow failed, it can be re-triggered. If the PR was created but has issues, close it and delete the branch `update/icp-cli-beta-$ARGUMENTS` on `dfinity/homebrew-tap` via the GitHub UI. No packages were published.

--- a/.claude/skills/release/task6-docs.md
+++ b/.claude/skills/release/task6-docs.md
@@ -2,7 +2,11 @@
 
 *Skip if `$ARGUMENTS` is a beta release. Requires Task 2. Runs concurrently with Task 3.*
 
-The tag push triggers a docs deployment workflow that builds and publishes the versioned docs to `/X.Y/` on the `docs-deployment` branch (served at `https://cli.internetcomputer.org/X.Y/`). The `versions.json` PR must not be merged until that deployment succeeds, otherwise the root redirect will point to a path that does not exist yet.
+The tag push triggers two automated workflows:
+
+1. **`docs.yml` (`publish-versioned-docs` job):** Builds and publishes the versioned docs to `/X.Y/` on the `docs-deployment` branch (served at `https://cli.internetcomputer.org/X.Y/`). The `versions.json` PR must not be merged until that deployment succeeds, otherwise the root redirect will point to a path that does not exist yet.
+
+2. **`delete-docs-branch.yml`:** Deletes the `docs/vX.Y` branch if one exists. This prevents a stale branch from re-deploying outdated content if someone later pushes to it accidentally.
 
 Once the `versions.json` PR merges to `main`, the `publish-root-files` CI job runs automatically and copies `og-image.png`, `llms.txt`, `llms-full.txt`, and `feed.xml` from the new version's folder to the deployment root — no manual step needed.
 

--- a/.github/workflows/delete-docs-branch.yml
+++ b/.github/workflows/delete-docs-branch.yml
@@ -1,0 +1,45 @@
+name: Delete docs branch after release
+
+# When a release tag is pushed, delete the docs/vX.Y branch (if it exists).
+# This prevents stale branches from re-deploying outdated docs if someone
+# accidentally pushes to them. The branch is short-lived by design: it is
+# created only when a docs-only fix needs immediate deployment between releases,
+# and cleaned up automatically here on the next release.
+#
+# If a docs-only fix is needed after this runs, create a fresh docs/vX.Y branch
+# from the new release tag — see .claude/docs-guidelines.md.
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!v*-*'    # exclude pre-release tags (e.g. v0.2.0-beta.0)
+
+permissions:
+  contents: write
+
+jobs:
+  delete-docs-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version info
+        run: |
+          TAG=${GITHUB_REF_NAME}          # e.g. v0.2.3
+          PATCH=${TAG#v}                  # e.g. 0.2.3
+          MINOR=${PATCH%.*}              # e.g. 0.2
+          echo "DOCS_BRANCH=docs/v${MINOR}" >> $GITHUB_ENV
+
+      - name: Delete docs branch if it exists
+        run: |
+          git fetch origin
+          if git ls-remote --exit-code --heads origin "refs/heads/${DOCS_BRANCH}" > /dev/null 2>&1; then
+            git push origin --delete "${DOCS_BRANCH}"
+            echo "Deleted ${DOCS_BRANCH}"
+          else
+            echo "${DOCS_BRANCH} does not exist, nothing to delete"
+          fi

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -119,8 +119,16 @@ The site is hosted on an IC asset canister and served at `https://cli.internetco
 ### Triggers
 
 - **Push to `main`**: Rebuilds `/main/` docs and root files (`index.html`, `versions.json`, `robots.txt`, `sitemap.xml`, IC config). Also copies `og-image.png`, `llms.txt`, `llms-full.txt`, and `feed.xml` from the latest versioned deployment to the root.
-- **Tags (`v*`)**: Builds versioned docs (e.g., `v0.2.0` → `/0.2/`)
-- **Branches (`docs/v*`)**: Updates versioned docs (e.g., `docs/v0.1` → `/0.1/`)
+- **Release tags (`v*`)**: Builds and deploys versioned docs (e.g., `v0.2.0` → `/0.2/`). Also triggers `delete-docs-branch.yml` which automatically deletes the `docs/v0.2` branch if one exists — preventing stale branches from re-deploying outdated content on accidental pushes.
+- **Docs-override branches (`docs/v*`)**: Redeploys versioned docs for a specific minor version without cutting a new code release (e.g., `docs/v0.2` → `/0.2/`). These branches are short-lived by design — created only for an immediate docs fix, then deleted automatically on the next release.
+
+  To trigger a re-deploy, create a fresh branch from the latest release tag and push your fix:
+  ```bash
+  git fetch origin
+  git checkout -b docs/v0.2 v0.2.3   # start from the release tag, not stale state
+  git cherry-pick <commit-sha>        # commit must already be merged to main
+  git push origin docs/v0.2
+  ```
 
 ### Root-level files
 


### PR DESCRIPTION
## What and why

The \`docs/v*\` branches trigger \`publish-versioned-docs\` in \`docs.yml\` and redeploy versioned docs. The problem: if a branch is left around after a release, an accidental push to it redeploys \`/X.Y/\` with stale content and no warning.

This PR adds a small workflow that deletes \`docs/vX.Y\` automatically on every non-beta release tag push, so the branch can never go stale.

## How it works

On each \`v*\` tag push (excluding pre-releases), \`delete-docs-branch.yml\`:
1. Fetches the latest remote state
2. Checks whether \`docs/vX.Y\` exists on the remote
3. Deletes it if found; no-ops if not

The branch is short-lived by design — it only exists while a docs-only fix is waiting for deployment between releases.

## Docs-only fix workflow (unchanged mechanism, now documented)

To deploy a docs fix to \`/X.Y/\` without a new code release:

```bash
# 1. Merge the fix to main first (always required)

# 2. Create a fresh branch from the latest release tag and push:
git fetch origin
git checkout -b docs/v0.2 v0.2.3
git cherry-pick <merged-commit-sha>
git push origin docs/v0.2           # triggers redeploy of /0.2/
```

On next release, the branch is deleted automatically.

## Files changed

| File | Change |
|---|---|
| \`.github/workflows/delete-docs-branch.yml\` | **New.** Deletes \`docs/vX.Y\` branch on each non-beta release tag |
| \`docs-site/README.md\` | Triggers section expanded with auto-delete behaviour and docs-only fix workflow |
| \`.claude/docs-guidelines.md\` | New section: "Docs-Only Fixes for Released Versions" |
| \`.claude/skills/release/task6-docs.md\` | Documents both workflows triggered by a release tag |
| \`.claude/skills/release/rollback.md\` | Task 2 rollback: note about branch state after auto-delete |