### PR TITLE
fix: flush buffered stdout once at end of exec to show canister call output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* fix: `icp canister call --json` no longer produces blank output.
+
 # v0.2.4
 
 * feat: `icp identity delegation request/sign/use` now permit creating and importing identity delegations

--- a/crates/icp-cli/src/commands/canister/call.rs
+++ b/crates/icp-cli/src/commands/canister/call.rs
@@ -236,7 +236,7 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
     };
 
     // catch errors, because the json result should be printed regardless of errors
-    let res = (|| {
+    let res: Result<(), anyhow::Error> = (|| {
         match args.output {
             CallOutputMode::Auto => {
                 if let Ok(ret) = try_decode_candid(&res, declared_method.as_ref()) {
@@ -251,11 +251,9 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
                         json_response.response_text = Some(s.to_string());
                     } else {
                         writeln!(term, "{s}")?;
-                        term.flush()?;
                     }
                 } else if !args.json {
                     writeln!(term, "{}", hex::encode(&res))?;
-                    term.flush()?;
                 }
             }
             CallOutputMode::Candid => {
@@ -276,18 +274,16 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
                     json_response.response_text = Some(s.to_string());
                 } else {
                     writeln!(term, "{s}")?;
-                    term.flush()?;
                 }
             }
             CallOutputMode::Hex => {
                 writeln!(term, "{}", hex::encode(&res))?;
-                term.flush()?;
             }
         };
         anyhow::Ok(())
     })();
     if args.json {
-        let write_result = serde_json::to_writer(term, &json_response);
+        let write_result = serde_json::to_writer(&term, &json_response);
         if let Err(write_err) = write_result {
             if let Err(decode_err) = res {
                 error!("failed to write JSON response: {write_err}");
@@ -298,6 +294,8 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
         }
     }
     res?;
+    // term is buffered; this single flush covers all output paths (json and non-json).
+    term.flush()?;
 
     Ok(())
 }
@@ -337,7 +335,6 @@ pub(crate) fn print_candid_for_term(term: &mut Term, args: &IDLArgs) -> io::Resu
     } else {
         writeln!(term, "{args}")?;
     }
-    term.flush()?;
     Ok(())
 }
 

--- a/crates/icp-cli/tests/canister_call_tests.rs
+++ b/crates/icp-cli/tests/canister_call_tests.rs
@@ -424,6 +424,72 @@ async fn canister_call_output_modes() {
 }
 
 #[tokio::test]
+async fn canister_call_json_output() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+    let wasm = ctx.make_asset("example_icp_mo.wasm");
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm}' "$ICP_WASM_OUTPUT_PATH"
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("write manifest");
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "deploy",
+            "my-canister",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+
+    let out = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "--json",
+            "my-canister",
+            "greet",
+            "(\"world\")",
+        ])
+        .output()
+        .expect("run call");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Regression: stdout was blank because the buffered term was never flushed.
+    assert!(
+        !out.stdout.is_empty(),
+        "stdout must not be blank with --json"
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout must be valid JSON");
+    // Candid encoding of ("Hello, world!") — didc encode '("Hello, world!")'
+    assert_eq!(
+        json["response_bytes"],
+        "4449444c0001710d48656c6c6f2c20776f726c6421"
+    );
+    assert_eq!(json["response_candid"], "(\"Hello, world!\")");
+    assert!(json["response_text"].is_null());
+}
+
+#[tokio::test]
 async fn canister_call_query_conflicts_with_proxy() {
     let ctx = TestContext::new();
 


### PR DESCRIPTION
## Summary

- `icp canister call --json` was producing blank output because `Term::buffered_stdout()` was never flushed — `serde_json::to_writer` takes a reference and the buffer held the bytes unsent.
- Consolidated the scattered `term.flush()` calls (one per output branch) into a single flush at the end of `exec`, after all writes and after propagating any closure error.

## Test plan

- [x] New integration test `canister_call_json_output` deploys a canister, calls `greet` with `--json`, and asserts stdout is non-empty valid JSON with the expected `response_bytes` and `response_candid` fields — directly covering the regression.
- [x] Existing `canister_call_output_modes` and other call tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)