### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.2.4
+
 * feat: `icp identity delegation request/sign/use` now permit creating and importing identity delegations
 * feat: `icp identity import` now takes `--seed-curve`, for seed phrases for non-k256 keys.
 * fix: `icp canister settings show` now outputs only the canister settings, consistent with the command name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.3"
+version = "0.2.4"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.2.4`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.2.4`

### Review checklist
- [ ] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct
