### PR TITLE
ci: add update-rust-toolchain workflow and BOT_APPROVED_FILES

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,8 @@
+# List of approved files that can be changed by a bot via an automated PR
+# This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
+
+# bump-network-launcher.yml
+network-launcher-version
+
+# update-rust-toolchain.yml
+rust-toolchain.toml

--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -1,0 +1,67 @@
+name: Update Rust Toolchain
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-toolchain:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check latest stable Rust version
+        id: check
+        run: |
+          MANIFEST=$(curl -sf https://static.rust-lang.org/dist/channel-rust-stable.toml)
+
+          RELEASE_DATE=$(echo "$MANIFEST" | grep '^date = ' | sed 's/date = "\(.*\)"/\1/')
+          LATEST=$(echo "$MANIFEST" | sed -n '/^\[pkg\.rust\]/,/^\[/{ s/^version = "\([0-9.]*\) .*/\1/p }')
+          CURRENT=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)
+
+          DAYS=$(( ( $(date +%s) - $(date -d "$RELEASE_DATE" +%s) ) / 86400 ))
+
+          echo "latest=$LATEST" | tee -a "$GITHUB_OUTPUT"
+          echo "current=$CURRENT" | tee -a "$GITHUB_OUTPUT"
+
+          echo "Latest stable: $LATEST (released $DAYS days ago), current: $CURRENT"
+
+          if [ "$DAYS" -ge 14 ] && [ "$LATEST" != "$CURRENT" ]; then
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update rust-toolchain.toml
+        if: steps.check.outputs.needs_update == 'true'
+        run: sed -i 's/^channel = ".*"/channel = "${{ steps.check.outputs.latest }}"/' rust-toolchain.toml
+
+      - name: Create GitHub App Token
+        if: steps.check.outputs.needs_update == 'true'
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Open pull request
+        if: steps.check.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="chore/update-rust-toolchain"
+          TITLE="chore(toolchain): update Rust to ${{ steps.check.outputs.latest }}"
+          BODY="Updates pinned Rust toolchain from \`${{ steps.check.outputs.current }}\` to \`${{ steps.check.outputs.latest }}\`."
+
+          git config user.name "pr-automation-bot-public[bot]"
+          git config user.email "pr-automation-bot-public[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add rust-toolchain.toml
+          git commit -m "$TITLE"
+          git push origin "$BRANCH" --force
+
+          gh pr create --title "$TITLE" --body "$BODY" --base main --head "$BRANCH" \
+            || echo "PR already open on $BRANCH, branch updated."


### PR DESCRIPTION
## Summary
- Add `update-rust-toolchain.yml` (copied 1:1 from the [icp-cli-network-launcher](https://github.com/dfinity/icp-cli-network-launcher) repo). Runs weekly and opens a PR bumping `rust-toolchain.toml` when a new stable Rust release is ≥14 days old.
- Add `.github/repo_policies/BOT_APPROVED_FILES` listing the files that bot-authored PRs are allowed to modify:
  - `network-launcher-version` → for `bump-network-launcher.yml`
  - `rust-toolchain.toml` → for the new `update-rust-toolchain.yml`

The missing `BOT_APPROVED_FILES` is what caused the `check-repo-policies / Check Bot Policies` job to fail on #572.

## Test plan
- [ ] After merge, re-run / rebase #572 and confirm `Check Bot Policies` passes
- [ ] Manually dispatch `Update Rust Toolchain` once to confirm the workflow opens a PR end-to-end (or wait for the next Monday 09:00 UTC cron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)