### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+# v0.3.1
+
 * fix: Account seeding in new networks is now done via transfer instead of mint. This should eliminate minting ratelimit errors for users with a lot of local identities.
 
 # v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6366,7 +6366,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.3.0"
+version = "0.3.1"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.3.1`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.3.1`

### Review checklist
- [ ] CI passes
- [ ] Changelog entries look correct
- [ ] Version number is correct
