### PR TITLE
feat: Include app manifest in bundles

### DIFF
--- a/crates/icp-cli/src/operations/bundle.rs
+++ b/crates/icp-cli/src/operations/bundle.rs
@@ -25,7 +25,7 @@ use icp::{
     prelude::*,
     store_artifact,
 };
-use snafu::{ResultExt, Snafu};
+use snafu::{OptionExt, ResultExt, Snafu};
 use tar::Builder;
 
 use crate::operations::build::{BuildManyError, build_many_with_progress_bar};
@@ -137,6 +137,42 @@ pub enum BundleError {
         file: String,
         source: fs::IoError,
     },
+
+    #[snafu(display("failed to read app manifest '{path}'"))]
+    ReadAppManifest { path: PathBuf, source: fs::IoError },
+
+    #[snafu(display("failed to parse app manifest '{path}'"))]
+    ParseAppManifest {
+        path: PathBuf,
+        source: serde_yaml::Error,
+    },
+
+    #[snafu(display("`screenshots` in app manifest '{path}' must be a list of file paths"))]
+    ScreenshotsNotSequence { path: PathBuf },
+
+    #[snafu(display("screenshot entries in app manifest '{path}' must be file path strings"))]
+    ScreenshotNotString { path: PathBuf },
+
+    #[snafu(display(
+        "screenshot path '{path}' resolves outside the project directory '{root}'; \
+         bundles cannot reference files outside the project"
+    ))]
+    ScreenshotEscapesProject { path: PathBuf, root: PathBuf },
+
+    #[snafu(display(
+        "screenshots {paths:?} both map to the same bundle path 'screenshots/{sanitized}'; \
+         rename one so they use distinct file names"
+    ))]
+    ScreenshotNameCollision {
+        sanitized: String,
+        paths: Vec<String>,
+    },
+
+    #[snafu(display("failed to serialize app manifest"))]
+    SerializeAppManifest { source: serde_yaml::Error },
+
+    #[snafu(display("failed to read screenshot '{path}'"))]
+    ReadScreenshot { path: PathBuf, source: fs::IoError },
 }
 
 /// In-memory bytes destined for a single tar entry.
@@ -164,6 +200,24 @@ struct InitArgsFile {
     src_path: PathBuf,
     archive_path: String,
 }
+
+/// The optional `icp_manifest.yaml` app-metadata file. We only understand its top-level
+/// `screenshots` list; everything else is preserved verbatim.
+struct AppManifest {
+    /// YAML to write at `APP_MANIFEST` in the archive. Identical to the source file unless a
+    /// screenshot path was rewritten.
+    yaml: String,
+    screenshots: Vec<ScreenshotFile>,
+}
+
+/// A screenshot referenced from `icp_manifest.yaml`, relocated under `screenshots/` in the bundle.
+struct ScreenshotFile {
+    src_path: PathBuf,
+    archive_path: String,
+}
+
+/// App-metadata manifest, included in bundles alongside the project manifest.
+const APP_MANIFEST: &str = "icp_manifest.yaml";
 
 /// Everything the canister section contributes to the archive, separate from the manifest items.
 #[derive(Default)]
@@ -206,6 +260,7 @@ pub(crate) async fn create_bundle(
 
     let (canister_items, bundle_artifacts) =
         prepare_canisters(&canisters, &*artifacts, pkg_cache).await?;
+    let app_manifest = prepare_app_manifest(project_dir, &canonical_project_dir)?;
     let networks = inline_networks(raw_manifest.networks, project_dir).await?;
     let (environments, init_args_files) = inline_environments(
         raw_manifest.environments,
@@ -226,6 +281,7 @@ pub(crate) async fn create_bundle(
         &bundle_manifest,
         &bundle_artifacts,
         &init_args_files,
+        app_manifest.as_ref(),
     )
 }
 
@@ -529,11 +585,94 @@ async fn inline_environments(
     Ok((out, init_args_files))
 }
 
+/// Load `icp_manifest.yaml` if present, rewriting its top-level `screenshots` paths to point at
+/// copies relocated under `screenshots/` in the bundle. Returns `None` when the file is absent.
+fn prepare_app_manifest(
+    project_dir: &Path,
+    canonical_project_dir: &Path,
+) -> Result<Option<AppManifest>, BundleError> {
+    let manifest_path = project_dir.join(APP_MANIFEST);
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&manifest_path).context(ReadAppManifestSnafu {
+        path: &manifest_path,
+    })?;
+    let mut doc: serde_yaml::Value = serde_yaml::from_str(&raw).context(ParseAppManifestSnafu {
+        path: &manifest_path,
+    })?;
+
+    let Some(screenshots_val) = doc.get_mut("screenshots") else {
+        // No screenshots to relocate; embed the file unchanged.
+        return Ok(Some(AppManifest {
+            yaml: raw,
+            screenshots: Vec::new(),
+        }));
+    };
+    let seq = screenshots_val
+        .as_sequence_mut()
+        .context(ScreenshotsNotSequenceSnafu {
+            path: &manifest_path,
+        })?;
+
+    let mut screenshots = Vec::with_capacity(seq.len());
+    // Maps a relocated archive name back to the canonical source and original path it came from,
+    // so identical entries are deduplicated and distinct sources that flatten to the same name
+    // are reported as a collision.
+    let mut seen: HashMap<String, (PathBuf, String)> = HashMap::new();
+    for entry in seq.iter_mut() {
+        let orig = entry
+            .as_str()
+            .context(ScreenshotNotStringSnafu {
+                path: &manifest_path,
+            })?
+            .to_owned();
+        let src = project_dir.join(&orig);
+        let canon = canonicalize(&src)?;
+        if !canon.starts_with(canonical_project_dir) {
+            return ScreenshotEscapesProjectSnafu {
+                path: src,
+                root: canonical_project_dir.to_path_buf(),
+            }
+            .fail();
+        }
+
+        // Flatten into the top-level `screenshots/` folder by basename, sanitized the same way
+        // canister name segments are.
+        let base = canon.file_name().unwrap_or(orig.as_str());
+        let sanitized = path_segment(base);
+        let archive_path = format!("screenshots/{sanitized}");
+
+        match seen.get(&sanitized) {
+            Some((prev_canon, _)) if *prev_canon == canon => {}
+            Some((_, prev_orig)) => {
+                let mut paths = vec![prev_orig.clone(), orig.clone()];
+                paths.sort();
+                return ScreenshotNameCollisionSnafu { sanitized, paths }.fail();
+            }
+            None => {
+                seen.insert(sanitized.clone(), (canon.clone(), orig.clone()));
+                screenshots.push(ScreenshotFile {
+                    src_path: canon,
+                    archive_path: archive_path.clone(),
+                });
+            }
+        }
+
+        *entry = serde_yaml::Value::String(archive_path);
+    }
+
+    let yaml = serde_yaml::to_string(&doc).context(SerializeAppManifestSnafu)?;
+    Ok(Some(AppManifest { yaml, screenshots }))
+}
+
 fn write_archive(
     output: &Path,
     bundle_manifest: &ProjectManifest,
     artifacts: &BundleArtifacts,
     init_args_files: &[InitArgsFile],
+    app_manifest: Option<&AppManifest>,
 ) -> Result<(), BundleError> {
     let manifest_yaml = serde_yaml::to_string(bundle_manifest).context(SerializeManifestSnafu)?;
 
@@ -552,6 +691,16 @@ fn write_archive(
     archive.mode(tar::HeaderMode::Deterministic);
 
     append_bytes(&mut archive, "icp.yaml", manifest_yaml.as_bytes())?;
+
+    if let Some(app) = app_manifest {
+        append_bytes(&mut archive, APP_MANIFEST, app.yaml.as_bytes())?;
+        for shot in &app.screenshots {
+            let data = fs::read(&shot.src_path).context(ReadScreenshotSnafu {
+                path: shot.src_path.clone(),
+            })?;
+            append_bytes(&mut archive, &shot.archive_path, &data)?;
+        }
+    }
 
     for nb in &artifacts.wasms {
         append_bytes(&mut archive, &nb.archive_path, &nb.bytes)?;

--- a/crates/icp-cli/src/operations/bundle.rs
+++ b/crates/icp-cli/src/operations/bundle.rs
@@ -200,7 +200,7 @@ struct InitArgsFile {
     archive_path: String,
 }
 
-/// The optional `icp_manifest.yaml` app-metadata file. We only understand its top-level
+/// The optional `icp_appmanifest.yaml` app-metadata file. We only understand its top-level
 /// `screenshots` list; all other keys are preserved semantically.
 struct AppManifest {
     /// YAML to write at `APP_MANIFEST` in the archive. The original source text is used when
@@ -209,14 +209,14 @@ struct AppManifest {
     screenshots: Vec<ScreenshotFile>,
 }
 
-/// A screenshot referenced from `icp_manifest.yaml`, relocated under `screenshots/` in the bundle.
+/// A screenshot referenced from `icp_appmanifest.yaml`, relocated under `screenshots/` in the bundle.
 struct ScreenshotFile {
     src_path: PathBuf,
     archive_path: String,
 }
 
 /// App-metadata manifest, included in bundles alongside the project manifest.
-const APP_MANIFEST: &str = "icp_manifest.yaml";
+const APP_MANIFEST: &str = "icp_appmanifest.yaml";
 
 /// Everything the canister section contributes to the archive, separate from the manifest items.
 #[derive(Default)]
@@ -554,7 +554,7 @@ async fn inline_environments(
     Ok((out, init_args_files))
 }
 
-/// Load `icp_manifest.yaml` if present, rewriting its top-level `screenshots` paths to point at
+/// Load `icp_appmanifest.yaml` if present, rewriting its top-level `screenshots` paths to point at
 /// copies relocated under `screenshots/` in the bundle. Returns `None` when the file is absent.
 fn prepare_app_manifest(
     project_dir: &Path,

--- a/crates/icp-cli/src/operations/bundle.rs
+++ b/crates/icp-cli/src/operations/bundle.rs
@@ -202,10 +202,10 @@ struct InitArgsFile {
 }
 
 /// The optional `icp_manifest.yaml` app-metadata file. We only understand its top-level
-/// `screenshots` list; everything else is preserved verbatim.
+/// `screenshots` list; all other keys are preserved semantically.
 struct AppManifest {
-    /// YAML to write at `APP_MANIFEST` in the archive. Identical to the source file unless a
-    /// screenshot path was rewritten.
+    /// YAML to write at `APP_MANIFEST` in the archive. The original source text is used when
+    /// no screenshot relocation is needed; otherwise the YAML is re-serialized (formatting/comments may change).
     yaml: String,
     screenshots: Vec<ScreenshotFile>,
 }

--- a/crates/icp-cli/tests/bundle_tests.rs
+++ b/crates/icp-cli/tests/bundle_tests.rs
@@ -680,7 +680,7 @@ fn bundle_packages_plugin_sync_steps() {
     );
 }
 
-/// An `icp_manifest.yaml` next to the project manifest must be included in the bundle, with its
+/// An `icp_appmanifest.yaml` next to the project manifest must be included in the bundle, with its
 /// top-level `screenshots` paths relocated under a top-level `screenshots/` folder and the
 /// referenced image files copied alongside. Unrelated metadata is preserved.
 #[test]
@@ -711,7 +711,7 @@ fn bundle_includes_app_manifest_screenshots() {
           - media/home.png
           - media/detail.png
     "#};
-    write_string(&project_dir.join("icp_manifest.yaml"), &app_manifest)
+    write_string(&project_dir.join("icp_appmanifest.yaml"), &app_manifest)
         .expect("failed to write app manifest");
 
     let bundle_path = project_dir.join("bundle.tar.gz");
@@ -738,10 +738,10 @@ fn bundle_includes_app_manifest_screenshots() {
             .into_owned();
 
         match path.as_str() {
-            "icp_manifest.yaml" => {
+            "icp_appmanifest.yaml" => {
                 entry
                     .read_to_string(&mut app_manifest_yaml)
-                    .expect("failed to read icp_manifest.yaml");
+                    .expect("failed to read icp_appmanifest.yaml");
             }
             "screenshots/home.png" => {
                 let mut buf = Vec::new();
@@ -817,7 +817,7 @@ fn bundle_rejects_screenshot_name_collision() {
           - a/shot.png
           - b/shot.png
     "#};
-    write_string(&project_dir.join("icp_manifest.yaml"), &app_manifest)
+    write_string(&project_dir.join("icp_appmanifest.yaml"), &app_manifest)
         .expect("failed to write app manifest");
 
     ctx.icp()
@@ -856,7 +856,7 @@ fn bundle_rejects_screenshot_outside_project() {
         screenshots:
           - ../outside.png
     "#};
-    write_string(&project_dir.join("icp_manifest.yaml"), &app_manifest)
+    write_string(&project_dir.join("icp_appmanifest.yaml"), &app_manifest)
         .expect("failed to write app manifest");
 
     ctx.icp()

--- a/crates/icp-cli/tests/bundle_tests.rs
+++ b/crates/icp-cli/tests/bundle_tests.rs
@@ -656,6 +656,193 @@ fn bundle_packages_plugin_sync_steps() {
     );
 }
 
+/// An `icp_manifest.yaml` next to the project manifest must be included in the bundle, with its
+/// top-level `screenshots` paths relocated under a top-level `screenshots/` folder and the
+/// referenced image files copied alongside. Unrelated metadata is preserved.
+#[test]
+fn bundle_includes_app_manifest_screenshots() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+    let wasm_src = ctx.make_asset("example_icp_mo.wasm");
+
+    let shots_dir = project_dir.join("media");
+    create_dir_all(&shots_dir).expect("failed to create media dir");
+    write(&shots_dir.join("home.png"), b"home-bytes").expect("failed to write home.png");
+    write(&shots_dir.join("detail.png"), b"detail-bytes").expect("failed to write detail.png");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let app_manifest = formatdoc! {r#"
+        name: My App
+        description: an app we do not parse
+        screenshots:
+          - media/home.png
+          - media/detail.png
+    "#};
+    write_string(&project_dir.join("icp_manifest.yaml"), &app_manifest)
+        .expect("failed to write app manifest");
+
+    let bundle_path = project_dir.join("bundle.tar.gz");
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["project", "bundle", "--output", bundle_path.as_str()])
+        .assert()
+        .success();
+
+    let bundle_bytes = fs::read(bundle_path.as_std_path()).expect("failed to read bundle");
+    let gz = GzDecoder::new(BufReader::new(bundle_bytes.as_slice()));
+    let mut archive = Archive::new(gz);
+
+    let mut home_bytes: Option<Vec<u8>> = None;
+    let mut detail_bytes: Option<Vec<u8>> = None;
+    let mut app_manifest_yaml = String::new();
+
+    for entry in archive.entries().expect("failed to read archive entries") {
+        let mut entry = entry.expect("failed to read archive entry");
+        let path = entry
+            .path()
+            .expect("failed to get entry path")
+            .to_string_lossy()
+            .into_owned();
+
+        match path.as_str() {
+            "icp_manifest.yaml" => {
+                entry
+                    .read_to_string(&mut app_manifest_yaml)
+                    .expect("failed to read icp_manifest.yaml");
+            }
+            "screenshots/home.png" => {
+                let mut buf = Vec::new();
+                entry
+                    .read_to_end(&mut buf)
+                    .expect("failed to read home.png");
+                home_bytes = Some(buf);
+            }
+            "screenshots/detail.png" => {
+                let mut buf = Vec::new();
+                entry
+                    .read_to_end(&mut buf)
+                    .expect("failed to read detail.png");
+                detail_bytes = Some(buf);
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        home_bytes.as_deref(),
+        Some(b"home-bytes".as_slice()),
+        "screenshots/home.png missing or wrong content"
+    );
+    assert_eq!(
+        detail_bytes.as_deref(),
+        Some(b"detail-bytes".as_slice()),
+        "screenshots/detail.png missing or wrong content"
+    );
+
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(&app_manifest_yaml).expect("app manifest yaml is invalid");
+    assert_eq!(
+        parsed["screenshots"][0].as_str(),
+        Some("screenshots/home.png")
+    );
+    assert_eq!(
+        parsed["screenshots"][1].as_str(),
+        Some("screenshots/detail.png")
+    );
+    // Unrelated metadata must survive the rewrite.
+    assert_eq!(parsed["name"].as_str(), Some("My App"));
+    assert_eq!(
+        parsed["description"].as_str(),
+        Some("an app we do not parse")
+    );
+}
+
+/// Two screenshots whose basenames collide under the flat `screenshots/` folder must be rejected.
+#[test]
+fn bundle_rejects_screenshot_name_collision() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+    let wasm_src = ctx.make_asset("example_icp_mo.wasm");
+
+    create_dir_all(&project_dir.join("a")).expect("failed to create dir a");
+    create_dir_all(&project_dir.join("b")).expect("failed to create dir b");
+    write(&project_dir.join("a/shot.png"), b"a").expect("failed to write a/shot.png");
+    write(&project_dir.join("b/shot.png"), b"b").expect("failed to write b/shot.png");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let app_manifest = formatdoc! {r#"
+        screenshots:
+          - a/shot.png
+          - b/shot.png
+    "#};
+    write_string(&project_dir.join("icp_manifest.yaml"), &app_manifest)
+        .expect("failed to write app manifest");
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["project", "bundle", "--output", "bundle.tar.gz"])
+        .assert()
+        .failure()
+        .stderr(contains("same bundle path").and(contains("shot.png")));
+}
+
+/// A screenshot path resolving outside the project directory must be rejected, like other bundle
+/// sources.
+#[test]
+fn bundle_rejects_screenshot_outside_project() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+    let wasm_src = ctx.make_asset("example_icp_mo.wasm");
+
+    let outside = project_dir
+        .parent()
+        .expect("project dir has no parent")
+        .join("outside.png");
+    write(&outside, b"secret").expect("failed to write outside screenshot");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let app_manifest = formatdoc! {r#"
+        screenshots:
+          - ../outside.png
+    "#};
+    write_string(&project_dir.join("icp_manifest.yaml"), &app_manifest)
+        .expect("failed to write app manifest");
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["project", "bundle", "--output", "bundle.tar.gz"])
+        .assert()
+        .failure()
+        .stderr(contains("outside the project directory"));
+}
+
 /// Projects with script sync steps must be rejected with a clear error.
 #[test]
 fn bundle_rejects_script_sync_step() {


### PR DESCRIPTION
This PR adds app manifests to bundles. icp-cli assumes nothing about app manifests besides the fact that they may have a `screenshots` key, naming files that also should be added to the bundle. They are rewritten to go under a `screenshots` folder.