### PR TITLE
ci: stabilize the Rust cache key by removing the runner's bundled toolchain

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Setup image (Linux)
         run: ./.github/scripts/provision-linux-build.sh
 
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
+
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
@@ -62,6 +68,12 @@ jobs:
       - name: Setup image (Linux)
         run: ./.github/scripts/provision-linux-build.sh
 
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
+
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
@@ -83,6 +95,12 @@ jobs:
 
       - name: Setup image (Linux)
         run: ./.github/scripts/provision-linux-build.sh
+
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
 
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
@@ -132,6 +150,12 @@ jobs:
       - name: Setup image (Linux)
         run: ./.github/scripts/provision-linux-build.sh
 
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
+
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-checks
@@ -167,6 +191,12 @@ jobs:
 
       - name: Setup image (Linux)
         run: ./.github/scripts/provision-linux-build.sh
+
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
 
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,12 @@ jobs:
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: ./.github/scripts/provision-linux-build.sh
 
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
+
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-test
@@ -130,6 +136,12 @@ jobs:
             "$env:GITHUB_WORKSPACE", `
             "$env:USERPROFILE\.cargo", `
             "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
+
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
 
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -52,6 +52,12 @@ jobs:
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: ./.github/scripts/provision-linux-build.sh
 
+      # rust-cache hashes all installed toolchains; the runner image's `stable`
+      # drifts as the image updates, which moves the cache key and causes misses.
+      # Remove it so only the rust-toolchain.toml-pinned version remains.
+      - name: Remove the runner's bundled Rust toolchain
+        run: rustup toolchain remove stable 2>/dev/null || true
+
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: ${{ runner.os }}-validate


### PR DESCRIPTION
## Problem

`Swatinem/rust-cache` folds the version of **every installed Rust toolchain** into its environment hash, which is part of the cache key. GitHub runner images ship a `stable` toolchain whose version drifts as the image is updated — so the cache key silently changes from run to run, jobs miss the cache, and rebuild from cold.

This was observed directly while debugging the Windows test cache: two otherwise-identical builds produced different env hashes (`…-9fc860dc-…` vs `…-b9079240-…`) with the same `Cargo.lock`, i.e. the only thing that moved was the bundled toolchain version.

## Fix

We already pin the toolchain via [`rust-toolchain.toml`](../blob/main/rust-toolchain.toml) (`1.95.0`), so the runner's bundled `stable` is never actually used for builds — it only pollutes the cache key. This PR removes it before `setup-rust-toolchain` in every workflow that caches:

```yaml
- name: Remove the runner's bundled Rust toolchain
  run: rustup toolchain remove stable 2>/dev/null || true
```

Added before all 8 `setup-rust-toolchain` usages:
- `test.yml` (2 — unit-tests + test)
- `checks.yml` (5 — compile, lint, format, cli-ref, icp-yaml-schema)
- `validate-examples.yml` (1)

The step is non-fatal (`2>/dev/null || true`) and runs under the default `bash` shell on every runner it touches.

## Notes for reviewers

- **Expect one more cold prime per cache namespace (`-test`, `-checks`, `-validate`) when this merges** — removing `stable` shifts the env hash once more, to whatever the 1.95.0-only environment produces. After that the key should stay put run-to-run, which is the whole point.
- Follow-up to #595 (Windows test speedups). Same rollout logic applies: once it's on `main`, every PR (base = `main`) reuses the new, stable-keyed caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)