### PR TITLE
ci: disable cache-bin in setup-rust-toolchain

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
+          cache-bin: false
 
       - name: build
         run: cargo build
@@ -64,6 +65,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
+          cache-bin: false
 
       - name: Run Lint
         run: cargo clippy --verbose --tests --benches -- -D warnings
@@ -85,6 +87,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
+          cache-bin: false
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -132,6 +135,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
+          cache-bin: false
 
       - name: generate docs
         run: ./scripts/generate-cli-docs.sh
@@ -167,6 +171,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
+          cache-bin: false
 
       - name: generate schemas
         run: ./scripts/generate-config-schemas.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-test
+          cache-bin: false
 
       - uses: t1m0thyj/unlock-keyring@e481cdc8833d4417a58f40734e8f197183317047
         if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -101,6 +102,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-test
+          cache-bin: false
 
       - name: Setup image (Linux)
         if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-validate
+          cache-bin: false
 
       - name: Build icp CLI
         run: cargo build


### PR DESCRIPTION
## Summary

- Add `cache-bin: false` to every `actions-rust-lang/setup-rust-toolchain` invocation across `checks.yml`, `test.yml`, and `validate-examples.yml` (8 sites).
- Stops `~/.cargo/bin/` from round-tripping through the GitHub Actions cache, which was poisoning macOS runs.

## Background

A Homebrew rustup formula change on 2026-05-06 ([cfffe64f](https://github.com/Homebrew/homebrew-core/commit/cfffe64f)) replaced the multiplexed `rustup-init` binary with an `env_script_all_files` wrapper. The wrapper exec's the real binary by filename, dropping `argv[0]`, which breaks rustup's name-based proxy dispatch — `cargo test` becomes `rustup-init test` and fails with `error: unexpected argument 'test' found`. The new macOS runner image `20260511.0048` baked that bottle in, surfacing on jobs that draw the new image.

`setup-rust-toolchain` caches `~/.cargo/bin/`, so once a single run on the broken image saved its `~/.cargo/bin/` into a cache key, every later run hitting that key restored the broken proxy on top of its freshly-installed one. Manually evicting the cache unblocks a job; this change prevents re-poisoning.

This repo doesn't run `cargo install` anywhere (`wasm-tools` is installed via `taiki-e/install-action`, which downloads prebuilt binaries), so the cache had no upside to weigh against this risk.

Related: actions/runner-images [#14099](https://github.com/actions/runner-images/issues/14099), [#14097](https://github.com/actions/runner-images/issues/14097); [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341).

## Test plan

- [x] CI green on this PR across macOS/ubuntu/windows jobs (poisoned macOS caches were already evicted before this PR was opened, so a fresh `~/.cargo/bin/` is built and not cached)
- [x] Subsequent re-runs on the same key continue to pass — confirms the cache no longer re-poisons

🤖 Generated with [Claude Code](https://claude.com/claude-code)