### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.2.6
+
 * feat: `icp token/cycles balance` now accept `--of-principal`
 * fix: The local wasm cache has moved from `.icp/cache/canisters/` to `.icp/cache/wasms/`. Existing cached files will be re-downloaded automatically on the next run.
 * feat: Canister manifests now support a `plugin` sync step type. Plugins are WebAssembly components that run in a sandboxed environment and can drive arbitrary post-deployment logic against the canister being synced. See `crates/icp-sync-plugin/DESIGN.md` for details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "camino",
  "candid",
@@ -6583,7 +6583,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.5"
+version = "0.2.6"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.2.6`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.2.6`

### Review checklist
- [x] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct
