### PR TITLE
fix: serialize candid assist value using type info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* fix: `icp canister call` now serializes arguments built via the interactive Candid assist prompt against the method's declared signature, matching the behavior of arguments passed on the command line. Previously, narrower values (e.g. a variant case from a multi-case variant) were encoded with a type table inferred only from the value, which the target canister rejected with errors like "Variant index N larger than length 1".
+
 # v0.2.5
 
 * feat: `icp new --init` no longer requires specifying a project name. If non is provided, the containing folder's name is used as the project name

--- a/crates/icp-cli/src/commands/canister/call.rs
+++ b/crates/icp-cli/src/commands/canister/call.rs
@@ -190,8 +190,8 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
                 return Ok(());
             }
             arguments
-                .to_bytes()
-                .context("failed to serialize candid arguments")?
+                .to_bytes_with_types(type_env, &func.args)
+                .context("failed to serialize candid arguments with specific types")?
         }
         (Some(_), Some(ResolvedArgs::Bytes(bytes))) => bytes,
         (Some((type_env, func)), Some(ResolvedArgs::Candid(arguments))) => arguments


### PR DESCRIPTION
`icp` currently serializes arguments produced using Candid assist without using all type info that is available.

Steps to reproduce:
```
icp new hello
cd hello
icp canister call frontend list_permitted '(record { permission = variant { Commit } })' # succeeds
icp canister call frontend list_permitted # then choose e.g. Commit in Candid assist
# expected error: Error: direct update call failed: The replica returned a rejection error: reject code CanisterError, reject message Error from Canister t63gs-up777-77776-aaaba-cai: Canister called `ic0.trap` with message: 'Panicked at 'called `Result::unwrap()` on an `Err` value: Custom(Fail to decode argument 0 from table0 to record { permission : variant { Prepare; ManagePermissions; Commit } }
```