### PR TITLE
ci: speed up Windows integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,16 @@ env:
   CURL_HOME: .
   # Disable incremental compilation
   CARGO_INCREMENTAL: 0
+  # Reduce debug info in CI builds: smaller object files mean much faster
+  # linking (the dominant cost on Windows MSVC) and smaller caches.
+  # line-tables-only keeps file:line numbers in backtraces.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  # Link with LLVM's lld-link instead of the slow MSVC link.exe. LLVM is
+  # preinstalled at C:\Program Files\LLVM on the windows-2025 image. This is
+  # only consumed when building the windows-msvc target, so it is a no-op on
+  # Linux/macOS, and being scoped to this workflow it does not affect the
+  # release/dist (thin-LTO) build, which keeps the default linker.
+  CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: "C:/Program Files/LLVM/bin/lld-link.exe"
   # These variables should be shared with WSL
   WSLENV: CARGO_INCREMENTAL:CURL_HOME/p:CARGO_NET_RETRY:GITHUB_ENV/p:GITHUB_OUTPUT/p
 
@@ -69,6 +79,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Defender real-time scanning of every object/rlib it writes slows
+      # file-heavy Rust builds and cache extraction considerably on Windows.
+      - name: Exclude build dirs from Windows Defender
+        if: ${{ contains(matrix.os, 'windows') }}
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath `
+            "$env:GITHUB_WORKSPACE", `
+            "$env:USERPROFILE\.cargo", `
+            "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
+
       - name: Setup image (Linux)
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: ./.github/scripts/provision-linux-build.sh
@@ -98,6 +119,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Defender real-time scanning of every object/rlib it writes slows
+      # file-heavy Rust builds and cache extraction considerably on Windows.
+      - name: Exclude build dirs from Windows Defender
+        if: ${{ contains(matrix.os, 'windows') }}
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath `
+            "$env:GITHUB_WORKSPACE", `
+            "$env:USERPROFILE\.cargo", `
+            "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
 
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:


### PR DESCRIPTION
## Problem

The Windows `test` jobs spend ~10 min compiling in the "Run tests" step while Ubuntu takes 1–2 min — and it's been this way regardless of PR. The Rust cache *is* working, but it only stores third-party **dependency** artifacts. By design `Swatinem/rust-cache` strips workspace crates from `target/` before saving (`cache-workspace-crates: false`), and the per-file integration test binaries (one per `tests/*.rs`) plus linking are never cached. So every `test` job recompiles the whole workspace and links its test binary from scratch. That residual work is ~1–2 min on Ubuntu but ~10 min on Windows because of slow MSVC `link.exe` linking, full debuginfo, and Defender real-time file scanning.

## Changes (quick, CI-scoped — no structural change)

All in `.github/workflows/test.yml`:

- **`CARGO_PROFILE_DEV_DEBUG=line-tables-only`** — drop full debuginfo so object files are smaller and link faster; keeps `file:line` in backtraces. The `test` profile inherits this.
- **`lld-link` on windows-msvc** — link with LLVM's `lld-link` (preinstalled at `C:\Program Files\LLVM` on `windows-2025`, no install step) instead of the slow `link.exe`. Only consumed when building the windows-msvc target → no-op on Linux/macOS. Scoped to this workflow, so the release/dist **thin-LTO** build keeps the default linker (lld + LTO has known segfault caveats).
- **Windows Defender exclusion** for the workspace + `.cargo`/`.rustup`, in both the `unit-tests` and `test` jobs. Non-fatal so it can't break CI.

## Notes for reviewers

- **First run recompiles fully on every OS** — changing the linker and debug level invalidates the cache fingerprint once. Steady-state is what improves.
- The **`lld-link` swap is validated by this PR's Windows CI run** (can't link MSVC locally from macOS). If `lld-link.exe` isn't found at that path on some image variant, those jobs fail at link with an obvious "linker not found" error; the fix/revert is a one-line env change.
- **Deferred follow-up:** the larger structural win — prime all integration test binaries once in the `unit-tests` job + `cache-workspace-crates: true` so the parallel `test` jobs reuse pre-built binaries instead of each recompiling the workspace. Larger payoff but grows caches and needs eviction-limit care.

## Verification

Confirmed against this PR's `Test` run on Windows:

- **Warm-cache compile+link dropped from ~10 min to ~3.2 min.** Example: `sync_tests` spent 194s compiling/linking + 182s actually running tests (was ~10 min compile before). Jobs that hit the deps cache finished in ~380s end-to-end.
- **`lld-link` works** — all Windows jobs linked and passed; no "linker not found" errors, so LLVM's `lld-link` is present and used on `windows-2025`.
- **The few slow jobs were cache *misses*, not a regression.** They cold-rebuilt dependencies (~7 min extra) because the repo is currently over GitHub's 10 GB cache cap and 30 jobs contend for the single cache `unit-tests` had just created — a transient warm-up effect, unrelated to the linker/debuginfo change. This clears once the new cache key is the norm across `main` and open PRs, which is why the rollout plan is: **merge this, then rebase/merge it into existing PRs** so all future CI populates and reuses the new caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
