### PR TITLE
feat(icp-cli): allow GIT_SHA to be overridden

### DIFF
--- a/crates/icp-cli/build.rs
+++ b/crates/icp-cli/build.rs
@@ -20,6 +20,8 @@ fn main() {
     println!("cargo:rerun-if-changed=artifacts/mod.rs");
     println!("cargo:rerun-if-changed=artifacts/source.json");
 
-    define_git_sha();
+    if option_env!("GIT_SHA").is_none() {
+        define_git_sha();
+    }
     artifacts::bundle_artifacts();
 }


### PR DESCRIPTION
Do not call define_git_sha if GIT_SHA already exists in environment.

This can be used to avoid invoking git at compile time, which is handy when the source is not a git repo.