### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+# v0.3.0
+
 * feat: `icp identity link web` now lets you sign in with web-based identities, especially Internet Identity. You can use your NNS-UI or Oisy principals locally with `--app nns.ic0.app` or `--app oisy.com`. When the session expires, sign in again with `icp identity reauth`.
 * BREAKING: removed the `assets` sync step type (`type: assets`). Asset uploading is no longer built into icp-cli — use a `script` or `plugin` sync step instead (for example, a recipe that provides a sync plugin). A manifest that still uses `type: assets` now fails to load with a message explaining the change.
 * feat: Recipe templates can now use `{{_.canister.name}}` to reference the canister's name from `icp.yaml` without repeating it in the `configuration:` block. The `_` namespace is reserved and cannot be overridden by user-provided configuration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6366,7 +6366,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.2.7"
+version = "0.3.0"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.3.0`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.3.0`

### Review checklist
- [ ] CI passes
- [ ] Changelog entries look correct
- [ ] Version number is correct
