### PR TITLE
chore: update docs site to v1.0

### DIFF
--- a/docs-site/versions.json
+++ b/docs-site/versions.json
@@ -2,8 +2,11 @@
   "$comment": "Before first release: Empty array redirects to /main/. After releases: Add versions here (newest first). Only 'version' is required; 'latest: true' marks the current release.",
   "versions": [
     {
-      "version": "0.3",
+      "version": "1.0",
       "latest": true
+    },
+    {
+      "version": "0.3"
     },
     {
       "version": "0.2"


### PR DESCRIPTION
## Summary

- `docs-site/versions.json`: add v1.0 as the new latest version

Updates the version switcher and root redirect (`dfinity.github.io/icp-cli/`) to point to the new stable release. Must be merged only after the versioned docs are confirmed deployed.
