### PR TITLE
icp-sync-plugin/build.rs: warn instead of panic when wasm32-wasip2 is missing

### DIFF
--- a/crates/icp-sync-plugin/build.rs
+++ b/crates/icp-sync-plugin/build.rs
@@ -28,12 +28,29 @@ fn build_test_fixture() {
             "--target-dir",
             fixture_target_dir.as_str(),
         ])
-        .status()
-        .expect("failed to spawn cargo build for test fixture");
-    assert!(
-        status.success(),
-        "cargo build --target wasm32-wasip2 failed for test fixture"
-    );
+        .status();
+
+    // Building the wasm test fixture requires the `wasm32-wasip2` target to be
+    // installed. Distribution toolchains (Homebrew, distro packagers — see
+    // dfinity/icp-cli#543) do not always include it, and the fixture is only
+    // referenced by `#[test]` functions in `runtime.rs`. Emit a warning and
+    // leave `TEST_PLUGIN_WASM` empty rather than panicking the whole build;
+    // any test that actually depends on the fixture will surface a clearer
+    // "fixture not built" error when the empty path is used.
+    let succeeded = matches!(&status, Ok(s) if s.success());
+    if !succeeded {
+        match status {
+            Err(e) => println!(
+                "cargo:warning=icp-sync-plugin: failed to spawn `cargo build --target wasm32-wasip2` for the test fixture: {e}; tests requiring TEST_PLUGIN_WASM will fail."
+            ),
+            Ok(_) => println!(
+                "cargo:warning=icp-sync-plugin: `cargo build --target wasm32-wasip2` failed for the test fixture (target probably not installed); tests requiring TEST_PLUGIN_WASM will fail."
+            ),
+        }
+        println!("cargo:rustc-env=TEST_PLUGIN_WASM=");
+        return;
+    }
+
     let wasm = fixture_target_dir.join("wasm32-wasip2/release/test_plugin.wasm");
     println!("cargo:rustc-env=TEST_PLUGIN_WASM={wasm}");
 }


### PR DESCRIPTION
Fixes #543.

`crates/icp-sync-plugin/build.rs` unconditionally ran `cargo build --target wasm32-wasip2` for the test fixture and panicked the entire build when the target wasn't installed. Distribution toolchains (Homebrew, distro packagers) often don't ship `wasm32-wasip2`, so `cargo install icp-cli` failed for downstream packagers.

The fixture is only consumed by `#[test]` functions in `runtime.rs`. `CARGO_CFG_TEST` isn't set during build-script execution, so suggested gating doesn't actually distinguish test from non-test invocations. Instead: keep building when the target is available, but on failure emit a `cargo:warning` and set `TEST_PLUGIN_WASM=` (empty). Tests that need the fixture will surface a clearer error at test time; `cargo install` and `cargo build` succeed cleanly on toolchains without `wasm32-wasip2` (e.g. the Homebrew Rust at https://github.com/Homebrew/homebrew-core/pull/280458).