### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+# v0.2.7
+
 * feat: `script` sync steps now receive `ICP_CLI_ENVIRONMENT`, `ICP_CLI_NETWORK`, `ICP_CLI_CID` (the current canister's principal), and `ICP_CLI_CID_<NAME>` (every canister's principal) as environment variables.
 * fix: `icp canister call` with both `--json` and `-o hex` no longer prints both kinds of output at once.
 * fix: `icp` no longer picks up a stale inherited `$PWD` when launched as a subprocess via `chdir(2)` + `execve` (e.g. from a test harness). The logical `$PWD` path is now validated against `getcwd()` by inode before use, preserving symlink-aware project root discovery while ignoring stale values.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6585,7 +6585,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.6"
+version = "0.2.7"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.2.7`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.2.7`

### Review checklist
- [ ] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct
