### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5878,9 +5878,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Bump `rustls-webpki` from 0.103.12 to 0.103.13 to resolve RUSTSEC-2026-0104 (reachable panic in certificate revocation list parsing)
- Lockfile-only change — no direct dependency versions changed

The remaining 3 warnings (RUSTSEC-2022-0034 for `pkcs11`, RUSTSEC-2026-0097 for `rand`) are pre-existing unsound warnings for transitive deps we can't control; they are already tracked as GitHub issues and do not fail the build.

## Test plan

- [x] `cargo audit` passes with no errors (3 pre-existing allowed warnings remain)