### PR TITLE
feat: add `--candid` flag to `icp canister call`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+* feat: `icp canister call` now accepts `--candid <PATH>` to load the canister's Candid interface from a local `.did` file instead of fetching it from the network. The supplied interface drives method selection, argument building, and response decoding.
+
 # v0.3.1
 
 * fix: Account seeding in new networks is now done via transfer instead of mint. This should eliminate minting ratelimit errors for users with a lot of local identities.

--- a/crates/icp-cli/src/commands/canister/call.rs
+++ b/crates/icp-cli/src/commands/canister/call.rs
@@ -58,6 +58,14 @@ pub(crate) struct CallArgs {
     #[arg(long, default_value = "candid")]
     pub(crate) args_format: ArgsFormat,
 
+    /// Path to a Candid (`.did`) file describing the canister's interface.
+    ///
+    /// When set, this interface is used to assist method selection, build
+    /// arguments, and decode the response, instead of fetching the canister's
+    /// Candid interface from the network.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) candid: Option<PathBuf>,
+
     /// Principal of a proxy canister to route the call through.
     ///
     /// When specified, instead of calling the target canister directly,
@@ -106,7 +114,10 @@ pub(crate) async fn exec(ctx: &Context, args: &CallArgs) -> Result<(), anyhow::E
         )
         .await?;
 
-    let candid_types = get_candid_type(&agent, cid).await;
+    let candid_types = match &args.candid {
+        Some(path) => Some(load_candid_from_file(path)?),
+        None => get_candid_type(&agent, cid).await,
+    };
 
     let method = if let Some(method) = &args.method {
         method.clone()
@@ -362,6 +373,23 @@ async fn get_candid_type(agent: &Agent, canister_id: Principal) -> Option<Canist
     let (type_env, ty) = candid_source.load().ok()?;
     let actor = ty?;
     Some(CanisterInterface {
+        env: type_env,
+        ty: actor,
+    })
+}
+
+/// Loads a Candid interface from a local `.did` file.
+///
+/// Unlike [`get_candid_type`], failures are surfaced to the caller because the
+/// user explicitly asked for this file to be used.
+fn load_candid_from_file(path: &Path) -> Result<CanisterInterface, anyhow::Error> {
+    let candid_source = CandidSource::File(path.as_std_path());
+    let (type_env, ty) = candid_source
+        .load()
+        .with_context(|| format!("failed to load Candid interface from {path}"))?;
+    let actor =
+        ty.ok_or_else(|| anyhow!("Candid file {path} does not declare a service interface"))?;
+    Ok(CanisterInterface {
         env: type_env,
         ty: actor,
     })

--- a/crates/icp-cli/tests/canister_call_tests.rs
+++ b/crates/icp-cli/tests/canister_call_tests.rs
@@ -210,6 +210,120 @@ async fn canister_call_with_arguments_from_file() {
 }
 
 #[tokio::test]
+async fn canister_call_with_candid_file() {
+    let ctx = TestContext::new();
+
+    // Setup project
+    let project_dir = ctx.create_project_dir("icp");
+
+    // Use vendored WASM
+    let wasm = ctx.make_asset("example_icp_mo.wasm");
+
+    // Project manifest
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm}' "$ICP_WASM_OUTPUT_PATH"
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    // A Candid interface describing the canister's `greet` method.
+    write_string(
+        &project_dir.join("service.did"),
+        r#"service : { "greet" : (text) -> (text) query }"#,
+    )
+    .expect("failed to write candid file");
+
+    // Start network
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    // Deploy canister
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "deploy",
+            "my-canister",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+
+    // Calling with a local Candid file uses that interface instead of fetching
+    // it from the network. The typed decode recovers the expected response.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "--candid",
+            "service.did",
+            "my-canister",
+            "greet",
+            "(\"world\")",
+        ])
+        .assert()
+        .success()
+        .stdout(eq("(\"Hello, world!\")").trim());
+
+    // The supplied interface — not the network's — drives method typing.
+    // Declaring `greet` as an update method makes `--query` reject the call,
+    // even though the canister actually exposes `greet` as a query. This proves
+    // the local file overrides what the network would report.
+    write_string(
+        &project_dir.join("update.did"),
+        r#"service : { "greet" : (text) -> (text) }"#,
+    )
+    .expect("failed to write candid file");
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "--query",
+            "--candid",
+            "update.did",
+            "my-canister",
+            "greet",
+            "(\"world\")",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("update method"));
+
+    // A missing or unparsable file is surfaced as an error rather than silently
+    // falling back to the network.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "--candid",
+            "does-not-exist.did",
+            "my-canister",
+            "greet",
+            "(\"world\")",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("failed to load Candid interface"));
+}
+
+#[tokio::test]
 async fn canister_call_through_proxy() {
     let ctx = TestContext::new();
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -178,6 +178,9 @@ Make a canister call
   - `bin`:
     Raw binary (only valid for file references)
 
+* `--candid <PATH>` — Path to a Candid (`.did`) file describing the canister's interface.
+
+   When set, this interface is used to assist method selection, build arguments, and decode the response, instead of fetching the canister's Candid interface from the network.
 * `--proxy <PROXY>` — Principal of a proxy canister to route the call through.
 
    When specified, instead of calling the target canister directly, the call will be sent to the proxy canister's `proxy` method, which forwards it to the target canister.


### PR DESCRIPTION
Adds an optional `--candid <PATH>` argument to `icp canister call` that loads the canister's Candid interface from a local `.did` file instead of fetching it from the network.

The supplied interface drives method selection, argument building, and response decoding. It also resolves relative `import`s in the `.did` (uses `CandidSource::File`).

Unlike the best-effort network fetch — which silently returns `None` on failure — errors loading a user-supplied file (missing, unparsable, or missing a `service` declaration) are surfaced to the user, since they explicitly asked for it.

## Example

```bash
icp canister call my-canister greet '("world")' --candid ./service.did
```

`--candid` only replaces the *interface*; the call still goes to the canister on the selected network, and it composes with `--query`, `--proxy`, `--args-file`, and `--output` as before.

## Changes

- `crates/icp-cli/src/commands/canister/call.rs`: new `--candid` arg and `load_candid_from_file`.
- `crates/icp-cli/tests/canister_call_tests.rs`: new `canister_call_with_candid_file` test covering a successful call, proof the file overrides the network (declaring `greet` as update makes `--query` reject a call the network would allow), and the missing-file error path.
- `docs/reference/cli.md`: regenerated.
- `CHANGELOG.md`: `feat` entry under Unreleased.

Ref: SDK-2747

🤖 Generated with [Claude Code](https://claude.com/claude-code)