### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.2.5
+
 * feat: `icp new --init` no longer requires specifying a project name. If non is provided, the containing folder's name is used as the project name
 * fix: `icp canister call --json` no longer produces blank output.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.4"
+version = "0.2.5"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.2.5`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.2.5`

### Review checklist
- [ ] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct
