### PR TITLE
ci: use dedicated PAT for cross-repo workflow dispatch

### DIFF
--- a/.github/workflows/promote-network-launcher.yml
+++ b/.github/workflows/promote-network-launcher.yml
@@ -22,18 +22,19 @@ jobs:
           fi
           echo "tag=v${VERSION#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        id: app-token
-        with:
-          client-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_CLIENT_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-          owner: dfinity
-          repositories: icp-cli-network-launcher
-
       - name: Dispatch promote-release workflow
+        # Rotating NETWORK_LAUNCHER_DISPATCH_PAT (fine-grained PAT, max 1y expiry).
+        # This PAT only dispatches INTO dfinity/icp-cli-network-launcher; the
+        # reverse direction uses a separate PAT stored in that repo.
+        #   1. github.com -> Settings -> Developer settings -> Personal access tokens
+        #      -> Fine-grained tokens -> Generate new token.
+        #   2. Resource owner: dfinity. Repository access: only
+        #      dfinity/icp-cli-network-launcher.
+        #   3. Repository permissions: Actions = Read and write
+        #      (Metadata: Read is auto-added).
+        #   4. Update the NETWORK_LAUNCHER_DISPATCH_PAT secret in dfinity/icp-cli.
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.NETWORK_LAUNCHER_DISPATCH_PAT }}
         run: |
           gh workflow run promote-release.yml \
             --repo dfinity/icp-cli-network-launcher \


### PR DESCRIPTION
## Summary
- The `promote-network-launcher` workflow added in #561 failed on its first run with HTTP 403 from `gh workflow run` — `PR_AUTOMATION_BOT_PUBLIC` does not have `actions: write` on `dfinity/icp-cli-network-launcher` (its scope is PR creation, not workflow dispatch).
- Replace the GitHub App token with a fine-grained PAT (`NETWORK_LAUNCHER_DISPATCH_PAT`) scoped only to `Actions: Read and write` on `dfinity/icp-cli-network-launcher`.
- Inline-document the rotation steps so the next rotation (max 1y expiry) doesn't require digging through git history.

## Notes
- The PAT is pending org-level approval from IDX (standard for fine-grained PATs in the `dfinity` org).
- A separate PAT will be created for the reverse direction (`icp-cli-network-launcher` → `icp-cli`) and stored in that repo — see [icp-cli-network-launcher#60](https://github.com/dfinity/icp-cli-network-launcher/pull/60).

## Test plan
- [x] PAT approved by IDX and added as `NETWORK_LAUNCHER_DISPATCH_PAT` secret on `dfinity/icp-cli`
- [ ] After merge, trigger the workflow (re-write `network-launcher-version` or re-run the failed run) and confirm the dispatch into `icp-cli-network-launcher` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)