### PR TITLE
fix: reconcile project bundling with assets sync step removal

### DIFF
--- a/crates/icp-cli/src/operations/bundle.rs
+++ b/crates/icp-cli/src/operations/bundle.rs
@@ -16,9 +16,8 @@ use icp::{
     manifest::{
         ArgsFormat, BuildStep, BuildSteps, CanisterManifest, EnvironmentManifest, Instructions,
         Item, LoadManifestFromPathError, ManagedMode, ManifestInitArgs, Mode, NetworkManifest,
-        PROJECT_MANIFEST, ProjectManifest, SyncStep, SyncSteps,
-        assets::DirField,
-        load_manifest_from_path, plugin, prebuilt,
+        PROJECT_MANIFEST, ProjectManifest, SyncStep, SyncSteps, load_manifest_from_path, plugin,
+        prebuilt,
         prebuilt::{LocalSource, SourceField},
     },
     package::PackageCache,
@@ -169,7 +168,6 @@ struct InitArgsFile {
 #[derive(Default)]
 struct BundleArtifacts {
     wasms: Vec<NamedBytes>,
-    asset_dirs: Vec<DirEntry>,
     plugin_wasms: Vec<NamedBytes>,
     plugin_dirs: Vec<DirEntry>,
     plugin_files: Vec<PluginFile>,
@@ -275,9 +273,6 @@ async fn prepare_canister(
                 }
                 .fail();
             }
-            SyncStep::Assets(adapter) => {
-                bundle_sync_steps.push(prepare_asset_step(adapter, canister_path, &path_name, out));
-            }
             SyncStep::Plugin(adapter) => {
                 let idx = plugin_idx;
                 plugin_idx += 1;
@@ -322,32 +317,6 @@ async fn prepare_canister(
             sync,
         },
     }))
-}
-
-fn prepare_asset_step(
-    adapter: &icp::manifest::assets::Adapter,
-    canister_path: &Path,
-    path_name: &str,
-    out: &mut BundleArtifacts,
-) -> SyncStep {
-    let dirs = adapter.dir.as_vec();
-    let mut prefixed: Vec<String> = Vec::with_capacity(dirs.len());
-    for d in &dirs {
-        let archive_prefix = format!("canisters/{path_name}/{}", normalize_archive_dir(d));
-        out.asset_dirs.push(DirEntry {
-            src_path: canister_path.join(d),
-            archive_prefix: archive_prefix.clone(),
-        });
-        prefixed.push(archive_prefix);
-    }
-
-    let new_dir = if prefixed.len() == 1 {
-        DirField::Dir(prefixed.into_iter().next().unwrap())
-    } else {
-        DirField::Dirs(prefixed)
-    };
-
-    SyncStep::Assets(icp::manifest::assets::Adapter { dir: new_dir })
 }
 
 async fn prepare_plugin_step(
@@ -564,10 +533,6 @@ fn write_archive(
         append_bytes(&mut archive, &entry.archive_path, &data)?;
     }
 
-    for d in &artifacts.asset_dirs {
-        append_dir(&mut archive, &d.src_path, &d.archive_prefix)?;
-    }
-
     for nb in &artifacts.plugin_wasms {
         append_bytes(&mut archive, &nb.archive_path, &nb.bytes)?;
     }
@@ -667,17 +632,6 @@ fn validate_source_paths(
         for step in &canister.sync.steps {
             match step {
                 SyncStep::Script(_) => {}
-                SyncStep::Assets(adapter) => {
-                    for d in adapter.dir.as_vec() {
-                        let src = canister_path.join(&d);
-                        let canon = canonicalize_within_project(
-                            &src,
-                            canonical_project_dir,
-                            &canister.name,
-                        )?;
-                        canonical_sync_dirs.push(canon);
-                    }
-                }
                 SyncStep::Plugin(adapter) => {
                     if let Some(dirs) = &adapter.dirs {
                         for d in dirs {

--- a/crates/icp-cli/tests/bundle_tests.rs
+++ b/crates/icp-cli/tests/bundle_tests.rs
@@ -376,9 +376,9 @@ fn bundle_sanitizes_canister_name_for_paths() {
     );
 }
 
-/// A plugin sync `dir` that contains `..` components but still resolves inside the project
-/// must be accepted, and the `..` components must be lexically resolved before the path is
-/// written into the archive or the rewritten manifest.
+/// A plugin sync `dirs` entry that contains `..` components but still resolves inside the
+/// project must be accepted, and the `..` components must be lexically resolved before the path
+/// is written into the archive or the rewritten manifest.
 #[test]
 fn bundle_normalizes_dotdot_within_project() {
     let ctx = TestContext::new();
@@ -479,8 +479,8 @@ fn bundle_normalizes_dotdot_within_project() {
     );
 }
 
-/// A plugin sync step whose `dir` resolves *outside* the project directory must be rejected.
-/// Bundles can only reference files inside the project so the produced archive is portable.
+/// A plugin sync step whose `dirs` entry resolves *outside* the project directory must be
+/// rejected. Bundles can only reference files inside the project so the produced archive is portable.
 #[test]
 fn bundle_rejects_source_outside_project() {
     let ctx = TestContext::new();

--- a/crates/icp-cli/tests/bundle_tests.rs
+++ b/crates/icp-cli/tests/bundle_tests.rs
@@ -6,9 +6,8 @@ use std::{
 use camino::Utf8Component;
 use flate2::bufread::GzDecoder;
 use icp::{
-    fs::{create_dir_all, json, write, write_string},
+    fs::{create_dir_all, write, write_string},
     prelude::*,
-    store_id::IdMapping,
 };
 use indoc::formatdoc;
 use predicates::{
@@ -19,13 +18,15 @@ use predicates::{
 use sha2::{Digest, Sha256};
 use tar::Archive;
 
-use crate::common::{ENVIRONMENT_RANDOM_PORT, NETWORK_RANDOM_PORT, TestContext, clients};
+use crate::common::{
+    ENVIRONMENT_RANDOM_PORT, NETWORK_RANDOM_PORT, TestContext, build_sync_plugin_example, clients,
+};
 
 mod common;
 
-/// Bundle a standard frontend-backend project: a script-built backend canister and an
-/// asset-canister-recipe frontend canister with an assets sync step.
-/// Verify archive structure, manifest content, and that the bundle deploys successfully.
+/// Bundle a standard multi-canister project: a script-built backend canister and a
+/// canister with a plugin sync step that seeds data on deploy. Verify archive structure,
+/// manifest content, and that the extracted bundle deploys and runs the bundled plugin.
 #[tokio::test]
 async fn bundle_and_deploy() {
     let ctx = TestContext::new();
@@ -33,12 +34,17 @@ async fn bundle_and_deploy() {
     let project_dir = ctx.create_project_dir("icp");
 
     // A small WASM to serve as the pre-built artifact for the backend.
-    let wasm_src = ctx.make_asset("example_icp_mo.wasm");
+    let backend_wasm = ctx.make_asset("example_icp_mo.wasm");
 
-    // Create asset directory for the frontend canister.
-    let asset_dir = project_dir.join("www");
-    create_dir_all(&asset_dir).expect("failed to create asset dir");
-    write_string(&asset_dir.join("index.html"), "hello").expect("failed to write asset file");
+    // The registry canister and its sync plugin come from the example project: on deploy the
+    // plugin reads the preopened `seed-data` dir and registers each file with the canister.
+    let (registry_wasm, plugin_wasm) = build_sync_plugin_example();
+
+    let seed_data = project_dir.join("seed-data");
+    create_dir_all(&seed_data).expect("failed to create seed-data");
+    write_string(&seed_data.join("fruit-01.txt"), "apple").expect("failed to write fruit-01.txt");
+    write_string(&seed_data.join("fruit-02.txt"), "banana").expect("failed to write fruit-02.txt");
+    write_string(&seed_data.join("fruit-03.txt"), "cherry").expect("failed to write fruit-03.txt");
 
     let pm = formatdoc! {r#"
         canisters:
@@ -46,13 +52,19 @@ async fn bundle_and_deploy() {
             build:
               steps:
                 - type: script
-                  command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
+                  command: cp '{backend_wasm}' "$ICP_WASM_OUTPUT_PATH"
 
-          - name: frontend
-            recipe:
-              type: "@dfinity/asset-canister@v2.1.0"
-              configuration:
-                dir: www
+          - name: registry
+            build:
+              steps:
+                - type: script
+                  command: cp '{registry_wasm}' "$ICP_WASM_OUTPUT_PATH"
+            sync:
+              steps:
+                - type: plugin
+                  path: {plugin_wasm}
+                  dirs:
+                    - seed-data
 
         {NETWORK_RANDOM_PORT}
         {ENVIRONMENT_RANDOM_PORT}
@@ -77,8 +89,9 @@ async fn bundle_and_deploy() {
 
     let mut found_manifest = false;
     let mut found_backend_wasm = false;
-    let mut found_frontend_wasm = false;
-    let mut found_asset = false;
+    let mut found_registry_wasm = false;
+    let mut found_plugin_wasm = false;
+    let mut found_seed_data = false;
     let mut manifest_yaml = String::new();
 
     for entry in archive.entries().expect("failed to read archive entries") {
@@ -99,11 +112,14 @@ async fn bundle_and_deploy() {
             "canisters/backend.wasm" => {
                 found_backend_wasm = true;
             }
-            "canisters/frontend.wasm" => {
-                found_frontend_wasm = true;
+            "canisters/registry.wasm" => {
+                found_registry_wasm = true;
             }
-            p if p.starts_with("canisters/frontend/www/") => {
-                found_asset = true;
+            "plugins/registry/0.wasm" => {
+                found_plugin_wasm = true;
+            }
+            p if p.starts_with("plugins/registry/0/dirs/seed-data/") => {
+                found_seed_data = true;
             }
             _ => {}
         }
@@ -115,15 +131,19 @@ async fn bundle_and_deploy() {
         "canisters/backend.wasm not found in bundle"
     );
     assert!(
-        found_frontend_wasm,
-        "canisters/frontend.wasm not found in bundle"
+        found_registry_wasm,
+        "canisters/registry.wasm not found in bundle"
     );
     assert!(
-        found_asset,
-        "asset file not found under canisters/frontend/www/ in bundle"
+        found_plugin_wasm,
+        "plugins/registry/0.wasm not found in bundle"
+    );
+    assert!(
+        found_seed_data,
+        "seed-data files not found under plugins/registry/0/dirs/seed-data/ in bundle"
     );
 
-    // Manifest must contain pre-built steps and no script or recipe steps.
+    // Manifest must convert build steps to pre-built and must not contain script or recipe steps.
     assert!(
         manifest_yaml.contains("pre-built"),
         "bundle manifest should have pre-built build steps"
@@ -154,13 +174,10 @@ async fn bundle_and_deploy() {
     let _g = ctx.start_network_in(&bundle_dir, "random-network").await;
     ctx.ping_until_healthy(&bundle_dir, "random-network");
 
-    let network_port = ctx
-        .wait_for_network_descriptor(&bundle_dir, "random-network")
-        .gateway_port;
-
     clients::icp(&ctx, &bundle_dir, Some("random-environment".to_string()))
         .mint_cycles(10 * TRILLION);
 
+    // deploy also runs the bundled plugin sync step, which seeds the registry canister.
     ctx.icp()
         .current_dir(&bundle_dir)
         .args(["deploy", "--environment", "random-environment"])
@@ -183,30 +200,26 @@ async fn bundle_and_deploy() {
         .success()
         .stdout(eq("(\"Hello, world!\")").trim());
 
-    // Verify the frontend canister serves the bundled asset.
-    let id_mapping: IdMapping = json::load(
-        &bundle_dir
-            .join(".icp")
-            .join("cache")
-            .join("mappings")
-            .join("random-environment.ids.json"),
-    )
-    .expect("failed to read ID mapping");
-
-    let frontend_cid = id_mapping
-        .get("frontend")
-        .expect("frontend canister ID not found");
-
-    let resp = reqwest::get(format!(
-        "http://localhost:{network_port}/?canisterId={frontend_cid}"
-    ))
-    .await
-    .expect("request to frontend canister failed");
-
-    assert_eq!(
-        resp.text().await.expect("failed to read response body"),
-        "hello"
-    );
+    // Verify the bundled plugin ran during deploy and registered all three seed files.
+    ctx.icp()
+        .current_dir(&bundle_dir)
+        .args([
+            "canister",
+            "call",
+            "registry",
+            "show",
+            "()",
+            "--query",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            contains("apple")
+                .and(contains("banana"))
+                .and(contains("cherry")),
+        );
 }
 
 /// Bundle a canister whose environment override uses an external init_args file.
@@ -363,7 +376,7 @@ fn bundle_sanitizes_canister_name_for_paths() {
     );
 }
 
-/// An asset sync `dir` that contains `..` components but still resolves inside the project
+/// A plugin sync `dir` that contains `..` components but still resolves inside the project
 /// must be accepted, and the `..` components must be lexically resolved before the path is
 /// written into the archive or the rewritten manifest.
 #[test]
@@ -372,7 +385,11 @@ fn bundle_normalizes_dotdot_within_project() {
     let project_dir = ctx.create_project_dir("icp");
     let wasm_src = ctx.make_asset("example_icp_mo.wasm");
 
-    // Assets live inside the project at ./shared-assets. The canister references them via
+    // Bundling only reads and repackages the plugin wasm bytes, so any non-empty content works.
+    write(&project_dir.join("plugin.wasm"), b"\x00asm\x01\x00\x00\x00")
+        .expect("failed to write plugin wasm");
+
+    // Preopened dir lives inside the project at ./shared-assets. The canister references it via
     // a path that goes `tmp/..` and resolves to the same location — proof that `..` is
     // handled lexically and doesn't have to point outside.
     let assets_dir = project_dir.join("shared-assets");
@@ -389,8 +406,10 @@ fn bundle_normalizes_dotdot_within_project() {
                   command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
             sync:
               steps:
-                - type: assets
-                  dir: tmp/../shared-assets
+                - type: plugin
+                  path: plugin.wasm
+                  dirs:
+                    - tmp/../shared-assets
     "#};
 
     write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
@@ -406,7 +425,7 @@ fn bundle_normalizes_dotdot_within_project() {
     let gz = GzDecoder::new(BufReader::new(bundle_bytes.as_slice()));
     let mut archive = Archive::new(gz);
 
-    let mut found_asset = false;
+    let mut found_dir = false;
     let mut manifest_yaml = String::new();
 
     for entry in archive.entries().expect("failed to read archive entries") {
@@ -432,26 +451,26 @@ fn bundle_normalizes_dotdot_within_project() {
                     .read_to_string(&mut manifest_yaml)
                     .expect("failed to read icp.yaml");
             }
-            p if p.starts_with("canisters/my-canister/shared-assets/") => {
-                found_asset = true;
+            p if p.starts_with("plugins/my-canister/0/dirs/shared-assets/") => {
+                found_dir = true;
             }
             _ => {}
         }
     }
 
     assert!(
-        found_asset,
-        "asset not found under canisters/my-canister/shared-assets/ in bundle"
+        found_dir,
+        "preopened dir not found under plugins/my-canister/0/dirs/shared-assets/ in bundle"
     );
 
     // Parse the rewritten manifest and inspect the actual sync dir field rather than
     // substring-matching the whole YAML.
     let parsed: serde_yaml::Value =
         serde_yaml::from_str(&manifest_yaml).expect("manifest yaml is invalid");
-    let dir = parsed["canisters"][0]["sync"]["steps"][0]["dir"]
+    let dir = parsed["canisters"][0]["sync"]["steps"][0]["dirs"][0]
         .as_str()
-        .expect("expected sync step 0 to have a string `dir` field");
-    assert_eq!(dir, "canisters/my-canister/shared-assets");
+        .expect("expected sync step 0 to have a string `dirs[0]` field");
+    assert_eq!(dir, "plugins/my-canister/0/dirs/shared-assets");
     assert!(
         !Path::new(dir)
             .components()
@@ -460,7 +479,7 @@ fn bundle_normalizes_dotdot_within_project() {
     );
 }
 
-/// An asset sync step whose `dir` resolves *outside* the project directory must be rejected.
+/// A plugin sync step whose `dir` resolves *outside* the project directory must be rejected.
 /// Bundles can only reference files inside the project so the produced archive is portable.
 #[test]
 fn bundle_rejects_source_outside_project() {
@@ -468,7 +487,10 @@ fn bundle_rejects_source_outside_project() {
     let project_dir = ctx.create_project_dir("icp");
     let wasm_src = ctx.make_asset("example_icp_mo.wasm");
 
-    // Assets live one directory above the project — outside its tree.
+    write(&project_dir.join("plugin.wasm"), b"\x00asm\x01\x00\x00\x00")
+        .expect("failed to write plugin wasm");
+
+    // Preopened dir lives one directory above the project — outside its tree.
     let assets_dir = project_dir
         .parent()
         .expect("project dir has no parent")
@@ -485,8 +507,10 @@ fn bundle_rejects_source_outside_project() {
                   command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
             sync:
               steps:
-                - type: assets
-                  dir: ../shared-assets
+                - type: plugin
+                  path: plugin.wasm
+                  dirs:
+                    - ../shared-assets
     "#};
 
     write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
@@ -727,6 +751,9 @@ fn bundle_rejects_output_inside_synced_dir() {
     let project_dir = ctx.create_project_dir("icp");
     let wasm_src = ctx.make_asset("example_icp_mo.wasm");
 
+    write(&project_dir.join("plugin.wasm"), b"\x00asm\x01\x00\x00\x00")
+        .expect("failed to write plugin wasm");
+
     let asset_dir = project_dir.join("www");
     create_dir_all(&asset_dir).expect("failed to create asset dir");
     write_string(&asset_dir.join("index.html"), "hello").expect("failed to write asset file");
@@ -740,8 +767,10 @@ fn bundle_rejects_output_inside_synced_dir() {
                   command: cp '{wasm_src}' "$ICP_WASM_OUTPUT_PATH"
             sync:
               steps:
-                - type: assets
-                  dir: www
+                - type: plugin
+                  path: plugin.wasm
+                  dirs:
+                    - www
     "#};
 
     write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");

--- a/crates/icp-cli/tests/common/mod.rs
+++ b/crates/icp-cli/tests/common/mod.rs
@@ -40,6 +40,56 @@ environments:
     network: docker-engine-network
 "#;
 
+/// Compiles the canister and plugin from `examples/icp-sync-plugin/` and returns
+/// (canister_wasm_path, plugin_wasm_path). Cargo caches the build so subsequent
+/// test runs are fast when sources haven't changed.
+pub(crate) fn build_sync_plugin_example() -> (camino::Utf8PathBuf, camino::Utf8PathBuf) {
+    let example_dir = camino::Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/icp-sync-plugin");
+    // Use CARGO env var when available (set by cargo test), fall back to PATH lookup.
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
+    let status = Command::new(&cargo)
+        .args([
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--release",
+            "-p",
+            "canister",
+        ])
+        .current_dir(&example_dir)
+        .status()
+        .expect("failed to spawn cargo build for canister");
+    assert!(
+        status.success(),
+        "cargo build --target wasm32-unknown-unknown failed"
+    );
+
+    let status = Command::new(&cargo)
+        .args([
+            "build",
+            "--target",
+            "wasm32-wasip2",
+            "--release",
+            "-p",
+            "plugin",
+        ])
+        .current_dir(&example_dir)
+        .status()
+        .expect("failed to spawn cargo build for plugin");
+
+    assert!(
+        status.success(),
+        "cargo build --target wasm32-wasip2 failed"
+    );
+
+    (
+        example_dir.join("target/wasm32-unknown-unknown/release/canister.wasm"),
+        example_dir.join("target/wasm32-wasip2/release/plugin.wasm"),
+    )
+}
+
 // Spawns a test server that expects a single request and responds with a 200 status code and the given body
 pub(crate) fn spawn_test_server(method: &str, path: &str, body: &[u8]) -> httptest::Server {
     // Run the server

--- a/crates/icp-cli/tests/sync_tests.rs
+++ b/crates/icp-cli/tests/sync_tests.rs
@@ -9,7 +9,9 @@ use predicates::{
     str::{PredicateStrExt, contains},
 };
 
-use crate::common::{ENVIRONMENT_RANDOM_PORT, NETWORK_RANDOM_PORT, TestContext, clients};
+use crate::common::{
+    ENVIRONMENT_RANDOM_PORT, NETWORK_RANDOM_PORT, TestContext, build_sync_plugin_example, clients,
+};
 
 mod common;
 
@@ -310,56 +312,6 @@ async fn sync_multiple_canisters() {
         .stderr(contains("DEBUG icp::progress: syncing canister-a"))
         .stderr(contains("DEBUG icp::progress: syncing canister-b"))
         .stderr(contains("DEBUG icp::progress: syncing canister-c").not());
-}
-
-/// Compiles the canister and plugin from `examples/icp-sync-plugin/` and returns
-/// (canister_wasm_path, plugin_wasm_path). Cargo caches the build so subsequent
-/// test runs are fast when sources haven't changed.
-fn build_sync_plugin_example() -> (PathBuf, PathBuf) {
-    let example_dir =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../examples/icp-sync-plugin");
-    // Use CARGO env var when available (set by cargo test), fall back to PATH lookup.
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-
-    let status = std::process::Command::new(&cargo)
-        .args([
-            "build",
-            "--target",
-            "wasm32-unknown-unknown",
-            "--release",
-            "-p",
-            "canister",
-        ])
-        .current_dir(&example_dir)
-        .status()
-        .expect("failed to spawn cargo build for canister");
-    assert!(
-        status.success(),
-        "cargo build --target wasm32-unknown-unknown failed"
-    );
-
-    let status = std::process::Command::new(&cargo)
-        .args([
-            "build",
-            "--target",
-            "wasm32-wasip2",
-            "--release",
-            "-p",
-            "plugin",
-        ])
-        .current_dir(&example_dir)
-        .status()
-        .expect("failed to spawn cargo build for plugin");
-
-    assert!(
-        status.success(),
-        "cargo build --target wasm32-wasip2 failed"
-    );
-
-    (
-        example_dir.join("target/wasm32-unknown-unknown/release/canister.wasm"),
-        example_dir.join("target/wasm32-wasip2/release/plugin.wasm"),
-    )
 }
 
 #[tokio::test]

--- a/crates/icp/src/manifest/mod.rs
+++ b/crates/icp/src/manifest/mod.rs
@@ -16,7 +16,6 @@ pub(crate) mod recipe;
 pub(crate) mod serde_helpers;
 
 pub use {
-    adapter::assets,
     adapter::plugin,
     adapter::prebuilt,
     canister::{


### PR DESCRIPTION
## Problem

CI on `main` is red. The merge of #530 (project bundling) did not reconcile with #582 (`feat(sync)!: remove `assets` sync step type`), which had merged just before it. #530's branch predated #582, so it still referenced the deleted `adapter::assets` module and `SyncStep::Assets` variant. The result is a `main` that does not compile:

```
error[E0432]: unresolved import `adapter::assets`
  --> crates/icp/src/manifest/mod.rs:19:5
```

This single compile error caused the **checks**, **Test**, and **Validate Examples** jobs to fail. The `bundle_tests` integration suite would additionally fail at runtime, since four of its tests drive the now-rejected `type: assets` step.

## Fix

Mirror #582's removal in the bundle path:

- Drop the stale `adapter::assets` re-export in `manifest/mod.rs`.
- Remove asset-step handling from `bundle.rs` (the `assets::DirField` import, the `SyncStep::Assets` match arms, `prepare_asset_step`, the `asset_dirs` field and its archive-write loop). `type: assets` no longer deserializes, so this code was unreachable.
- Convert the four asset-based bundle tests to plugin sync steps, which the bundle code already handles. `bundle_and_deploy` now uses the local example sync plugin (proven end-to-end by `sync_plugin_registers_seed_data`) instead of the retired `@dfinity/asset-canister@v2.1.0` recipe — `v2.1.0` emits the removed step, and the recipe's deploy+serve path isn't exercised in CI (validate-examples only runs `project show`).
- Hoist `build_sync_plugin_example` into the shared test `common` module so `sync_tests` and `bundle_tests` share it.

## Verification (local)

- `cargo build --workspace` and `cargo test --workspace --no-run` with `RUSTFLAGS="-D warnings"` ✅
- `cargo clippy --workspace --all-targets` ✅ / `cargo fmt --all --check` ✅
- `cargo test --workspace --lib --bins` ✅
- `cargo test --test bundle_tests` — all 10 pass, including `bundle_and_deploy` end-to-end (deploy from extracted bundle; bundled plugin runs and seeds the canister) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)