### PR TITLE
feat(canister-install): add --wasm-memory-persistence flag

### DIFF
--- a/crates/icp-cli/src/commands/canister/install.rs
+++ b/crates/icp-cli/src/commands/canister/install.rs
@@ -128,7 +128,7 @@ pub(crate) async fn exec(ctx: &Context, args: &InstallArgs) -> Result<(), anyhow
             );
             if args.yes {
                 info!("Proceeding without confirmation (--yes).");
-            } else {
+            } else if std::io::stdin().is_terminal() {
                 let confirmed = Confirm::new()
                     .with_prompt("Do you want to proceed?")
                     .default(false)
@@ -136,6 +136,11 @@ pub(crate) async fn exec(ctx: &Context, args: &InstallArgs) -> Result<(), anyhow
                 if !confirmed {
                     bail!("Operation cancelled by user");
                 }
+            } else {
+                bail!(
+                    "Refusing to discard the canister's main memory without confirmation \
+                     in a non-interactive context. Use --yes to proceed."
+                );
             }
         }
     }

--- a/crates/icp-cli/src/commands/canister/install.rs
+++ b/crates/icp-cli/src/commands/canister/install.rs
@@ -14,7 +14,10 @@ use crate::{
     commands::args::{self, ArgsOpt},
     operations::{
         candid_compat::{CandidCompatibility, check_candid_compatibility},
-        install::{install_canister, resolve_install_mode_and_status},
+        install::{
+            WasmMemoryPersistenceOpt, install_canister, is_eop_canister,
+            resolve_install_mode_and_status,
+        },
     },
 };
 
@@ -25,6 +28,19 @@ pub(crate) struct InstallArgs {
     #[arg(long, short, default_value = "auto", value_parser = ["auto", "install", "reinstall", "upgrade"])]
     pub(crate) mode: String,
 
+    /// For Motoko canisters with enhanced orthogonal persistence (EOP), controls whether
+    /// the canister's main (Wasm) memory is preserved across an upgrade.
+    ///
+    /// Only valid with `--mode upgrade` on an EOP canister.
+    ///
+    /// - `keep`: preserve main memory — the normal EOP upgrade (the default if this flag
+    ///   is omitted).
+    ///
+    /// - `replace`: discard main memory. DANGEROUS: any state not held in `stable`
+    ///   variables is lost. Requires interactive confirmation (or `--yes`).
+    #[arg(long, value_enum)]
+    pub(crate) wasm_memory_persistence: Option<WasmMemoryPersistenceOpt>,
+
     /// Path to the WASM file to install. Uses the build output if not explicitly provided.
     #[arg(long)]
     pub(crate) wasm: Option<PathBuf>,
@@ -32,7 +48,8 @@ pub(crate) struct InstallArgs {
     #[command(flatten)]
     pub(crate) args_opt: ArgsOpt,
 
-    /// Skip confirmation prompts, including the Candid interface compatibility check.
+    /// Skip confirmation prompts, including the Candid interface compatibility check and
+    /// the dangerous-operation prompt for `--wasm-memory-persistence replace`.
     #[arg(long, short)]
     pub(crate) yes: bool,
 
@@ -84,6 +101,45 @@ pub(crate) async fn exec(ctx: &Context, args: &InstallArgs) -> Result<(), anyhow
     // If you add .did support to this code, consider extracting/unifying with the logic from call.rs
     let init_args_bytes = args.args_opt.resolve_bytes()?;
 
+    // Validate --wasm-memory-persistence: only meaningful for upgrades of EOP canisters.
+    if let Some(persistence) = args.wasm_memory_persistence {
+        if args.mode != "upgrade" {
+            bail!(
+                "--wasm-memory-persistence can only be used with `--mode upgrade` \
+                 (got `--mode {}`). It has no effect for install/reinstall, and `auto` \
+                 is ambiguous; pass `--mode upgrade` explicitly.",
+                args.mode
+            );
+        }
+        if !is_eop_canister(&agent, &canister_id).await {
+            bail!(
+                "--wasm-memory-persistence only applies to Motoko canisters with enhanced \
+                 orthogonal persistence (EOP). The target canister is not an EOP canister."
+            );
+        }
+        if persistence == WasmMemoryPersistenceOpt::Replace {
+            warn!(
+                "--wasm-memory-persistence=replace will DISCARD the canister's \
+                 main (Wasm) memory."
+            );
+            warn!(
+                "Only state held in `stable` variables survives. Heap state is lost \
+                 and cannot be recovered."
+            );
+            if args.yes {
+                info!("Proceeding without confirmation (--yes).");
+            } else {
+                let confirmed = Confirm::new()
+                    .with_prompt("Do you want to proceed?")
+                    .default(false)
+                    .interact()?;
+                if !confirmed {
+                    bail!("Operation cancelled by user");
+                }
+            }
+        }
+    }
+
     let canister_display = args.cmd_args.canister.to_string();
     let (install_mode, status) = resolve_install_mode_and_status(
         &agent,
@@ -132,6 +188,7 @@ pub(crate) async fn exec(ctx: &Context, args: &InstallArgs) -> Result<(), anyhow
         install_mode,
         status,
         init_args_bytes.as_deref(),
+        args.wasm_memory_persistence,
     )
     .await?;
 

--- a/crates/icp-cli/src/operations/install.rs
+++ b/crates/icp-cli/src/operations/install.rs
@@ -17,6 +17,33 @@ use super::misc::fetch_canister_metadata;
 use super::proxy::UpdateOrProxyError;
 use super::proxy_management;
 
+/// CLI-facing choice for `wasm_memory_persistence` on EOP upgrades.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum WasmMemoryPersistenceOpt {
+    /// Preserve canister main memory across upgrade (normal EOP upgrade).
+    Keep,
+    /// Discard canister main memory; only `stable` variables survive.
+    /// Dangerous — heap state is lost.
+    Replace,
+}
+
+impl WasmMemoryPersistenceOpt {
+    fn to_ic(self) -> WasmMemoryPersistence {
+        match self {
+            WasmMemoryPersistenceOpt::Keep => WasmMemoryPersistence::Keep,
+            WasmMemoryPersistenceOpt::Replace => WasmMemoryPersistence::Replace,
+        }
+    }
+}
+
+/// Returns true if the canister exposes the `enhanced-orthogonal-persistence`
+/// custom-section metadata (i.e. it is a Motoko EOP canister).
+pub(crate) async fn is_eop_canister(agent: &Agent, canister_id: &Principal) -> bool {
+    fetch_canister_metadata(agent, *canister_id, "enhanced-orthogonal-persistence")
+        .await
+        .is_some()
+}
+
 #[derive(Debug, Snafu)]
 pub enum InstallOperationError {
     #[snafu(display("Could not find build artifact for canister '{canister_name}'"))]
@@ -100,18 +127,24 @@ pub(crate) async fn install_canister(
     mode: CanisterInstallMode,
     status: CanisterStatusType,
     init_args: Option<&[u8]>,
+    wasm_memory_persistence: Option<WasmMemoryPersistenceOpt>,
 ) -> Result<(), InstallOperationError> {
     let mode = match mode {
         CanisterInstallMode::Upgrade(_) => {
-            // if this is a motoko canister using EOP
-            // we need to set additional options
-            if fetch_canister_metadata(agent, *canister_id, "enhanced-orthogonal-persistence")
-                .await
-                .is_some()
-            {
+            // if this is a motoko canister using EOP we need to set additional options.
+            // If the caller supplied an explicit override, trust it (the CLI layer has
+            // already validated that it's an EOP canister); otherwise auto-detect and
+            // default to Keep.
+            let persistence = match wasm_memory_persistence {
+                Some(opt) => Some(opt.to_ic()),
+                None => is_eop_canister(agent, canister_id)
+                    .await
+                    .then_some(WasmMemoryPersistence::Keep),
+            };
+            if let Some(persistence) = persistence {
                 CanisterInstallMode::Upgrade(Some(UpgradeFlags {
                     skip_pre_upgrade: None,
-                    wasm_memory_persistence: Some(WasmMemoryPersistence::Keep),
+                    wasm_memory_persistence: Some(persistence),
                 }))
             } else {
                 mode
@@ -361,6 +394,7 @@ pub(crate) async fn install_many(
                     mode,
                     status,
                     init_args.as_deref(),
+                    None,
                 )
                 .await
             }

--- a/crates/icp-cli/tests/canister_install_tests.rs
+++ b/crates/icp-cli/tests/canister_install_tests.rs
@@ -1199,3 +1199,339 @@ async fn canister_install_through_proxy() {
         .success()
         .stdout(eq("(\"Hello, test!\")").trim());
 }
+
+/// `--wasm-memory-persistence keep` preserves a Motoko EOP canister's heap state
+/// across an upgrade, while `replace` discards it (only `stable`/persistent data in
+/// stable memory would survive, and a plain `var` lives in main memory).
+///
+/// Motoko enables enhanced orthogonal persistence (EOP) by default since moc 0.15.0,
+/// so a `persistent actor` built with moc 0.16.3 produces an EOP canister.
+#[cfg(unix)] // moc
+#[tokio::test]
+async fn canister_install_wasm_memory_persistence_keep_and_replace() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+
+    // Motoko toolchain.
+    write_string(
+        &project_dir.join("mops.toml"),
+        indoc! {r#"
+            [toolchain]
+            moc = "0.16.3"
+        "#},
+    )
+    .expect("failed to write mops.toml");
+
+    // A counter whose state lives in main (Wasm) memory: `count` is a plain heap `var`,
+    // preserved across upgrades only while main memory is kept.
+    write_string(
+        &project_dir.join("main.mo"),
+        indoc! {"
+            persistent actor {
+                var count : Nat = 0;
+
+                public func inc() : async Nat {
+                    count += 1;
+                    count;
+                };
+
+                public query func get() : async Nat {
+                    count;
+                };
+            };
+        "},
+    )
+    .expect("failed to write main.mo");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            recipe:
+              type: "@dfinity/motoko@v4.0.0"
+              configuration:
+                main: main.mo
+                args: ""
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+    clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
+        .mint_cycles(10 * TRILLION);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["build", "my-canister"])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "create",
+            "my-canister",
+            "--quiet",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+
+    // Build up some heap state: count -> 3.
+    for _ in 0..3 {
+        ctx.icp()
+            .current_dir(&project_dir)
+            .args([
+                "canister",
+                "call",
+                "--environment",
+                "random-environment",
+                "my-canister",
+                "inc",
+                "()",
+            ])
+            .assert()
+            .success();
+    }
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "my-canister",
+            "get",
+            "()",
+        ])
+        .assert()
+        .success()
+        .stdout(eq("(3 : nat)").trim());
+
+    // Upgrade keeping main memory: heap state survives (no --yes needed; keep is the safe
+    // default and triggers no confirmation, and the Candid interface is unchanged).
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--mode",
+            "upgrade",
+            "--wasm-memory-persistence",
+            "keep",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "my-canister",
+            "get",
+            "()",
+        ])
+        .assert()
+        .success()
+        .stdout(eq("(3 : nat)").trim());
+
+    // `replace` is dangerous and requires confirmation. In a non-interactive context (as
+    // here, with no TTY) it must refuse cleanly rather than erroring on the prompt, and it
+    // must not touch the canister's state.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--mode",
+            "upgrade",
+            "--wasm-memory-persistence",
+            "replace",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("Use --yes to proceed"));
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "my-canister",
+            "get",
+            "()",
+        ])
+        .assert()
+        .success()
+        .stdout(eq("(3 : nat)").trim());
+
+    // Upgrade replacing main memory: heap state is discarded, counter resets to 0.
+    // --yes bypasses the confirmation.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--mode",
+            "upgrade",
+            "--wasm-memory-persistence",
+            "replace",
+            "--yes",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "my-canister",
+            "get",
+            "()",
+        ])
+        .assert()
+        .success()
+        .stdout(eq("(0 : nat)").trim());
+}
+
+/// `--wasm-memory-persistence` is rejected unless used with `--mode upgrade` on an EOP
+/// canister. The vendored `example_icp_mo.wasm` is a classic (non-EOP) Motoko canister,
+/// which lets us exercise both guardrails without building from source.
+#[tokio::test]
+async fn canister_install_wasm_memory_persistence_rejected_for_non_eop() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+
+    let wasm = ctx.make_asset("example_icp_mo.wasm");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm}' "$ICP_WASM_OUTPUT_PATH"
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+    clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
+        .mint_cycles(10 * TRILLION);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["build", "my-canister"])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "create",
+            "my-canister",
+            "--quiet",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success();
+
+    // Default mode is `auto`, which is ambiguous for this flag -> rejected.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--wasm-memory-persistence",
+            "keep",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("can only be used with `--mode upgrade`"));
+
+    // Explicit non-upgrade mode is also rejected.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--mode",
+            "install",
+            "--wasm-memory-persistence",
+            "keep",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("can only be used with `--mode upgrade`"));
+
+    // Correct mode, but the target is not an EOP canister -> rejected.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "install",
+            "my-canister",
+            "--mode",
+            "upgrade",
+            "--wasm-memory-persistence",
+            "keep",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("not an EOP canister"));
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -297,6 +297,20 @@ Install a built WASM to a canister on a network
 
   Possible values: `auto`, `install`, `reinstall`, `upgrade`
 
+* `--wasm-memory-persistence <WASM_MEMORY_PERSISTENCE>` — For Motoko canisters with enhanced orthogonal persistence (EOP), controls whether the canister's main (Wasm) memory is preserved across an upgrade.
+
+   Only valid with `--mode upgrade` on an EOP canister.
+
+   - `keep`: preserve main memory — the normal EOP upgrade (the default if this flag is omitted).
+
+   - `replace`: discard main memory. DANGEROUS: any state not held in `stable` variables is lost. Requires interactive confirmation.
+
+  Possible values:
+  - `keep`:
+    Preserve canister main memory across upgrade (normal EOP upgrade)
+  - `replace`:
+    Discard canister main memory; only `stable` variables survive. Dangerous — heap state is lost
+
 * `--wasm <WASM>` — Path to the WASM file to install. Uses the build output if not explicitly provided
 * `--args <ARGS>` — Inline arguments, interpreted per `--args-format` (Candid by default)
 * `--args-file <ARGS_FILE>` — Path to a file containing arguments

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -303,7 +303,7 @@ Install a built WASM to a canister on a network
 
    - `keep`: preserve main memory — the normal EOP upgrade (the default if this flag is omitted).
 
-   - `replace`: discard main memory. DANGEROUS: any state not held in `stable` variables is lost. Requires interactive confirmation.
+   - `replace`: discard main memory. DANGEROUS: any state not held in `stable` variables is lost. Requires interactive confirmation (or `--yes`).
 
   Possible values:
   - `keep`:
@@ -326,7 +326,7 @@ Install a built WASM to a canister on a network
   - `bin`:
     Raw binary (only valid for file references)
 
-* `-y`, `--yes` — Skip confirmation prompts, including the Candid interface compatibility check
+* `-y`, `--yes` — Skip confirmation prompts, including the Candid interface compatibility check and the dangerous-operation prompt for `--wasm-memory-persistence replace`
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
 * `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used


### PR DESCRIPTION
Supersedes #558 (original work by @timohanke), rebased onto `main` as a single squashed commit. See that PR for the feature description.

This branch adds, on top of the original change:
- Integration test coverage for the flag (EOP keep/replace behavior + validation guardrails).
- A small fix so `replace` without `--yes` fails cleanly in non-interactive contexts instead of erroring on the prompt.
- Regenerated CLI reference docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)