### PR TITLE
fix: skip Matomo tracking on localhost

### DIFF
--- a/docs-site/matomo.js
+++ b/docs-site/matomo.js
@@ -1,4 +1,4 @@
-if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") {
+if (!location.hostname.endsWith("localhost") && location.hostname !== "127.0.0.1") {
   var _paq = (window._paq = window._paq || []);
   _paq.push(["disableCookies"]);
   _paq.push(["enableLinkTracking"]);

--- a/docs-site/matomo.js
+++ b/docs-site/matomo.js
@@ -1,15 +1,17 @@
-var _paq = (window._paq = window._paq || []);
-_paq.push(["disableCookies"]);
-_paq.push(["enableLinkTracking"]);
-_paq.push(["trackPageView"]);
-(function () {
-  var u = "https://internetcomputer.matomo.cloud/";
-  _paq.push(["setTrackerUrl", u + "matomo.php"]);
-  _paq.push(["setSiteId", "21"]);
-  var d = document,
-    g = d.createElement("script"),
-    s = d.getElementsByTagName("script")[0];
-  g.async = true;
-  g.src = "https://cdn.matomo.cloud/internetcomputer.matomo.cloud/matomo.js";
-  s.parentNode.insertBefore(g, s);
-})();
+if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") {
+  var _paq = (window._paq = window._paq || []);
+  _paq.push(["disableCookies"]);
+  _paq.push(["enableLinkTracking"]);
+  _paq.push(["trackPageView"]);
+  (function () {
+    var u = "https://internetcomputer.matomo.cloud/";
+    _paq.push(["setTrackerUrl", u + "matomo.php"]);
+    _paq.push(["setSiteId", "21"]);
+    var d = document,
+      g = d.createElement("script"),
+      s = d.getElementsByTagName("script")[0];
+    g.async = true;
+    g.src = "https://cdn.matomo.cloud/internetcomputer.matomo.cloud/matomo.js";
+    s.parentNode.insertBefore(g, s);
+  })();
+}


### PR DESCRIPTION
## Summary

- Wraps the Matomo script in a `location.hostname` guard so tracking is skipped on `localhost` and `127.0.0.1`
- Because `matomo.js` is deployed once at the site root and referenced by all versioned builds, this fix covers all versions globally