### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+# v0.3.2
+
 * feat: `icp canister call` now accepts `--candid <PATH>` to load the canister's Candid interface from a local `.did` file instead of fetching it from the network. The supplied interface drives method selection, argument building, and response decoding.
 
 # v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6366,7 +6366,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.3.1"
+version = "0.3.2"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `0.3.2`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v0.3.2`

### Review checklist
- [ ] CI passes
- [ ] Changelog entries look correct
- [ ] Version number is correct
