### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+# v1.0.0
+
 * feat: The default gateway domain is now `icp.net`, not `icp0.io`.
 * feat: Password-protected identities now only need your password once per session. The session length defaults to 5 minutes and can be changed with `icp settings session-length <DURATION>` (e.g. `30m`, `1h`) or turned off with `icp settings session-length disabled`. You can also explicitly create or refresh a session with `icp identity reauth <NAME> [--duration <DURATION>]`.
 * feat!: Remove `--set-controller` and replace with a new flag `--remove-all-controllers`. For the old behavior, combine this flag with `--add-controller`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "0.3.2"
+version = "1.0.0"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "0.3.2"
+version = "1.0.0"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "0.3.2"
+version = "1.0.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "0.3.2"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6366,7 +6366,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "0.3.2"
+version = "1.0.0"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "0.3.2"
+version = "1.0.0"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `1.0.0`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v1.0.0`

### Review checklist
- [x] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct
