### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: sync plugins.
 
 # Unreleased
 
+# v1.0.1
+
 * feat: `icp identity import` can now be used with a `--delegation` flag to import a delegated identity. This is most useful for containers or other internal-only delegations; for anything involving a network, `icp identity delegation request` remains the recommended way to work with delegations.
 
 # v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "icp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-dropper",
  "async-trait",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "icp-canister-interfaces"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bigdecimal",
  "candid",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "icp-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "icp-sync-plugin"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "schema-gen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "icp",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "3"
 [workspace.package]
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
-version = "1.0.0"
+version = "1.0.1"
 repository = "https://github.com/dfinity/icp-cli"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- `Cargo.toml`: version bumped to `1.0.1`
- `Cargo.lock`: updated
- `CHANGELOG.md`: entries consolidated under `# v1.0.1`

### Review checklist
- [x] CI passes
- [x] Changelog entries look correct
- [x] Version number is correct
