### PR TITLE
docs: simplify icp new command and unify fullstack spelling

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -163,7 +163,7 @@ The network launcher downloads automatically on first use. If it fails:
 
 ## Next Steps
 
-- [Quickstart](../quickstart.md) — Deploy a full-stack app in under 5 minutes
+- [Quickstart](../quickstart.md) — Deploy a fullstack app in under 5 minutes
 - [Tutorial](../tutorial.md) — Understand each step in detail
 - [Local Development](local-development.md) — Day-to-day workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Build and deploy applications on the [Internet Computer](https://internetcompute
 
 ## Start Here
 
-- **[Quickstart](quickstart.md)** — Deploy a full-stack app in under 5 minutes
+- **[Quickstart](quickstart.md)** — Deploy a fullstack app in under 5 minutes
 - **[Tutorial](tutorial.md)** — Deploy your first app step by step
 
 ## Guides

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,9 +1,9 @@
 ---
 title: Quickstart
-description: Install icp-cli and deploy a full-stack Internet Computer app to a local network in under 5 minutes.
+description: Install icp-cli and deploy a fullstack Internet Computer app to a local network in under 5 minutes.
 ---
 
-Deploy a full-stack app to a local network in under 5 minutes.
+Deploy a fullstack app to a local network in under 5 minutes.
 
 **Prerequisites:** [Node.js](https://nodejs.org/) (LTS) is required for the installation commands below.
 
@@ -25,10 +25,7 @@ npm install -g ic-mops
 
 ```bash
 # 1. Create a new project with Motoko backend + React frontend
-icp new my-project --subfolder hello-world \
-  --define backend_type=motoko \
-  --define frontend_type=react \
-  --define network_type=Default && cd my-project
+icp new hello-icp --subfolder hello-world --silent && cd hello-icp
 
 # 2. Start a local network (runs in background)
 icp network start -d

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,11 +1,11 @@
 ---
 title: Tutorial
-description: Step-by-step walkthrough of deploying a full-stack Motoko and React app on the Internet Computer.
+description: Step-by-step walkthrough of deploying a fullstack Motoko and React app on the Internet Computer.
 ---
 
-This tutorial walks through deploying a full-stack app on the Internet Computer, explaining each step along the way.
+This tutorial walks through deploying a fullstack app on the Internet Computer, explaining each step along the way.
 
-> **Already did the Quickstart?** This tutorial covers the same steps with detailed explanations. The Quickstart used `--define` flags to skip the interactive prompts — here you'll see what those prompts are and what they mean.
+> **Already did the Quickstart?** This tutorial covers the same steps with detailed explanations. The Quickstart used `--silent` to skip the interactive prompts — here you'll see what those prompts are and what they mean.
 
 ## What is a Canister?
 
@@ -49,31 +49,29 @@ mops --version
 ## Create a Project
 
 ```bash
-icp new my-project
+icp new hello-icp
 ```
 
 You'll see three prompts:
 
-**1. Template selection** — Choose `hello-world` for a full-stack app with backend and frontend.
+**1. Template selection** — Choose `hello-world` for a fullstack app with backend and frontend.
 
 **2. Backend language** — Choose `motoko` (or `rust` if you prefer).
 
 **3. Network type** — Choose `Default` for native local networks. On Windows, Docker is always used regardless of this setting.
 
-> **Tip:** The Quickstart skipped these prompts using `--define` flags:
+> **Tip:** The Quickstart skipped these prompts using `--silent`, which applies the template's default values:
 > ```bash
-> icp new my-project --subfolder hello-world \
->   --define backend_type=motoko \
->   --define frontend_type=react \
->   --define network_type=Default
+> icp new hello-icp --subfolder hello-world --silent && cd hello-icp
 > ```
+> To override a default, add `--define <placeholder>=<value>` (for example, `--define backend_type=rust`).
 
 Templates are fetched from the [icp-cli-templates](https://github.com/dfinity/icp-cli-templates) repository by default. You can also [create your own templates](guides/creating-templates.md).
 
 Enter the project directory:
 
 ```bash
-cd my-project
+cd hello-icp
 ```
 
 Your project contains:
@@ -181,7 +179,7 @@ icp network stop
 
 ## Next Steps
 
-You've deployed a full-stack app on the Internet Computer! Continue your journey:
+You've deployed a fullstack app on the Internet Computer! Continue your journey:
 
 - [Local Development](guides/local-development.md) — Learn the day-to-day development workflow
 - [Deploying to Mainnet](guides/deploying-to-mainnet.md) — Go live on the Internet Computer


### PR DESCRIPTION
## Summary

- Replace three explicit `--define` flags with `--silent` in quickstart and tutorial (in sync with dfinity/developer-docs#266)
- Rename project from `my-project` to `hello-icp` throughout
- Update tutorial tip callout to show the new `--silent` form and explain `--define` as the override pattern
- Change `full-stack` → `fullstack` across all docs prose (quickstart, tutorial, index, installation guide)

## Sync recommendation

`informed by dfinity/developer-docs#266`