### PR TITLE
feat(recipe): inject `_.cli.version` and hard-error on reserved `_` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
-* feat: Recipe templates can now use `{{_.canister.name}}` to reference the canister's name from `icp.yaml` without repeating it in the `configuration:` block. The `_` namespace is reserved and cannot be overridden by user-provided configuration.
+* feat: Recipe templates can now use `{{_.canister.name}}` to reference the canister's name from `icp.yaml` without repeating it in the `configuration:` block. The `_` namespace is reserved — setting it in `configuration:` is an error.
 * feat: Recipe templates can now use `{{_.cli.version}}` to read the running icp-cli version string (e.g. `0.3.0`), allowing recipes to adapt behaviour across CLI versions.
-* fix: Setting `_` in a recipe's `configuration:` block is now an explicit error instead of being silently ignored.
+* fix: A recipe template that renders to invalid YAML now produces a clear error with the rendered output included, instead of panicking.
 
 # v0.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ bump. Currently experimental: sync plugins.
 # Unreleased
 
 * feat: Recipe templates can now use `{{_.canister.name}}` to reference the canister's name from `icp.yaml` without repeating it in the `configuration:` block. The `_` namespace is reserved and cannot be overridden by user-provided configuration.
+* feat: Recipe templates can now use `{{_.cli.version}}` to read the running icp-cli version string (e.g. `0.3.0`), allowing recipes to adapt behaviour across CLI versions.
+* fix: Setting `_` in a recipe's `configuration:` block is now an explicit error instead of being silently ignored.
 
 # v0.2.7
 

--- a/crates/icp/src/canister/recipe/handlebars.rs
+++ b/crates/icp/src/canister/recipe/handlebars.rs
@@ -81,6 +81,20 @@ pub enum HandlebarsError {
 
     #[snafu(display("failed to acquire lock on package cache"))]
     LockCache { source: crate::fs::lock::LockError },
+
+    #[snafu(display(
+        "_ is a reserved namespace in recipe configuration and cannot be set by the user"
+    ))]
+    ReservedNamespace,
+
+    #[snafu(display(
+        "recipe template for '{recipe}' rendered to invalid YAML\n\nRendered content:\n------\n{template}\n------"
+    ))]
+    ParseRenderedYaml {
+        source: serde_yaml::Error,
+        recipe: String,
+        template: String,
+    },
 }
 
 impl Handlebars {
@@ -89,6 +103,11 @@ impl Handlebars {
         recipe: &Recipe,
         recipe_context: &super::RecipeContext,
     ) -> Result<(BuildSteps, SyncSteps), HandlebarsError> {
+        ensure!(
+            !recipe.configuration.contains_key("_"),
+            ReservedNamespaceSnafu
+        );
+
         // Determine the template source
         let tmpl_source = match &recipe.recipe_type {
             RecipeType::File(path) => TemplateSource::LocalPath(Path::new(&path).into()),
@@ -188,7 +207,6 @@ impl Handlebars {
         );
 
         // Build render context: user-provided configuration plus injected _.* variables.
-        // The _ key is reserved and always overrides any user-supplied value.
         let mut render_context = recipe.configuration.clone();
         render_context.insert("_".to_string(), recipe_context.to_yaml());
 
@@ -209,21 +227,11 @@ impl Handlebars {
             sync: SyncSteps,
         }
 
-        let insts = serde_yaml::from_str::<BuildSyncHelper>(&out);
-        let (build, sync) = match insts {
-            Ok(helper) => (helper.build, helper.sync),
-            Err(e) => panic!(
-                "{}",
-                formatdoc! {r#"
-                Unable to render recipe {} template into valid yaml: {e}
-
-                Rendered content:
-                ------
-                {out}
-                ------
-            "#, recipe.recipe_type}
-            ),
-        };
+        let BuildSyncHelper { build, sync } = serde_yaml::from_str::<BuildSyncHelper>(&out)
+            .with_context(|_| ParseRenderedYamlSnafu {
+                recipe: recipe.recipe_type.to_string(),
+                template: out,
+            })?;
 
         // The template is verified good - now cache it if it was remote
         if should_cache {
@@ -355,6 +363,7 @@ mod tests {
     fn recipe_context(canister_name: &str) -> RecipeContext {
         RecipeContext {
             canister_name: canister_name.to_string(),
+            cli_version: "1.2.3".to_string(),
         }
     }
 
@@ -454,6 +463,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cli_version_is_injected() {
+        let tmp = camino_tempfile::Utf8TempDir::new().unwrap();
+        let tmpl_path = tmp.path().join("recipe.hbs");
+        std::fs::write(
+            &tmpl_path,
+            indoc::indoc! {r#"
+                build:
+                  steps:
+                    - type: script
+                      command: "requires icp {{_.cli.version}}"
+            "#},
+        )
+        .unwrap();
+
+        let pkg_cache = PackageCache::new(tmp.path().join("pkg")).unwrap();
+        let hbs = Handlebars {
+            http_client: reqwest::Client::new(),
+            pkg_cache,
+        };
+
+        let recipe = Recipe {
+            recipe_type: RecipeType::File(tmpl_path.to_string()),
+            configuration: HashMap::new(),
+            sha256: None,
+        };
+
+        let (build, _sync) = hbs
+            .resolve_impl(&recipe, &recipe_context("my-canister"))
+            .await
+            .unwrap();
+
+        match build.steps[0].clone() {
+            crate::manifest::canister::BuildStep::Script(adapter) => {
+                assert_eq!(adapter.command.as_vec()[0], "requires icp 1.2.3");
+            }
+            other => panic!("Expected Script build step, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn canister_name_works_with_replace_helper() {
         let tmp = camino_tempfile::Utf8TempDir::new().unwrap();
         let tmpl_path = tmp.path().join("recipe.hbs");
@@ -494,7 +543,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reserved_namespace_cannot_be_overridden_by_user_config() {
+    async fn reserved_namespace_in_user_config_is_an_error() {
         let tmp = camino_tempfile::Utf8TempDir::new().unwrap();
         let tmpl_path = tmp.path().join("recipe.hbs");
         std::fs::write(
@@ -515,24 +564,7 @@ mod tests {
         };
 
         let mut configuration = HashMap::new();
-        configuration.insert(
-            "_".to_string(),
-            serde_yaml::Value::Mapping({
-                let mut m = serde_yaml::Mapping::new();
-                m.insert(
-                    serde_yaml::Value::String("canister".to_string()),
-                    serde_yaml::Value::Mapping({
-                        let mut inner = serde_yaml::Mapping::new();
-                        inner.insert(
-                            serde_yaml::Value::String("name".to_string()),
-                            serde_yaml::Value::String("user-override".to_string()),
-                        );
-                        inner
-                    }),
-                );
-                m
-            }),
-        );
+        configuration.insert("_".to_string(), serde_yaml::Value::Null);
 
         let recipe = Recipe {
             recipe_type: RecipeType::File(tmpl_path.to_string()),
@@ -540,20 +572,14 @@ mod tests {
             sha256: None,
         };
 
-        let (build, _sync) = hbs
+        let err = hbs
             .resolve_impl(&recipe, &recipe_context("real-name"))
             .await
-            .unwrap();
+            .unwrap_err();
 
-        match build.steps[0].clone() {
-            crate::manifest::canister::BuildStep::Script(adapter) => {
-                assert_eq!(
-                    adapter.command.as_vec()[0],
-                    "build real-name",
-                    "_ namespace must not be overridable by user configuration"
-                );
-            }
-            other => panic!("Expected Script build step, got: {other:?}"),
-        }
+        assert!(
+            matches!(err, HandlebarsError::ReservedNamespace),
+            "expected ReservedNamespace error, got: {err:?}"
+        );
     }
 }

--- a/crates/icp/src/canister/recipe/mod.rs
+++ b/crates/icp/src/canister/recipe/mod.rs
@@ -15,9 +15,13 @@ pub mod handlebars;
 /// ```yaml
 /// canister:
 ///   name: <canister_name>
+/// cli:
+///   version: <cli_version>
 /// ```
 pub struct RecipeContext {
     pub canister_name: String,
+    /// The icp-cli version string, e.g. `"0.3.0"`.
+    pub cli_version: String,
 }
 
 impl RecipeContext {
@@ -29,8 +33,12 @@ impl RecipeContext {
         let mut canister = Mapping::new();
         canister.insert("name".into(), Value::String(self.canister_name.clone()));
 
+        let mut cli = Mapping::new();
+        cli.insert("version".into(), Value::String(self.cli_version.clone()));
+
         let mut root = Mapping::new();
         root.insert("canister".into(), Value::Mapping(canister));
+        root.insert("cli".into(), Value::Mapping(cli));
 
         Value::Mapping(root)
     }

--- a/crates/icp/src/project.rs
+++ b/crates/icp/src/project.rs
@@ -266,6 +266,7 @@ pub async fn consolidate_manifest(
                 Instructions::Recipe { recipe } => {
                     let ctx = recipe::RecipeContext {
                         canister_name: m.name.clone(),
+                        cli_version: env!("CARGO_PKG_VERSION").to_string(),
                     };
                     recipe_resolver
                         .resolve(recipe, &ctx)

--- a/docs/concepts/recipes.md
+++ b/docs/concepts/recipes.md
@@ -127,8 +127,9 @@ recipe:
 | Variable | Value |
 |---|---|
 | `{{_.canister.name}}` | The canister name as defined in `icp.yaml` |
+| `{{_.cli.version}}` | The icp-cli version string, e.g. `0.3.0` |
 
-The `_` namespace is reserved and cannot be overridden by user-provided configuration.
+The `_` namespace is reserved and cannot be set in `configuration:`. Attempting to do so is an error.
 
 These injected variables are available to the Handlebars `replace` helper and all other template features, for example `{{ replace "-" "_" _.canister.name }}` produces the underscore form of the canister name needed for Rust WASM artifact filenames.
 

--- a/docs/guides/creating-recipes.md
+++ b/docs/guides/creating-recipes.md
@@ -153,8 +153,19 @@ icp-cli automatically injects variables into every recipe template under the res
 | Variable | Value |
 |---|---|
 | `{{_.canister.name}}` | The canister name as defined in `icp.yaml` |
+| `{{_.cli.version}}` | The icp-cli version string, e.g. `0.3.0` |
+
+The `_` namespace is reserved. If a user sets `_` in the `configuration:` block, icp-cli will error immediately.
 
 Use `{{_.canister.name}}` whenever a recipe needs to refer to the canister being built — this avoids requiring users to repeat the name in the `configuration:` block.
+
+Use `{{_.cli.version}}` when a recipe needs to adapt behaviour based on which version of icp-cli the developer is running:
+
+```
+{{#if (eq _.cli.version "0.3.0")}}
+  - echo "running on icp-cli 0.3.0"
+{{/if}}
+```
 
 Built-in recipe variables work with all Handlebars helpers. For example, the `replace` helper can produce the underscore form of a name required by Rust WASM artifact filenames:
 


### PR DESCRIPTION
## Summary

- **`{{_.cli.version}}`** — recipe templates can now read the running icp-cli version string (sourced from `CARGO_PKG_VERSION` at compile time), allowing recipe authors to adapt behaviour across CLI versions
- **Reserved `_` key is now a hard error** — setting `_` in a recipe's `configuration:` block previously silently discarded the user value; it now errors immediately, before any network I/O
- **Panic → proper error** — pre-existing `panic!` on invalid rendered YAML is replaced with a `ParseRenderedYaml` error variant that includes the full rendered output

## Test plan

- [ ] `cargo test -p icp --lib canister::recipe` — all 5 recipe tests pass
- [ ] `cargo clippy -p icp` — no warnings
- [ ] `cargo fmt --check` — clean
- [ ] Verify `{{_.cli.version}}` renders the correct version in a local recipe template
- [ ] Verify setting `_` in `configuration:` produces a clear error message before any fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)