### PR TITLE
fix(sync-plugin): skip wasm32-wasip2 fixture build when target is not installed

### DIFF
--- a/crates/icp-sync-plugin/build.rs
+++ b/crates/icp-sync-plugin/build.rs
@@ -6,7 +6,9 @@ fn main() {
     println!("cargo:rerun-if-changed=tests/fixtures/test-plugin/src/lib.rs");
     println!("cargo:rerun-if-changed=tests/fixtures/test-plugin/Cargo.toml");
 
-    build_test_fixture();
+    if std::env::var("CARGO_CFG_TEST").is_ok() {
+        build_test_fixture();
+    }
 }
 
 fn build_test_fixture() {

--- a/crates/icp-sync-plugin/build.rs
+++ b/crates/icp-sync-plugin/build.rs
@@ -19,7 +19,7 @@ fn wasm32_wasip2_is_installed() -> bool {
         return false;
     }
     let sysroot = String::from_utf8_lossy(&output.stdout);
-    std::path::Path::new(sysroot.trim())
+    Utf8PathBuf::from(sysroot.trim())
         .join("lib/rustlib/wasm32-wasip2")
         .exists()
 }

--- a/crates/icp-sync-plugin/build.rs
+++ b/crates/icp-sync-plugin/build.rs
@@ -6,9 +6,22 @@ fn main() {
     println!("cargo:rerun-if-changed=tests/fixtures/test-plugin/src/lib.rs");
     println!("cargo:rerun-if-changed=tests/fixtures/test-plugin/Cargo.toml");
 
-    if std::env::var("CARGO_CFG_TEST").is_ok() {
+    if wasm32_wasip2_is_installed() {
         build_test_fixture();
     }
+}
+
+fn wasm32_wasip2_is_installed() -> bool {
+    let Ok(output) = Command::new("rustc").args(["--print", "sysroot"]).output() else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let sysroot = String::from_utf8_lossy(&output.stdout);
+    std::path::Path::new(sysroot.trim())
+        .join("lib/rustlib/wasm32-wasip2")
+        .exists()
 }
 
 fn build_test_fixture() {

--- a/crates/icp-sync-plugin/src/runtime.rs
+++ b/crates/icp-sync-plugin/src/runtime.rs
@@ -363,7 +363,9 @@ mod tests {
 
     #[test]
     fn preopen_dir_error_on_missing_dir() {
-        let wasm_path = env!("TEST_PLUGIN_WASM");
+        let Some(wasm_path) = option_env!("TEST_PLUGIN_WASM") else {
+            return;
+        };
         let result = run_plugin(
             wasm_path.into(),
             ".".into(),
@@ -381,7 +383,9 @@ mod tests {
 
     #[test]
     fn plugin_success_returns_ok() {
-        let wasm_path = env!("TEST_PLUGIN_WASM");
+        let Some(wasm_path) = option_env!("TEST_PLUGIN_WASM") else {
+            return;
+        };
         let result = run_plugin(
             wasm_path.into(),
             ".".into(),
@@ -399,7 +403,9 @@ mod tests {
 
     #[test]
     fn plugin_failure_maps_to_run_plugin_error() {
-        let wasm_path = env!("TEST_PLUGIN_WASM");
+        let Some(wasm_path) = option_env!("TEST_PLUGIN_WASM") else {
+            return;
+        };
         let result = run_plugin(
             wasm_path.into(),
             ".".into(),
@@ -420,7 +426,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn plugin_stdout_forwarded_through_stdio_channel() {
-        let wasm_path = env!("TEST_PLUGIN_WASM");
+        let Some(wasm_path) = option_env!("TEST_PLUGIN_WASM") else {
+            return;
+        };
         let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(16);
         let result = tokio::task::block_in_place(|| {
             run_plugin(


### PR DESCRIPTION
## Summary

- In `build.rs`, gates `build_test_fixture()` behind a check that the `wasm32-wasip2` target is actually installed (via `rustc --print sysroot`). `CARGO_CFG_TEST` was not viable — Cargo does not set it for build scripts.
- In `runtime.rs`, switches `env!("TEST_PLUGIN_WASM")` → `option_env!` with an early return, so fixture-dependent tests compile and skip gracefully when the fixture was not built.

Fixes #543

## Behavior

| Environment | `cargo build` | `cargo test` |
|---|---|---|
| Without `wasm32-wasip2` (e.g. Homebrew) | ✅ succeeds | ✅ compiles; fixture tests skip |
| With `wasm32-wasip2` (dev / CI) | ✅ succeeds | ✅ all 5 tests run and pass |

## Test plan

- [x] `cargo build -p icp-sync-plugin` succeeds without `wasm32-wasip2` target installed
- [x] `cargo test -p icp-sync-plugin --lib` passes (fixture tests skip when target absent, run when present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)