### PR TITLE
ci: clean up CI workflows and fix WSL2 Docker on Windows

### DIFF
--- a/.github/scripts/init-docker.sh
+++ b/.github/scripts/init-docker.sh
@@ -5,6 +5,13 @@
 set -ex
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+# Installing docker.io enables a systemd docker service. The Ubuntu rootfs that
+# setup-wsl v7 provisions has systemd enabled, so that service auto-starts and
+# claims /var/run/docker.pid, which blocks the tcp-only daemon below (the one
+# the Windows-side tests connect to). Stop it first. On a non-systemd image
+# (e.g. setup-wsl v6) systemctl is absent, so this is a harmless no-op.
+systemctl stop docker.socket docker.service 2>/dev/null || true
+rm -f /var/run/docker.pid
 nohup dockerd -H tcp://127.0.0.1:2375 >/var/log/dockerd.log 2>&1 &
 for i in $(seq 1 30); do
     if docker -H tcp://127.0.0.1:2375 info >/dev/null 2>&1; then

--- a/.github/scripts/test-matrix.py
+++ b/.github/scripts/test-matrix.py
@@ -5,17 +5,6 @@ TEST_DIR = "crates/icp-cli/tests"
 
 MACOS_TESTS = ["network_tests"]
 
-# Test files whose tests need a Docker daemon (Docker-backed managed networks).
-# On Windows the daemon runs in WSL2, and that setup (setup-wsl + dockerd) adds
-# ~1 min per job, so only these jobs run it. Linux uses its preinstalled Docker,
-# so the flag is a no-op there. Keep in sync with the tests that use Docker.
-DOCKER_TESTS = [
-    "bundle_tests",
-    "canister_create_tests",
-    "deploy_tests",
-    "network_tests",
-]
-
 
 def test_names():
     all_files = os.listdir(TEST_DIR)
@@ -25,25 +14,21 @@ def test_names():
 
 include = []
 for test in test_names():
-    needs_docker = test in DOCKER_TESTS
     # Ubuntu/Windows: run everything
     include.append({
         "test": test,
-        "os": "ubuntu-22.04",
-        "needs_docker": needs_docker,
+        "os": "ubuntu-22.04"
     })
     include.append({
         "test": test,
-        "os": "windows-2025",
-        "needs_docker": needs_docker,
+        "os": "windows-2025"
     })
 
     # macOS: only run selected tests
     if test in MACOS_TESTS:
         include.append({
             "test": test,
-            "os": "macos-15",
-            "needs_docker": needs_docker,
+            "os": "macos-15"
         })
 
 

--- a/.github/scripts/test-matrix.py
+++ b/.github/scripts/test-matrix.py
@@ -5,6 +5,17 @@ TEST_DIR = "crates/icp-cli/tests"
 
 MACOS_TESTS = ["network_tests"]
 
+# Test files whose tests need a Docker daemon (Docker-backed managed networks).
+# On Windows the daemon runs in WSL2, and that setup (setup-wsl + dockerd) adds
+# ~1 min per job, so only these jobs run it. Linux uses its preinstalled Docker,
+# so the flag is a no-op there. Keep in sync with the tests that use Docker.
+DOCKER_TESTS = [
+    "bundle_tests",
+    "canister_create_tests",
+    "deploy_tests",
+    "network_tests",
+]
+
 
 def test_names():
     all_files = os.listdir(TEST_DIR)
@@ -14,21 +25,25 @@ def test_names():
 
 include = []
 for test in test_names():
+    needs_docker = test in DOCKER_TESTS
     # Ubuntu/Windows: run everything
     include.append({
         "test": test,
-        "os": "ubuntu-22.04"
+        "os": "ubuntu-22.04",
+        "needs_docker": needs_docker,
     })
     include.append({
         "test": test,
-        "os": "windows-2025"
+        "os": "windows-2025",
+        "needs_docker": needs_docker,
     })
 
     # macOS: only run selected tests
     if test in MACOS_TESTS:
         include.append({
             "test": test,
-            "os": "macos-15"
+            "os": "macos-15",
+            "needs_docker": needs_docker,
         })
 
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,7 @@ jobs:
           cache-bin: false
 
       - name: Run Lint
-        run: cargo clippy --verbose --tests --benches -- -D warnings
+        run: cargo clippy --tests --benches -- -D warnings
         env:
           RUST_BACKTRACE: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Setup WSL2 (Windows)
         if: ${{ contains(matrix.os, 'windows') }}
-        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
+        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
           distribution: Ubuntu-22.04
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,15 @@ jobs:
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: ./.github/scripts/provision-linux-build.sh
 
+      # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
+      # now flags as untrusted on every `brew install` (including the one inside
+      # setup-rust-toolchain below). We use neither, so untap them up front to
+      # keep the logs clean. Guarded so it stays green if an image stops shipping
+      # them. Must run before any brew install to suppress the warning.
+      - name: Untap unused Homebrew taps (macOS)
+        if: ${{ contains(matrix.os, 'macos') }}
+        run: brew untap aws/tap azure/bicep 2>/dev/null || true
+
       # rust-cache hashes all installed toolchains; the runner image's `stable`
       # drifts as the image updates, which moves the cache key and causes misses.
       # Remove it so only the rust-toolchain.toml-pinned version remains.
@@ -136,6 +145,16 @@ jobs:
             "$env:GITHUB_WORKSPACE", `
             "$env:USERPROFILE\.cargo", `
             "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
+
+      # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
+      # now flags as untrusted on every `brew install` (including the one inside
+      # setup-rust-toolchain below and our provision-macos-test.sh). We use
+      # neither, so untap them up front to keep the logs clean. Guarded so it
+      # stays green if an image stops shipping them. Must run before any brew
+      # install to suppress the warning.
+      - name: Untap unused Homebrew taps (macOS)
+        if: ${{ contains(matrix.os, 'macos') }}
+        run: brew untap aws/tap azure/bicep 2>/dev/null || true
 
       # rust-cache hashes all installed toolchains; the runner image's `stable`
       # drifts as the image updates, which moves the cache key and causes misses.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
           cache-shared-key: ${{ runner.os }}-test
           cache-bin: false
 
-      - uses: t1m0thyj/unlock-keyring@e481cdc8833d4417a58f40734e8f197183317047
+      - uses: t1m0thyj/unlock-keyring@cbcf205c879ebd86add70bab3a6abfcce59a5cae # 1.2.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Run unit tests
@@ -172,7 +172,7 @@ jobs:
         run: .github/scripts/init-docker.sh
         shell: wsl-bash_Ubuntu-22.04 {0}
 
-      - uses: t1m0thyj/unlock-keyring@e481cdc8833d4417a58f40734e8f197183317047
+      - uses: t1m0thyj/unlock-keyring@cbcf205c879ebd86add70bab3a6abfcce59a5cae # 1.2.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Install mops

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,17 +191,14 @@ jobs:
         run: .github/scripts/provision-windows-test.ps1
         shell: pwsh
 
-      # WSL2 exists solely to host the Docker daemon, so only set it up for the
-      # Windows jobs whose tests need Docker (matrix.needs_docker). This skips
-      # ~1 min of setup on the majority of Windows jobs that never use Docker.
       - name: Setup WSL2 (Windows)
-        if: ${{ contains(matrix.os, 'windows') && matrix.needs_docker }}
+        if: ${{ contains(matrix.os, 'windows') }}
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
           distribution: Ubuntu-22.04
 
       - name: Setup Docker in WSL2 (Windows)
-        if: ${{ contains(matrix.os, 'windows') && matrix.needs_docker }}
+        if: ${{ contains(matrix.os, 'windows') }}
         run: .github/scripts/init-docker.sh
         shell: wsl-bash_Ubuntu-22.04 {0}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,11 +97,15 @@ jobs:
       # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
       # now flags as untrusted on every `brew install` (including the one inside
       # setup-rust-toolchain below). We use neither, so untap them up front to
-      # keep the logs clean. Guarded so it stays green if an image stops shipping
-      # them. Must run before any brew install to suppress the warning.
+      # keep the logs clean. --force because azure/bicep has an installed formula
+      # (bicep) that brew otherwise refuses to untap; one tap per line so a
+      # missing tap in a future image can't stop the other. Must run before any
+      # brew install to suppress the warning.
       - name: Untap unused Homebrew taps (macOS)
         if: ${{ contains(matrix.os, 'macos') }}
-        run: brew untap aws/tap azure/bicep 2>/dev/null || true
+        run: |
+          brew untap --force aws/tap || true
+          brew untap --force azure/bicep || true
 
       # rust-cache hashes all installed toolchains; the runner image's `stable`
       # drifts as the image updates, which moves the cache key and causes misses.
@@ -149,12 +153,15 @@ jobs:
       # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
       # now flags as untrusted on every `brew install` (including the one inside
       # setup-rust-toolchain below and our provision-macos-test.sh). We use
-      # neither, so untap them up front to keep the logs clean. Guarded so it
-      # stays green if an image stops shipping them. Must run before any brew
-      # install to suppress the warning.
+      # neither, so untap them up front to keep the logs clean. --force because
+      # azure/bicep has an installed formula (bicep) that brew otherwise refuses
+      # to untap; one tap per line so a missing tap in a future image can't stop
+      # the other. Must run before any brew install to suppress the warning.
       - name: Untap unused Homebrew taps (macOS)
         if: ${{ contains(matrix.os, 'macos') }}
-        run: brew untap aws/tap azure/bicep 2>/dev/null || true
+        run: |
+          brew untap --force aws/tap || true
+          brew untap --force azure/bicep || true
 
       # rust-cache hashes all installed toolchains; the runner image's `stable`
       # drifts as the image updates, which moves the cache key and causes misses.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,19 +205,20 @@ jobs:
       - uses: t1m0thyj/unlock-keyring@cbcf205c879ebd86add70bab3a6abfcce59a5cae # 1.2.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
+      # mops is only needed for the Motoko (moc) tests, which are all
+      # #[cfg(unix)], so skip it on Windows. Install the CLI directly rather
+      # than via dfinity/setup-mops, which only wraps this same script with a
+      # Linux/macOS-only package cache and Node 20 actions (setup-node/cache).
       - name: Install mops
-        uses: dfinity/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
-
-      - name: Verify mops installation
+        if: ${{ !contains(matrix.os, 'windows') }}
         run: |
+          curl -fsSL cli.mops.one/install.sh | sh
           which mops
           mops --version
 
       - name: Install ic-wasm
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/ic-wasm/releases/download/0.9.10/ic-wasm-installer.sh | sh
-
-      - name: Verify ic-wasm installation
         run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/ic-wasm/releases/download/0.9.10/ic-wasm-installer.sh | sh
           which ic-wasm
           ic-wasm --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,14 +191,17 @@ jobs:
         run: .github/scripts/provision-windows-test.ps1
         shell: pwsh
 
+      # WSL2 exists solely to host the Docker daemon, so only set it up for the
+      # Windows jobs whose tests need Docker (matrix.needs_docker). This skips
+      # ~1 min of setup on the majority of Windows jobs that never use Docker.
       - name: Setup WSL2 (Windows)
-        if: ${{ contains(matrix.os, 'windows') }}
+        if: ${{ contains(matrix.os, 'windows') && matrix.needs_docker }}
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
           distribution: Ubuntu-22.04
 
       - name: Setup Docker in WSL2 (Windows)
-        if: ${{ contains(matrix.os, 'windows') }}
+        if: ${{ contains(matrix.os, 'windows') && matrix.needs_docker }}
         run: .github/scripts/init-docker.sh
         shell: wsl-bash_Ubuntu-22.04 {0}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,16 +96,18 @@ jobs:
 
       # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
       # now flags as untrusted on every `brew install` (including the one inside
-      # setup-rust-toolchain below). We use neither, so untap them up front to
-      # keep the logs clean. --force because azure/bicep has an installed formula
-      # (bicep) that brew otherwise refuses to untap; one tap per line so a
-      # missing tap in a future image can't stop the other. Must run before any
-      # brew install to suppress the warning.
+      # setup-rust-toolchain below). We use neither. bicep (from azure/bicep) is
+      # the only formula installed from them, so uninstall it first; then both
+      # taps untap cleanly without --force (which would untap but warn about the
+      # installed formula). || true keeps the step green if a future image no
+      # longer ships these. Must run before any brew install to suppress the
+      # warning.
       - name: Untap unused Homebrew taps (macOS)
         if: ${{ contains(matrix.os, 'macos') }}
         run: |
-          brew untap --force aws/tap || true
-          brew untap --force azure/bicep || true
+          brew uninstall bicep || true
+          brew untap aws/tap || true
+          brew untap azure/bicep || true
 
       # rust-cache hashes all installed toolchains; the runner image's `stable`
       # drifts as the image updates, which moves the cache key and causes misses.
@@ -153,15 +155,17 @@ jobs:
       # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
       # now flags as untrusted on every `brew install` (including the one inside
       # setup-rust-toolchain below and our provision-macos-test.sh). We use
-      # neither, so untap them up front to keep the logs clean. --force because
-      # azure/bicep has an installed formula (bicep) that brew otherwise refuses
-      # to untap; one tap per line so a missing tap in a future image can't stop
-      # the other. Must run before any brew install to suppress the warning.
+      # neither. bicep (from azure/bicep) is the only formula installed from
+      # them, so uninstall it first; then both taps untap cleanly without --force
+      # (which would untap but warn about the installed formula). || true keeps
+      # the step green if a future image no longer ships these. Must run before
+      # any brew install to suppress the warning.
       - name: Untap unused Homebrew taps (macOS)
         if: ${{ contains(matrix.os, 'macos') }}
         run: |
-          brew untap --force aws/tap || true
-          brew untap --force azure/bicep || true
+          brew uninstall bicep || true
+          brew untap aws/tap || true
+          brew untap azure/bicep || true
 
       # rust-cache hashes all installed toolchains; the runner image's `stable`
       # drifts as the image updates, which moves the cache key and causes misses.


### PR DESCRIPTION
Maintenance pass on the CI workflows. The goal was clearing two classes of CI warnings; bumping `setup-wsl` to v7 then surfaced a Windows Docker regression, which is fixed here too.

## Silence CI warnings
- **Node.js 20 deprecation** — clear every Node 20 action that ran in the test jobs:
  - bump `Vampire/setup-wsl` → v7.0.0 and `t1m0thyj/unlock-keyring` → v1.2.0 (Node 24 runtime);
  - drop `dfinity/setup-mops`, which transitively pulled in `actions/setup-node@v4` + `actions/cache@v4` (both Node 20) — the warning still showing at the "Complete job" step. mops is now installed directly via `curl … cli.mops.one/install.sh` (the same thing the action did for us, minus a Linux/macOS-only cache).
- **Homebrew untrusted taps** — the macOS runner image pre-taps `aws/tap` and `azure/bicep`, which Homebrew now flags on every `brew install` (including the one inside `setup-rust-toolchain`, so even the unit-tests job warned). We use neither, so before any brew call we uninstall `bicep` (the only installed formula from those taps) and untap both — cleanly, without `--force` (which untaps but re-warns).

## Fix: Docker daemon in WSL2 (regression from the setup-wsl v7 bump)
setup-wsl v7 provisions the Ubuntu rootfs with **systemd enabled**, so `apt-get install docker.io` now auto-starts `docker.service`, which holds `/var/run/docker.pid` and blocked our manual tcp-only `dockerd` (the daemon the Windows-side tests connect to). `init-docker.sh` now stops the systemd service and clears the pid file before launching the tcp daemon. On a non-systemd image `systemctl` is absent, so it's a no-op.

## Reduce noise & simplify
- Drop `--verbose` from the `cargo clippy` lint step in `checks.yml` — a cargo flag that prints the full rustc/clippy-driver command line for every compiled crate, flooding the log without adding any lint detail.
- Fold each tool's verify (`which` + `--version`) into its install step, so mops and ic-wasm are one step each instead of two. mops is also skipped on Windows, since the Motoko (moc) tests that need it are all `#[cfg(unix)]`.

<sub>An earlier commit tried gating WSL2+Docker setup to only the Windows jobs that "need" Docker, but on Windows the local test network itself runs as a Docker container, so nearly all tests need it — that change was reverted.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)