### PR TITLE
feat(identity): receive II delegation via form POST and redirect back with status

### DIFF
--- a/.claude/rules/team-general
+++ b/.claude/rules/team-general
@@ -1,1 +1,0 @@
-/home/claude/.identity-team-skills/rules/general

--- a/.claude/rules/team-general
+++ b/.claude/rules/team-general
@@ -1,0 +1,1 @@
+/home/claude/.identity-team-skills/rules/general

--- a/crates/icp-cli/src/commands/identity/link/ii.rs
+++ b/crates/icp-cli/src/commands/identity/link/ii.rs
@@ -1,10 +1,10 @@
 use std::net::SocketAddr;
 
 use axum::{
-    Router,
+    Form, Router,
     extract::State,
     http::{HeaderMap, HeaderValue, StatusCode, header},
-    response::IntoResponse,
+    response::{IntoResponse, Redirect},
     routing::post,
 };
 use base64::engine::{Engine as _, general_purpose::URL_SAFE_NO_PAD};
@@ -23,6 +23,7 @@ use icp::{
     prelude::*,
 };
 use indicatif::{ProgressBar, ProgressStyle};
+use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu, ensure};
 use tokio::{net::TcpListener, sync::oneshot};
 use tracing::{info, warn};
@@ -99,7 +100,8 @@ pub(crate) async fn exec(ctx: &Context, args: &IiArgs) -> Result<(), IiError> {
     let basic = BasicIdentity::from_raw_key(&secret_key.serialize_raw());
     let der_public_key = basic.public_key().expect("ed25519 always has a public key");
 
-    let chain = recv_delegation(&args.host, &der_public_key)
+    // Linking creates a brand-new identity, so there is no principal to match against.
+    let chain = recv_delegation(&args.host, &der_public_key, None)
         .await
         .context(PollSnafu)?;
 
@@ -192,12 +194,10 @@ pub(crate) enum IiRecvError {
     #[snafu(display("failed to fetch `{url}`"))]
     FetchDiscovery { url: String, source: reqwest::Error },
 
-    #[snafu(display("failed to read discovery response from `{url}`"))]
-    ReadDiscovery { url: String, source: reqwest::Error },
+    #[snafu(display("failed to parse discovery response from `{url}` as JSON"))]
+    ParseDiscovery { url: String, source: reqwest::Error },
 
-    #[snafu(display(
-        "`{url}` returned an empty login path — the response must be a single non-empty line"
-    ))]
+    #[snafu(display("`{url}` returned an empty `path` — it must be a non-empty login path"))]
     EmptyLoginPath { url: String },
 
     #[snafu(display("interrupted"))]
@@ -208,33 +208,41 @@ pub(crate) enum IiRecvError {
 
     #[snafu(display("failed to read confirmation from terminal"))]
     TermConfirm,
+
+    #[snafu(display("the browser sent back an invalid delegation chain"))]
+    InvalidDelegation,
 }
 
-/// Discovers the login path from `{host}/.well-known/ic-cli-login`, then opens
-/// a local HTTP server, builds the login URL, and returns the delegation chain
-/// once the frontend POSTs it back.
+/// Discovers the login path from the `{ "path": "…" }` JSON served at
+/// `{host}/.well-known/cli-auth-config`, then opens a local HTTP server, builds
+/// the login URL, and returns the delegation chain once the frontend submits it.
+///
+/// When `expected_principal` is set (the `login` re-auth path), a delegation
+/// whose self-authenticating principal does not match is rejected without
+/// stopping the server, so the frontend can show a mismatch message and retry.
 pub(crate) async fn recv_delegation(
     host: &Url,
     der_public_key: &[u8],
+    expected_principal: Option<Principal>,
 ) -> Result<DelegationChain, IiRecvError> {
     let key_b64 = URL_SAFE_NO_PAD.encode(der_public_key);
 
     // Discover the login path.
     let discovery_url = host
-        .join("/.well-known/ic-cli-login")
+        .join("/.well-known/cli-auth-config")
         .expect("joining an absolute path is infallible");
     let discovery_url_str = discovery_url.to_string();
-    let login_path = reqwest::get(discovery_url)
+    let config: CliAuthConfig = reqwest::get(discovery_url)
         .await
         .context(FetchDiscoverySnafu {
             url: &discovery_url_str,
         })?
-        .text()
+        .json()
         .await
-        .context(ReadDiscoverySnafu {
+        .context(ParseDiscoverySnafu {
             url: &discovery_url_str,
         })?;
-    let login_path = login_path.trim();
+    let login_path = config.path.trim();
     if login_path.is_empty() {
         return EmptyLoginPathSnafu {
             url: discovery_url_str,
@@ -262,8 +270,28 @@ pub(crate) async fn recv_delegation(
     let mut login_url = host.join(login_path).expect("login_path is a valid path");
     login_url.set_fragment(Some(&fragment));
 
-    let (chain_tx, chain_rx) = oneshot::channel::<DelegationChain>();
+    // Where the loopback server sends the browser back to once it has the
+    // delegation, so the frontend keeps ownership of the success/error UI. The
+    // mismatch URL re-supplies `public_key`/`callback` so the user can pick
+    // another identity and submit again to the same loopback server.
+    let status_url = |status: &str| {
+        let mut url = host.join(login_path).expect("login_path is a valid path");
+        url.set_fragment(Some(&format!("status={status}")));
+        url.to_string()
+    };
+    let success_url = status_url("success");
+    let error_url = status_url("error");
+    let mismatch_url = {
+        let mut url = host.join(login_path).expect("login_path is a valid path");
+        url.set_fragment(Some(&format!("{fragment}&status=identity-mismatch")));
+        url.to_string()
+    };
+
+    let (chain_tx, mut chain_rx) = oneshot::channel::<Result<DelegationChain, ()>>();
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    // In-flight events the handler reports while still listening (e.g. a
+    // mismatch that the user can retry), so the CLI isn't silent during retries.
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<CallbackEvent>();
 
     let allowed_origin =
         HeaderValue::from_str(&host.origin().ascii_serialization()).expect("URL origin is valid");
@@ -272,11 +300,16 @@ pub(crate) async fn recv_delegation(
     let state = CallbackState {
         chain_tx: std::sync::Mutex::new(Some(chain_tx)),
         shutdown_tx: std::sync::Mutex::new(Some(shutdown_tx)),
+        event_tx,
         allowed_origin,
+        expected_principal,
+        success_url,
+        error_url,
+        mismatch_url,
     };
 
     let app = Router::new()
-        .route("/", post(handle_callback).options(handle_preflight))
+        .route("/", post(handle_callback))
         .with_state(std::sync::Arc::new(state));
 
     let spinner = ProgressBar::new_spinner();
@@ -305,93 +338,118 @@ pub(crate) async fn recv_delegation(
         let _ = shutdown_rx.await;
     });
     open::that(login_url.as_str()).context(OpenBrowserSnafu)?;
-    let result = tokio::select! {
-        res = serve.into_future() => {
-            res.context(ServeServerSnafu)?;
-            panic!("receiving server ended unexpectedly");
+    let mut serve_fut = std::pin::pin!(serve.into_future());
+    let result = loop {
+        tokio::select! {
+            res = &mut serve_fut => {
+                res.context(ServeServerSnafu)?;
+                panic!("receiving server ended unexpectedly");
+            }
+            Some(event) = event_rx.recv() => match event {
+                CallbackEvent::Mismatch => spinner.println(
+                    "  That identity doesn't match the one linked to this identity. \
+                     Choose the correct identity in the browser to try again.",
+                ),
+            },
+            chain = &mut chain_rx => break chain,
         }
-        chain = chain_rx => chain,
     };
 
     spinner.finish_and_clear();
-    Ok(result.expect("sender only dropped after sending"))
+    match result.expect("sender only dropped after sending") {
+        Ok(chain) => Ok(chain),
+        Err(()) => InvalidDelegationSnafu.fail(),
+    }
+}
+
+/// An event reported by the callback handler while it keeps listening.
+#[derive(Debug)]
+enum CallbackEvent {
+    /// A delegation arrived whose principal didn't match `expected_principal`.
+    Mismatch,
+}
+
+/// Response body of `{host}/.well-known/cli-auth-config`.
+#[derive(Debug, Deserialize)]
+struct CliAuthConfig {
+    path: String,
+}
+
+/// Form fields posted by the frontend to the loopback callback.
+#[derive(Debug, Deserialize)]
+struct CallbackForm {
+    /// The delegation chain as JSON (`DelegationChain.toJSON()`).
+    delegation: String,
 }
 
 #[derive(Debug)]
 struct CallbackState {
-    chain_tx: std::sync::Mutex<Option<oneshot::Sender<DelegationChain>>>,
+    chain_tx: std::sync::Mutex<Option<oneshot::Sender<Result<DelegationChain, ()>>>>,
     shutdown_tx: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<CallbackEvent>,
     allowed_origin: HeaderValue,
+    /// When set, a delegation must resolve to this principal or it is rejected.
+    expected_principal: Option<Principal>,
+    success_url: String,
+    error_url: String,
+    mismatch_url: String,
 }
 
-fn cors_headers(origin: &HeaderValue) -> HeaderMap {
-    let mut headers = HeaderMap::new();
-    headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin.clone());
-    headers.insert(
-        header::ACCESS_CONTROL_ALLOW_METHODS,
-        HeaderValue::from_static("POST, OPTIONS"),
-    );
-    headers.insert(
-        header::ACCESS_CONTROL_ALLOW_HEADERS,
-        HeaderValue::from_static("content-type"),
-    );
-    headers
+/// Hands the result to `recv_delegation` and stops the server.
+fn finish(state: &CallbackState, result: Result<DelegationChain, ()>) {
+    if let Some(tx) = state.chain_tx.lock().unwrap().take() {
+        let _ = tx.send(result);
+    }
+    if let Some(tx) = state.shutdown_tx.lock().unwrap().take() {
+        let _ = tx.send(());
+    }
 }
 
-async fn handle_preflight(State(state): State<std::sync::Arc<CallbackState>>) -> impl IntoResponse {
-    (StatusCode::NO_CONTENT, cors_headers(&state.allowed_origin))
+/// The self-authenticating principal of the chain's leaf public key.
+fn principal_of_chain(chain: &DelegationChain) -> Option<Principal> {
+    let from_key = hex::decode(&chain.public_key).ok()?;
+    Some(Principal::self_authenticating(&from_key))
 }
 
 async fn handle_callback(
     State(state): State<std::sync::Arc<CallbackState>>,
     headers: HeaderMap,
-    body: axum::body::Bytes,
-) -> impl IntoResponse {
+    Form(form): Form<CallbackForm>,
+) -> axum::response::Response {
+    // A top-level form-POST navigation from the II origin carries `Origin`.
+    // Reject anything else without ending the flow, so stray or forged local
+    // requests can't abort an in-progress login.
     let origin_ok = headers
         .get(header::ORIGIN)
         .map(|v| *v == state.allowed_origin)
         .unwrap_or(false);
     if !origin_ok {
-        return (
-            StatusCode::FORBIDDEN,
-            cors_headers(&state.allowed_origin),
-            "forbidden",
-        )
-            .into_response();
+        return StatusCode::FORBIDDEN.into_response();
     }
 
-    // Only accept POST with JSON content.
-    let content_type = headers
-        .get(header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    if !content_type.starts_with("application/json") {
-        return (
-            StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            cors_headers(&state.allowed_origin),
-            "expected application/json",
-        )
-            .into_response();
-    }
-
-    let chain: DelegationChain = match serde_json::from_slice(&body) {
+    let chain: DelegationChain = match serde_json::from_str(&form.delegation) {
         Ok(c) => c,
         Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                cors_headers(&state.allowed_origin),
-                "invalid delegation chain",
-            )
-                .into_response();
+            finish(&state, Err(()));
+            return Redirect::to(&state.error_url).into_response();
         }
     };
 
-    if let Some(tx) = state.chain_tx.lock().unwrap().take() {
-        let _ = tx.send(chain);
-    }
-    if let Some(tx) = state.shutdown_tx.lock().unwrap().take() {
-        let _ = tx.send(());
+    if let Some(expected) = state.expected_principal {
+        match principal_of_chain(&chain) {
+            // Keep listening so the user can retry with the right identity.
+            Some(principal) if principal != expected => {
+                let _ = state.event_tx.send(CallbackEvent::Mismatch);
+                return Redirect::to(&state.mismatch_url).into_response();
+            }
+            Some(_) => {}
+            None => {
+                finish(&state, Err(()));
+                return Redirect::to(&state.error_url).into_response();
+            }
+        }
     }
 
-    (StatusCode::OK, cors_headers(&state.allowed_origin), "").into_response()
+    finish(&state, Ok(chain));
+    Redirect::to(&state.success_url).into_response()
 }

--- a/crates/icp-cli/src/commands/identity/link/ii.rs
+++ b/crates/icp-cli/src/commands/identity/link/ii.rs
@@ -181,7 +181,7 @@ pub(crate) enum IiError {
     BadPassword {},
 }
 
-pub(crate) const DEFAULT_HOST: &str = "https://cli.id.ai";
+pub(crate) const DEFAULT_HOST: &str = "https://id.ai";
 
 #[derive(Debug, Snafu)]
 pub(crate) enum IiRecvError {

--- a/crates/icp-cli/src/commands/identity/link/ii.rs
+++ b/crates/icp-cli/src/commands/identity/link/ii.rs
@@ -1,5 +1,6 @@
-use std::net::SocketAddr;
+use std::{io::IsTerminal, net::SocketAddr, time::Duration};
 
+use anstyle::{AnsiColor, Reset, Style};
 use axum::{
     Form, Router,
     extract::State,
@@ -38,9 +39,15 @@ pub(crate) struct IiArgs {
     /// Name for the linked identity
     name: String,
 
-    /// Host of the II login frontend (e.g. example.icp0.io or https://example.icp0.io)
-    #[arg(long, default_value = DEFAULT_HOST, value_parser = parse_host)]
-    host: Url,
+    /// Auth domain to sign in at (e.g. id.ai or identity.ce1.com). Its
+    /// `/.well-known/cli-auth-config` decides the login path.
+    #[arg(long, default_value = DEFAULT_AUTH, value_parser = parse_auth)]
+    auth: Url,
+
+    /// Delegation domain to get an identity for (e.g. oisy.com). When omitted,
+    /// the auth domain picks its default (id.ai uses cli.id.ai).
+    #[arg(long)]
+    app: Option<String>,
 
     /// Where to store the session private key
     #[arg(long, value_enum, default_value_t)]
@@ -51,7 +58,7 @@ pub(crate) struct IiArgs {
     storage_password_file: Option<PathBuf>,
 }
 
-fn parse_host(s: &str) -> Result<Url, String> {
+fn parse_auth(s: &str) -> Result<Url, String> {
     let with_scheme = if s.contains("://") {
         s.to_owned()
     } else {
@@ -102,14 +109,15 @@ pub(crate) async fn exec(ctx: &Context, args: &IiArgs) -> Result<(), IiError> {
     let der_public_key = basic.public_key().expect("ed25519 always has a public key");
 
     // Linking creates a brand-new identity, so there is no principal to match against.
-    let chain = recv_delegation(&args.host, &der_public_key, None)
+    let chain = recv_delegation(&args.auth, args.app.as_deref(), &der_public_key, None)
         .await
         .context(PollSnafu)?;
 
     let from_key = hex::decode(&chain.public_key).context(DecodeFromKeySnafu)?;
     let ii_principal = Principal::self_authenticating(&from_key);
 
-    let host = args.host.clone();
+    let auth = args.auth.clone();
+    let app = args.app.clone();
     ctx.dirs
         .identity()?
         .with_write(async |dirs| {
@@ -120,7 +128,8 @@ pub(crate) async fn exec(ctx: &Context, args: &IiArgs) -> Result<(), IiError> {
                 &chain,
                 ii_principal,
                 create_format,
-                host,
+                auth,
+                app,
             )
         })
         .await?
@@ -182,7 +191,7 @@ pub(crate) enum IiError {
     BadPassword {},
 }
 
-pub(crate) const DEFAULT_HOST: &str = "https://id.ai";
+pub(crate) const DEFAULT_AUTH: &str = "https://id.ai";
 
 #[derive(Debug, Snafu)]
 pub(crate) enum IiRecvError {
@@ -215,14 +224,18 @@ pub(crate) enum IiRecvError {
 }
 
 /// Discovers the login path from the `{ "path": "…" }` JSON served at
-/// `{host}/.well-known/cli-auth-config`, then opens a local HTTP server, builds
+/// `{auth}/.well-known/cli-auth-config`, then opens a local HTTP server, builds
 /// the login URL, and returns the delegation chain once the frontend submits it.
+///
+/// `delegation_domain` is the domain to get a delegation for; when `None`, the
+/// auth page picks its own default (id.ai uses cli.id.ai).
 ///
 /// When `expected_principal` is set (the `login` re-auth path), a delegation
 /// whose self-authenticating principal does not match is rejected without
 /// stopping the server, so the frontend can show a mismatch message and retry.
 pub(crate) async fn recv_delegation(
-    host: &Url,
+    auth: &Url,
+    delegation_domain: Option<&str>,
     der_public_key: &[u8],
     expected_principal: Option<Principal>,
 ) -> Result<DelegationChain, IiRecvError> {
@@ -236,7 +249,7 @@ pub(crate) async fn recv_delegation(
     let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
 
     // Discover the login path.
-    let discovery_url = host
+    let discovery_url = auth
         .join("/.well-known/cli-auth-config")
         .expect("joining an absolute path is infallible");
     let discovery_url_str = discovery_url.to_string();
@@ -269,29 +282,37 @@ pub(crate) async fn recv_delegation(
     // can parse it with `new URLSearchParams(location.hash.slice(1))`.
     let fragment = {
         let mut scratch = Url::parse("x:?").expect("infallible");
-        scratch
-            .query_pairs_mut()
-            .append_pair("public_key", &key_b64)
-            .append_pair("callback", &callback_url)
-            .append_pair("nonce", &nonce);
+        {
+            let mut pairs = scratch.query_pairs_mut();
+            pairs
+                .append_pair("public_key", &key_b64)
+                .append_pair("callback", &callback_url)
+                .append_pair("nonce", &nonce);
+            // Omitted when the caller passes no `--app`, so the auth page picks
+            // its own default delegation domain.
+            if let Some(domain) = delegation_domain {
+                pairs.append_pair("domain", domain);
+            }
+        }
         scratch.query().expect("just set").to_owned()
     };
-    let mut login_url = host.join(login_path).expect("login_path is a valid path");
+    let mut login_url = auth.join(login_path).expect("login_path is a valid path");
     login_url.set_fragment(Some(&fragment));
 
     // Where the loopback server sends the browser back to once it has the
     // delegation, so the frontend keeps ownership of the success/error UI. The
-    // mismatch URL re-supplies `public_key`/`callback`/`nonce` so the user can
-    // pick another identity and submit again to the same loopback server.
+    // mismatch URL re-supplies the request params (`public_key`/`callback`/
+    // `nonce`/`domain`) so the user can pick another identity and submit again
+    // to the same loopback server.
     let status_url = |status: &str| {
-        let mut url = host.join(login_path).expect("login_path is a valid path");
+        let mut url = auth.join(login_path).expect("login_path is a valid path");
         url.set_fragment(Some(&format!("status={status}")));
         url.to_string()
     };
     let success_url = status_url("success");
     let error_url = status_url("error");
     let mismatch_url = {
-        let mut url = host.join(login_path).expect("login_path is a valid path");
+        let mut url = auth.join(login_path).expect("login_path is a valid path");
         url.set_fragment(Some(&format!("{fragment}&status=identity-mismatch")));
         url.to_string()
     };
@@ -318,11 +339,13 @@ pub(crate) async fn recv_delegation(
         .route("/", post(handle_callback))
         .with_state(std::sync::Arc::new(state));
 
+    // Animated braille frames while waiting, with a green `✓` as the final
+    // tick so a finished step matches the checkmark on the id.ai/cli screen.
     let spinner = ProgressBar::new_spinner();
     spinner.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.green} {msg}")
-            .expect("valid template"),
+        ProgressStyle::with_template("{spinner:.green} {msg}")
+            .expect("valid template")
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
     );
 
     eprintln!();
@@ -344,6 +367,11 @@ pub(crate) async fn recv_delegation(
         let _ = shutdown_rx.await;
     });
     open::that(login_url.as_str()).context(OpenBrowserSnafu)?;
+    // Mirror the id.ai/cli terminal block: a checked "Browser opened" line, then
+    // an animated "Linking Internet Identity" step until the delegation lands.
+    spinner.println(format!("{} Browser opened", green_check()));
+    spinner.set_message("Linking Internet Identity");
+    spinner.enable_steady_tick(Duration::from_millis(80));
     let mut serve_fut = std::pin::pin!(serve.into_future());
     let result = loop {
         tokio::select! {
@@ -361,10 +389,28 @@ pub(crate) async fn recv_delegation(
         }
     };
 
-    spinner.finish_and_clear();
     match result.expect("sender only dropped after sending") {
-        Ok(chain) => Ok(chain),
-        Err(()) => InvalidDelegationSnafu.fail(),
+        Ok(chain) => {
+            // Leaves a checked "✓ Linking Internet Identity" line (the final
+            // tick of the spinner style).
+            spinner.finish_with_message("Linking Internet Identity");
+            Ok(chain)
+        }
+        Err(()) => {
+            spinner.finish_and_clear();
+            InvalidDelegationSnafu.fail()
+        }
+    }
+}
+
+/// A green `✓`, or a plain one when color is disabled or stderr isn't a TTY —
+/// matching how the rest of the CLI gates ANSI styling.
+fn green_check() -> String {
+    const GREEN: Style = AnsiColor::Green.on_default();
+    if std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal() {
+        format!("{GREEN}✓{Reset}")
+    } else {
+        "✓".to_string()
     }
 }
 
@@ -375,7 +421,7 @@ enum CallbackEvent {
     Mismatch,
 }
 
-/// Response body of `{host}/.well-known/cli-auth-config`.
+/// Response body of `{auth}/.well-known/cli-auth-config`.
 #[derive(Debug, Deserialize)]
 struct CliAuthConfig {
     path: String,

--- a/crates/icp-cli/src/commands/identity/link/ii.rs
+++ b/crates/icp-cli/src/commands/identity/link/ii.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use axum::{
     Form, Router,
     extract::State,
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::StatusCode,
     response::{IntoResponse, Redirect},
     routing::post,
 };
@@ -23,6 +23,7 @@ use icp::{
     prelude::*,
 };
 use indicatif::{ProgressBar, ProgressStyle};
+use rand::RngExt as _;
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt, Snafu, ensure};
 use tokio::{net::TcpListener, sync::oneshot};
@@ -227,6 +228,13 @@ pub(crate) async fn recv_delegation(
 ) -> Result<DelegationChain, IiRecvError> {
     let key_b64 = URL_SAFE_NO_PAD.encode(der_public_key);
 
+    // Single-use secret shared with the frontend via the URL fragment, which is
+    // never sent over the network and is unreadable cross-origin. The frontend
+    // echoes it back in its POST, proving the request came from the page the
+    // user logged in through rather than a stray or forged local request.
+    let nonce_bytes: [u8; 32] = rand::rng().random();
+    let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+
     // Discover the login path.
     let discovery_url = host
         .join("/.well-known/cli-auth-config")
@@ -264,7 +272,8 @@ pub(crate) async fn recv_delegation(
         scratch
             .query_pairs_mut()
             .append_pair("public_key", &key_b64)
-            .append_pair("callback", &callback_url);
+            .append_pair("callback", &callback_url)
+            .append_pair("nonce", &nonce);
         scratch.query().expect("just set").to_owned()
     };
     let mut login_url = host.join(login_path).expect("login_path is a valid path");
@@ -272,8 +281,8 @@ pub(crate) async fn recv_delegation(
 
     // Where the loopback server sends the browser back to once it has the
     // delegation, so the frontend keeps ownership of the success/error UI. The
-    // mismatch URL re-supplies `public_key`/`callback` so the user can pick
-    // another identity and submit again to the same loopback server.
+    // mismatch URL re-supplies `public_key`/`callback`/`nonce` so the user can
+    // pick another identity and submit again to the same loopback server.
     let status_url = |status: &str| {
         let mut url = host.join(login_path).expect("login_path is a valid path");
         url.set_fragment(Some(&format!("status={status}")));
@@ -293,15 +302,12 @@ pub(crate) async fn recv_delegation(
     // mismatch that the user can retry), so the CLI isn't silent during retries.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<CallbackEvent>();
 
-    let allowed_origin =
-        HeaderValue::from_str(&host.origin().ascii_serialization()).expect("URL origin is valid");
-
     // chain_tx is wrapped in an Option so the handler can take ownership.
     let state = CallbackState {
         chain_tx: std::sync::Mutex::new(Some(chain_tx)),
         shutdown_tx: std::sync::Mutex::new(Some(shutdown_tx)),
         event_tx,
-        allowed_origin,
+        expected_nonce: nonce,
         expected_principal,
         success_url,
         error_url,
@@ -380,6 +386,8 @@ struct CliAuthConfig {
 struct CallbackForm {
     /// The delegation chain as JSON (`DelegationChain.toJSON()`).
     delegation: String,
+    /// The single-use nonce echoed back from the login URL fragment.
+    nonce: String,
 }
 
 #[derive(Debug)]
@@ -387,7 +395,8 @@ struct CallbackState {
     chain_tx: std::sync::Mutex<Option<oneshot::Sender<Result<DelegationChain, ()>>>>,
     shutdown_tx: std::sync::Mutex<Option<oneshot::Sender<()>>>,
     event_tx: tokio::sync::mpsc::UnboundedSender<CallbackEvent>,
-    allowed_origin: HeaderValue,
+    /// The nonce the frontend must echo back, proving it read the login URL fragment.
+    expected_nonce: String,
     /// When set, a delegation must resolve to this principal or it is rejected.
     expected_principal: Option<Principal>,
     success_url: String,
@@ -413,17 +422,13 @@ fn principal_of_chain(chain: &DelegationChain) -> Option<Principal> {
 
 async fn handle_callback(
     State(state): State<std::sync::Arc<CallbackState>>,
-    headers: HeaderMap,
     Form(form): Form<CallbackForm>,
 ) -> axum::response::Response {
-    // A top-level form-POST navigation from the II origin carries `Origin`.
-    // Reject anything else without ending the flow, so stray or forged local
-    // requests can't abort an in-progress login.
-    let origin_ok = headers
-        .get(header::ORIGIN)
-        .map(|v| *v == state.allowed_origin)
-        .unwrap_or(false);
-    if !origin_ok {
+    // Only the frontend the user logged in through saw the nonce in the login
+    // URL fragment. Reject anything else without ending the flow, so stray or
+    // forged local requests can't abort an in-progress login.
+    if form.nonce != state.expected_nonce {
+        warn!("rejecting callback POST: nonce missing or mismatched");
         return StatusCode::FORBIDDEN.into_response();
     }
 

--- a/crates/icp-cli/src/commands/identity/login.rs
+++ b/crates/icp-cli/src/commands/identity/login.rs
@@ -20,7 +20,7 @@ pub(crate) struct LoginArgs {
 }
 
 pub(crate) async fn exec(ctx: &Context, args: &LoginArgs) -> Result<(), LoginError> {
-    let (algorithm, storage, host, principal) = ctx
+    let (algorithm, storage, host, domain, principal) = ctx
         .dirs
         .identity()?
         .with_read(async |dirs| {
@@ -35,7 +35,14 @@ pub(crate) async fn exec(ctx: &Context, args: &LoginArgs) -> Result<(), LoginErr
                     principal,
                     storage,
                     host,
-                } => Ok((algorithm.clone(), *storage, host.clone(), *principal)),
+                    domain,
+                } => Ok((
+                    algorithm.clone(),
+                    *storage,
+                    host.clone(),
+                    domain.clone(),
+                    *principal,
+                )),
                 _ => NotIiSnafu { name: &args.name }.fail(),
             }
         })
@@ -55,8 +62,9 @@ pub(crate) async fn exec(ctx: &Context, args: &LoginArgs) -> Result<(), LoginErr
         .await?
         .context(LoadSessionKeySnafu)?;
 
-    // Re-auth must resolve to the same II principal that was originally linked.
-    let chain = ii::recv_delegation(&host, &der_public_key, Some(principal))
+    // Re-auth must resolve to the same II principal that was originally linked,
+    // so reuse the delegation domain captured at link time.
+    let chain = ii::recv_delegation(&host, domain.as_deref(), &der_public_key, Some(principal))
         .await
         .context(PollSnafu)?;
 

--- a/crates/icp-cli/src/commands/identity/login.rs
+++ b/crates/icp-cli/src/commands/identity/login.rs
@@ -20,7 +20,7 @@ pub(crate) struct LoginArgs {
 }
 
 pub(crate) async fn exec(ctx: &Context, args: &LoginArgs) -> Result<(), LoginError> {
-    let (algorithm, storage, host) = ctx
+    let (algorithm, storage, host, principal) = ctx
         .dirs
         .identity()?
         .with_read(async |dirs| {
@@ -32,10 +32,10 @@ pub(crate) async fn exec(ctx: &Context, args: &LoginArgs) -> Result<(), LoginErr
             match spec {
                 IdentitySpec::InternetIdentity {
                     algorithm,
+                    principal,
                     storage,
                     host,
-                    ..
-                } => Ok((algorithm.clone(), *storage, host.clone())),
+                } => Ok((algorithm.clone(), *storage, host.clone(), *principal)),
                 _ => NotIiSnafu { name: &args.name }.fail(),
             }
         })
@@ -55,7 +55,8 @@ pub(crate) async fn exec(ctx: &Context, args: &LoginArgs) -> Result<(), LoginErr
         .await?
         .context(LoadSessionKeySnafu)?;
 
-    let chain = ii::recv_delegation(&host, &der_public_key)
+    // Re-auth must resolve to the same II principal that was originally linked.
+    let chain = ii::recv_delegation(&host, &der_public_key, Some(principal))
         .await
         .context(PollSnafu)?;
 

--- a/crates/icp/src/identity/key.rs
+++ b/crates/icp/src/identity/key.rs
@@ -1176,6 +1176,7 @@ pub fn link_ii_identity(
     principal: ic_agent::export::Principal,
     create_format: CreateFormat,
     host: Url,
+    domain: Option<String>,
 ) -> Result<(), CreatePendingDelegationError> {
     let mut identity_list = IdentityList::load_from(dirs.read())?;
     ensure!(
@@ -1251,6 +1252,7 @@ pub fn link_ii_identity(
         principal,
         storage: ii_storage,
         host,
+        domain,
     };
     identity_list.identities.insert(name.to_string(), spec);
     identity_list.write_to(dirs)?;

--- a/crates/icp/src/identity/manifest.rs
+++ b/crates/icp/src/identity/manifest.rs
@@ -135,9 +135,13 @@ pub enum IdentitySpec {
         /// (`Principal::self_authenticating(from_key)`), not the session key.
         principal: Principal,
         storage: DelegationKeyStorage,
-        /// The host used for II login, stored so `icp identity login` can
-        /// re-authenticate without requiring `--host` again.
+        /// The auth domain used for II login, stored so `icp identity login`
+        /// can re-authenticate without requiring `--auth` again.
         host: Url,
+        /// The delegation domain (`--app`) used at link time, stored so re-auth
+        /// resolves the same principal. `None` means the auth page's default.
+        #[serde(default)]
+        domain: Option<String>,
     },
     /// Session key created via `icp identity delegation request`; no delegation
     /// chain yet. Cannot be used as an identity until `icp identity delegation use`


### PR DESCRIPTION
## Motivation

Chrome's Local Network Access gates public-origin → loopback subresource requests behind a permission prompt next to the URL bar. The II frontend used to POST the delegation to the CLI's loopback callback with `fetch`, which triggers that prompt. Switching the delivery to a top-level form-POST navigation avoids the prompt, and having the loopback server redirect the browser back to the II frontend keeps id.ai in control of the success/error UI.

That top-level navigation, however, posts from the https login page to the http loopback callback — an https→http downgrade. Under the browser's default `strict-origin-when-cross-origin` referrer policy, a non-CORS navigation has its `Origin` serialized to `null` on a scheme downgrade, so the original exact-match `Origin` check rejected every legitimate POST with 403. The check is replaced with a nonce that doesn't depend on browser `Origin` behavior.

## Command

```
icp identity link ii <name> [--auth <auth domain>] [--app <delegation domain>]
```

- `--auth` — the domain to sign in at. Defaults to `id.ai`; its `/.well-known/cli-auth-config` decides the login path (so `id.ai` → `id.ai/cli`). Use it to point at another II deployment or a custom login page (e.g. `--auth identity.ce1.com`, `--auth special.com`).
- `--app` — the delegation domain to get an identity for (e.g. `--app oisy.com`), emitted in the fragment as `domain`. Omitted, the auth page picks its own default (id.ai uses `cli.id.ai`), so a bare `icp identity link ii <name>` creates a portable id.ai/cli identity.

## Changes

- The loopback callback now accepts a top-level form POST (field `delegation`) instead of a JSON `fetch`, and 303-redirects the browser back to `{auth}{login_path}#status=...`:
  - `success`: the delegation is accepted; the server returns the chain and shuts down.
  - `identity-mismatch` (only on `icp identity login` re-auth): the delegation's self-authenticating principal does not match the linked identity. The server keeps listening (the redirect re-supplies `public_key`/`callback`/`nonce`/`domain` so the user can retry in place) and the CLI prints a message so it is not silent.
  - `error`: malformed delegation; the server shuts down, the redirect carries only the status, and the CLI exits with an error.
- Renames `--host` to `--auth` and adds `--app`. The login fragment now carries `public_key`/`callback`/`nonce`/`domain` (`domain` only when `--app` is given).
- The auth domain and the delegation domain are persisted in the identity manifest, so `icp identity login` re-authenticates against the same auth page and the same delegation domain — resolving the same principal — without re-passing the flags. (`domain` is serde-defaulted for back-compat with already-linked identities.)
- `recv_delegation` gains `delegation_domain` and `expected_principal` parameters: `login` passes the stored principal/domain, `link` passes `None` for the principal (it creates a brand-new identity).
- Discovery reads the `{ "path": "..." }` JSON at `/.well-known/cli-auth-config` to match the II frontend's contract.
- Drops the CORS preflight handling (a top-level navigation needs none).
- **Gates the callback with a single-use nonce instead of `Origin`.** The CLI generates a 32-byte base64url nonce, puts it in the login URL fragment, and requires the frontend to echo it back in the POST body; a missing or mismatched nonce is rejected with 403 without ending the flow. The fragment is never sent over the network and is unreadable cross-origin, so only the page the user logged in through can produce it — the same anti-abort property the `Origin` check was meant to provide, but immune to the https→http downgrade that made `Origin` `null`.
- **Console output** mirrors the id.ai/cli terminal block: after the "Press Enter to log in" prompt it shows a green `✓ Browser opened` line and an animated `Linking Internet Identity` spinner that finishes with a green check, instead of going silent.

Pairs with the II frontend change in dfinity/internet-identity#3956 (form POST + status parsing + success/mismatch/error screens + nonce echo + `domain` derivation).
