### PR TITLE
fix: validate $PWD against getcwd() inode before trusting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* fix: `icp` no longer picks up a stale inherited `$PWD` when launched as a subprocess via `chdir(2)` + `execve` (e.g. from a test harness). The logical `$PWD` path is now validated against `getcwd()` by inode before use, preserving symlink-aware project root discovery while ignoring stale values.
+
 # v0.2.6
 
 * feat: `icp token/cycles balance` now accept `--of-principal`

--- a/crates/icp/src/context/init.rs
+++ b/crates/icp/src/context/init.rs
@@ -48,8 +48,9 @@ pub fn initialize(
     //
     // Guard with an inode check: if $PWD was inherited from a parent process
     // that used chdir(2) without updating $PWD, the two paths point to
-    // different inodes and we fall back to getcwd(). A symlink and its target
-    // share the same inode, so the symlink case still works.
+    // different inodes and we fall back to getcwd(). Because `metadata()`
+    // follows symlinks, a symlinked $PWD still resolves to the same inode as
+    // getcwd(), so the symlink case still works.
     #[cfg(unix)]
     let cwd: PathBuf = {
         let real = PathBuf::try_from(current_dir().context(CwdSnafu)?).context(Utf8PathSnafu)?;
@@ -160,19 +161,24 @@ fn same_inode(a: &Path, b: &Path) -> bool {
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
+    use std::sync::Mutex;
+
     use camino_tempfile::Utf8TempDir;
 
     use super::*;
 
+    // Serializes tests that mutate $PWD, since cargo test runs tests in parallel.
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
     #[test]
     fn stale_pwd_is_ignored() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+
         let stale = Utf8TempDir::new().unwrap();
         let real = PathBuf::try_from(std::env::current_dir().unwrap()).unwrap();
 
         let old_pwd = std::env::var("PWD").ok();
-        // SAFETY: this test is the only writer; cargo test runs each test
-        // binary single-threaded unless --test-threads>1, and no other test
-        // in this module touches $PWD.
+        // SAFETY: ENV_MUTEX serializes all tests that mutate $PWD.
         unsafe { std::env::set_var("PWD", stale.path()) };
 
         let resolved = match std::env::var("PWD")

--- a/crates/icp/src/context/init.rs
+++ b/crates/icp/src/context/init.rs
@@ -45,14 +45,23 @@ pub fn initialize(
     // through) over getcwd(3), which resolves symlinks to the physical path
     // and would break upward traversal when the user is inside a symlinked
     // directory whose manifest sits above the symlink's location.
+    //
+    // Guard with an inode check: if $PWD was inherited from a parent process
+    // that used chdir(2) without updating $PWD, the two paths point to
+    // different inodes and we fall back to getcwd(). A symlink and its target
+    // share the same inode, so the symlink case still works.
     #[cfg(unix)]
-    let cwd: PathBuf = match std::env::var("PWD")
-        .ok()
-        .map(PathBuf::from)
-        .filter(|p| p.is_absolute())
-    {
-        Some(p) => p,
-        None => PathBuf::try_from(current_dir().context(CwdSnafu)?).context(Utf8PathSnafu)?,
+    let cwd: PathBuf = {
+        let real = PathBuf::try_from(current_dir().context(CwdSnafu)?).context(Utf8PathSnafu)?;
+        match std::env::var("PWD")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+            .filter(|p| same_inode(p.as_path(), real.as_path()))
+        {
+            Some(logical) => logical,
+            None => real,
+        }
     };
 
     #[cfg(not(unix))]
@@ -137,4 +146,53 @@ pub fn initialize(
         debug,
         telemetry_data,
     })
+}
+
+#[cfg(unix)]
+fn same_inode(a: &Path, b: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match (std::fs::metadata(a), std::fs::metadata(b)) {
+        (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use camino_tempfile::Utf8TempDir;
+
+    use super::*;
+
+    #[test]
+    fn stale_pwd_is_ignored() {
+        let stale = Utf8TempDir::new().unwrap();
+        let real = PathBuf::try_from(std::env::current_dir().unwrap()).unwrap();
+
+        let old_pwd = std::env::var("PWD").ok();
+        // SAFETY: this test is the only writer; cargo test runs each test
+        // binary single-threaded unless --test-threads>1, and no other test
+        // in this module touches $PWD.
+        unsafe { std::env::set_var("PWD", stale.path()) };
+
+        let resolved = match std::env::var("PWD")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+            .filter(|p| same_inode(p.as_path(), real.as_path()))
+        {
+            Some(logical) => logical,
+            None => real.clone(),
+        };
+
+        match old_pwd {
+            Some(v) => unsafe { std::env::set_var("PWD", v) },
+            None => unsafe { std::env::remove_var("PWD") },
+        }
+
+        assert_eq!(
+            resolved, real,
+            "stale $PWD should be ignored in favour of getcwd()"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where `icp` picks up a stale inherited `$PWD` when spawned as a subprocess via `chdir(2)` + `execve` (e.g. from a test harness), causing it to search for `icp.yaml` from the wrong directory.
- Adds a `same_inode` guard: `$PWD` is only used when its `(dev, ino)` matches that of `getcwd()`. A symlink and its target share the same inode, so the existing symlink-aware traversal (introduced in #524) is preserved.
- Adds a `stale_pwd_is_ignored` test that sets `$PWD` to a different temp directory and asserts `getcwd()` wins.

## Test plan

- [x] `cargo test -p icp -- context::init::tests::stale_pwd_is_ignored` passes
- [x] `cargo test -p icp -- manifest::tests::locate_walks_up_through_symlink` still passes
- [x] `cargo clippy -p icp` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)