### PR TITLE
ci(test): build test binaries once via a nextest archive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,16 +64,21 @@ jobs:
       - id: set-matrix
         run: echo "matrix=$(python3 .github/scripts/test-matrix.py)" >> $GITHUB_OUTPUT
 
-  unit-tests:
-    name: Unit tests on ${{ matrix.os }}
+  # Compile every test binary (unit + integration) plus the `icp` bin ONCE per
+  # OS and publish them as a nextest archive. The downstream unit-tests and test
+  # jobs run these prebuilt binaries with zero recompilation and no cache
+  # restore, replacing the old model where each of the ~30 integration-test jobs
+  # rebuilt the whole workspace from a deps-only cache.
+  build:
+    name: Build test archive on ${{ matrix.os }}
     needs: changes
     if: needs.changes.outputs.src == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        # Make the os matrix match .github/scripts/test-matrix.py so that
-        # we optimize caching
+        # Keep this os matrix in sync with .github/scripts/test-matrix.py so
+        # every OS the test jobs run on has a matching archive.
         os: [ubuntu-22.04, macos-15, windows-2025]
 
     steps:
@@ -115,21 +120,97 @@ jobs:
       - name: Remove the runner's bundled Rust toolchain
         run: rustup toolchain remove stable 2>/dev/null || true
 
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache-shared-key: ${{ runner.os }}-test
           cache-bin: false
+          # Write the dependency cache only from main; PRs restore it read-only
+          # (GitHub lets branches read the default branch's caches). This keeps
+          # the count of ~GB caches small so the repo stays under GitHub's 10 GB
+          # cache budget and its LRU eviction doesn't purge warm caches.
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2.70.2
+        with:
+          tool: nextest
+
+      # Build all test binaries + the `icp` bin into a single self-contained
+      # archive. This is the only place the workspace is compiled for tests.
+      - name: Build nextest archive
+        run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
+
+      - name: Upload nextest archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-archive-${{ runner.os }}
+          path: nextest-archive.tar.zst
+          # Only needed by same-run downstream jobs; don't retain it.
+          retention-days: 1
+
+  unit-tests:
+    name: Unit tests on ${{ matrix.os }}
+    # Run the workspace unit tests from the prebuilt archive (no recompilation).
+    needs: build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2025]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Defender scans the files nextest extracts from the archive; excluding the
+      # workspace/cargo dirs keeps that cheap on Windows.
+      - name: Exclude build dirs from Windows Defender
+        if: ${{ contains(matrix.os, 'windows') }}
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath `
+            "$env:GITHUB_WORKSPACE", `
+            "$env:USERPROFILE\.cargo", `
+            "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
+
+      # Provides the dbus runtime library the keyring-touching unit tests link
+      # against (see the unlock-keyring step below).
+      - name: Setup image (Linux)
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        run: ./.github/scripts/provision-linux-build.sh
+
+      - name: Untap unused Homebrew taps (macOS)
+        if: ${{ contains(matrix.os, 'macos') }}
+        run: |
+          brew uninstall bicep || true
+          brew untap aws/tap || true
+          brew untap azure/bicep || true
+
+      # Toolchain to invoke `cargo nextest`; cache: false skips the (large) deps
+      # cache restore since this job never compiles.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+
+      - name: Install nextest
+        uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2.70.2
+        with:
+          tool: nextest
 
       - uses: t1m0thyj/unlock-keyring@cbcf205c879ebd86add70bab3a6abfcce59a5cae # 1.2.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
+      - name: Download nextest archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-archive-${{ runner.os }}
+
       - name: Run unit tests
-        run: cargo test --workspace --lib --bins
+        run: cargo nextest run --archive-file nextest-archive.tar.zst -E 'kind(lib) | kind(bin)'
 
   test:
     name: ${{ matrix.test }} on ${{ matrix.os }}
-    # Wait until unit tests have run so we can reuse the cache
-    needs: [discover, unit-tests]
+    # Reuse the prebuilt archive from the build job.
+    needs: [discover, build]
     # Check discover's result (not changes.outputs.src) because this job
     # needs discover's matrix output, which is only available when it ran.
     if: needs.discover.result == 'success'
@@ -141,8 +222,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Defender real-time scanning of every object/rlib it writes slows
-      # file-heavy Rust builds and cache extraction considerably on Windows.
+      # Defender scans the files nextest extracts from the archive; excluding the
+      # workspace/cargo dirs keeps that cheap on Windows.
       - name: Exclude build dirs from Windows Defender
         if: ${{ contains(matrix.os, 'windows') }}
         shell: pwsh
@@ -153,13 +234,13 @@ jobs:
             "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
 
       # The macOS runner image pre-taps aws/tap and azure/bicep, which Homebrew
-      # now flags as untrusted on every `brew install` (including the one inside
-      # setup-rust-toolchain below and our provision-macos-test.sh). We use
-      # neither. bicep (from azure/bicep) is the only formula installed from
-      # them, so uninstall it first; then both taps untap cleanly without --force
-      # (which would untap but warn about the installed formula). || true keeps
-      # the step green if a future image no longer ships these. Must run before
-      # any brew install to suppress the warning.
+      # now flags as untrusted on every `brew install` (including our
+      # provision-macos-test.sh). We use neither. bicep (from azure/bicep) is
+      # the only formula installed from them, so uninstall it first; then both
+      # taps untap cleanly without --force (which would untap but warn about the
+      # installed formula). || true keeps the step green if a future image no
+      # longer ships these. Must run before any brew install to suppress the
+      # warning.
       - name: Untap unused Homebrew taps (macOS)
         if: ${{ contains(matrix.os, 'macos') }}
         run: |
@@ -167,16 +248,11 @@ jobs:
           brew untap aws/tap || true
           brew untap azure/bicep || true
 
-      # rust-cache hashes all installed toolchains; the runner image's `stable`
-      # drifts as the image updates, which moves the cache key and causes misses.
-      # Remove it so only the rust-toolchain.toml-pinned version remains.
-      - name: Remove the runner's bundled Rust toolchain
-        run: rustup toolchain remove stable 2>/dev/null || true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+      # Toolchain to invoke `cargo nextest`; cache: false skips the (large) deps
+      # cache restore since this job never compiles.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          cache-shared-key: ${{ runner.os }}-test
-          cache-bin: false
+          cache: false
 
       - name: Setup image (Linux)
         if: ${{ contains(matrix.os, 'ubuntu') }}
@@ -222,10 +298,10 @@ jobs:
           which ic-wasm
           ic-wasm --version
 
-      - name: Install wasm-tools
+      - name: Install wasm-tools and nextest
         uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2.70.2
         with:
-          tool: wasm-tools
+          tool: nextest, wasm-tools
 
       - name: Verify wasm-tools installation
         run: |
@@ -236,9 +312,18 @@ jobs:
         if: ${{ !contains(matrix.os, 'windows') }}
         run: ./scripts/download_test_network_launcher.sh
 
+      - name: Download nextest archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-archive-${{ runner.os }}
+
       - name: Run ${{ matrix.test }}
-        # the macos runners do not support Docker
-        run: cargo test --test ${{ matrix.test }} -- ${{ contains(matrix.os, 'macos') && '--skip :docker:' || '' }}
+        # Run just this file's test binary from the archive. binary(=...) is an
+        # exact match so e.g. canister_call_tests does not also pull in
+        # canister_call_root_key_tests. The macOS runners do not support Docker,
+        # so drop the docker-tagged tests there (test-tag bakes ":docker:" into
+        # their names).
+        run: cargo nextest run --archive-file nextest-archive.tar.zst -E "binary(=${{ matrix.test }})${{ contains(matrix.os, 'macos') && ' & not test(~:docker:)' || '' }}"
         env:
           ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -246,8 +331,11 @@ jobs:
     name: test:required
     if: always() && needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, unit-tests, test]
+    needs: [changes, build, unit-tests, test]
     steps:
+      - name: check build result
+        if: ${{ needs.build.result != 'success' }}
+        run: exit 1
       - name: check unit-tests result
         if: ${{ needs.unit-tests.result != 'success' }}
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,17 +65,19 @@ jobs:
         run: echo "matrix=$(python3 .github/scripts/test-matrix.py)" >> $GITHUB_OUTPUT
 
   # Compile every test binary (unit + integration) plus the `icp` bin ONCE per
-  # OS and publish them as a nextest archive. The downstream unit-tests and test
-  # jobs run these prebuilt binaries with zero recompilation and no cache
-  # restore, replacing the old model where each of the ~30 integration-test jobs
-  # rebuilt the whole workspace from a deps-only cache.
+  # OS. Publish the binaries as a nextest archive so the integration-test jobs
+  # can run them without recompiling, and run the workspace UNIT tests right
+  # here (see the "Run unit tests" step for why they don't run from the archive).
   build:
-    name: Build test archive on ${{ matrix.os }}
+    name: Build & unit tests on ${{ matrix.os }}
     needs: changes
     if: needs.changes.outputs.src == 'true'
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # Don't cancel the other platforms when one fails — we want every OS's
+      # build + unit-test result from a single run.
+      fail-fast: false
       matrix:
         # Keep this os matrix in sync with .github/scripts/test-matrix.py so
         # every OS the test jobs run on has a matching archive.
@@ -143,64 +145,18 @@ jobs:
           # Only needed by same-run downstream jobs; don't retain it.
           retention-days: 1
 
-  unit-tests:
-    name: Unit tests on ${{ matrix.os }}
-    # Run the workspace unit tests from the prebuilt archive (no recompilation).
-    needs: build
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, macos-15, windows-2025]
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      # Defender scans the files nextest extracts from the archive; excluding the
-      # workspace/cargo dirs keeps that cheap on Windows.
-      - name: Exclude build dirs from Windows Defender
-        if: ${{ contains(matrix.os, 'windows') }}
-        shell: pwsh
-        run: |
-          Add-MpPreference -ExclusionPath `
-            "$env:GITHUB_WORKSPACE", `
-            "$env:USERPROFILE\.cargo", `
-            "$env:USERPROFILE\.rustup" -ErrorAction SilentlyContinue
-
-      # Provides the dbus runtime library the keyring-touching unit tests link
-      # against (see the unlock-keyring step below).
-      - name: Setup image (Linux)
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-        run: ./.github/scripts/provision-linux-build.sh
-
-      - name: Untap unused Homebrew taps (macOS)
-        if: ${{ contains(matrix.os, 'macos') }}
-        run: |
-          brew uninstall bicep || true
-          brew untap aws/tap || true
-          brew untap azure/bicep || true
-
-      # Toolchain to invoke `cargo nextest`; cache: false skips the (large) deps
-      # cache restore since this job never compiles.
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          cache: false
-
-      - name: Install nextest
-        uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2.70.2
-        with:
-          tool: nextest
-
       - uses: t1m0thyj/unlock-keyring@cbcf205c879ebd86add70bab3a6abfcce59a5cae # 1.2.0
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
-      - name: Download nextest archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: nextest-archive-${{ runner.os }}
-
+      # Run the workspace unit tests here, NOT from the archive. Some unit tests
+      # (e.g. icp-sync-plugin's runtime tests) read build-script fixtures under
+      # OUT_DIR that only exist on the machine that compiled them — nextest
+      # archives OUT_DIR only one level deep and can't carry the nested wasm, so
+      # an archived run on another machine can't find it. Running here reuses
+      # this job's fresh build (fixtures on disk) and avoids compiling the
+      # workspace a second time in a separate job.
       - name: Run unit tests
-        run: cargo nextest run --archive-file nextest-archive.tar.zst -E 'kind(lib) | kind(bin)'
+        run: cargo nextest run -E 'kind(lib) | kind(bin)'
 
   test:
     name: ${{ matrix.test }} on ${{ matrix.os }}
@@ -317,8 +273,11 @@ jobs:
         # exact match so e.g. canister_call_tests does not also pull in
         # canister_call_root_key_tests. The macOS runners do not support Docker,
         # so drop the docker-tagged tests there (test-tag bakes ":docker:" into
-        # their names).
-        run: cargo nextest run --archive-file nextest-archive.tar.zst -E "binary(=${{ matrix.test }})${{ contains(matrix.os, 'macos') && ' & not test(~:docker:)' || '' }}"
+        # their names). --no-tests=warn: some files are entirely #[cfg(unix)], so
+        # on Windows the binary has zero tests — warn (exit 0) instead of the
+        # default error, since the auto-generated matrix can't produce a typo'd
+        # binary name.
+        run: cargo nextest run --archive-file nextest-archive.tar.zst --no-tests=warn -E "binary(=${{ matrix.test }})${{ contains(matrix.os, 'macos') && ' & not test(~:docker:)' || '' }}"
         env:
           ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -326,13 +285,11 @@ jobs:
     name: test:required
     if: always() && needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, build, unit-tests, test]
+    needs: [changes, build, test]
     steps:
+      # `build` also runs the unit tests, so this covers unit-test failures too.
       - name: check build result
         if: ${{ needs.build.result != 'success' }}
-        run: exit 1
-      - name: check unit-tests result
-        if: ${{ needs.unit-tests.result != 'success' }}
         run: exit 1
       - name: check test result
         if: ${{ needs.test.result != 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,8 +155,14 @@ jobs:
       # an archived run on another machine can't find it. Running here reuses
       # this job's fresh build (fixtures on disk) and avoids compiling the
       # workspace a second time in a separate job.
+      #
+      # --workspace is required: without it cargo defaults to default-members
+      # (icp-cli only), which both skips the other crates' unit tests AND
+      # re-resolves features differently from the `nextest archive --workspace`
+      # build above, forcing a full recompile. Matching --workspace reuses the
+      # just-built artifacts (no recompile) and runs every crate's unit tests.
       - name: Run unit tests
-        run: cargo nextest run -E 'kind(lib) | kind(bin)'
+        run: cargo nextest run --workspace -E 'kind(lib) | kind(bin)'
 
   test:
     name: ${{ matrix.test }} on ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,11 +124,6 @@ jobs:
         with:
           cache-shared-key: ${{ runner.os }}-test
           cache-bin: false
-          # Write the dependency cache only from main; PRs restore it read-only
-          # (GitHub lets branches read the default branch's caches). This keeps
-          # the count of ~GB caches small so the repo stays under GitHub's 10 GB
-          # cache budget and its LRU eviction doesn't purge warm caches.
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
         uses: taiki-e/install-action@e9e8e031bcd90cdbe8ac6bb1d376f8596e587fbf # v2.70.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/icp-cli/tests/common/context.rs
+++ b/crates/icp-cli/tests/common/context.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use assert_cmd::{Command, cargo::cargo_bin_cmd};
+use assert_cmd::Command;
 use camino_tempfile::{Utf8TempDir as TempDir, tempdir};
 use ic_agent::Agent;
 use icp::prelude::*;
@@ -16,6 +16,19 @@ use time::UtcDateTime;
 use url::Url;
 
 use crate::common::{ChildGuard, PATH_SEPARATOR, TestNetwork, softhsm::SoftHsmContext};
+
+/// Path to the `icp` binary under test.
+///
+/// Under `cargo nextest run --archive-file`, the binary lives in nextest's extracted
+/// archive directory rather than the workspace `target/`, and its location is exposed at
+/// runtime via `NEXTEST_BIN_EXE_icp`. Fall back to the compile-time `CARGO_BIN_EXE_icp`
+/// path for a plain `cargo test` run (where the value is baked in and valid).
+fn icp_bin_path() -> PathBuf {
+    match env::var("NEXTEST_BIN_EXE_icp") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => PathBuf::from(env!("CARGO_BIN_EXE_icp")),
+    }
+}
 
 pub(crate) struct TestContext {
     home_dir: TempDir,
@@ -86,8 +99,7 @@ impl TestContext {
     }
 
     pub(crate) fn icp(&self) -> Command {
-        #[allow(clippy::disallowed_types)]
-        let mut cmd = cargo_bin_cmd!("icp");
+        let mut cmd = Command::new(icp_bin_path());
 
         // Isolate the command
         cmd.current_dir(self.home_path());
@@ -183,7 +195,7 @@ impl TestContext {
     /// Calling this method more than once will panic.
     /// Calling this method after calling [TestContext::start_network_with_config] will panic.
     pub(crate) async fn start_network_in(&self, project_dir: &Path, name: &str) -> ChildGuard {
-        let icp_path = env!("CARGO_BIN_EXE_icp");
+        let icp_path = icp_bin_path();
         let mut cmd = std::process::Command::new(icp_path);
         cmd.current_dir(project_dir);
         // isolate the whole user directory in Unix, test in normal mode


### PR DESCRIPTION
## Problem

Every integration-test job rebuilt the whole workspace before running, even on a cache **hit** — `Swatinem/rust-cache` (via `setup-rust-toolchain`) caches only registry **dependencies**, never workspace-crate artifacts. So the workspace was compiled **~32× per OS per run** (once in `unit-tests`, once in each of ~30 `test` jobs). Windows MSVC linking made each rebuild ~2× the Ubuntu cost.

Baseline (`network_status_tests` on windows-2025):

| step | time |
|---|---|
| toolchain setup + 2.1 GB cache restore | 1m11s |
| `Run` (build + test) | 5m20s (~4.5m build) |
| **job total** | **8m22s** |

## Approach — build once, run everywhere (`cargo-nextest archive`)

- **`build`** job (per OS): `cargo nextest archive --workspace` compiles every test binary + the `icp` bin **once**, uploads a `nextest-archive-<os>` artifact, and runs the workspace **unit tests** in place.
- **`test`** jobs (per file × OS): download the archive and run one binary with `-E "binary(=<name>)"` — **no compilation, no cache restore**. `--no-tests=warn` lets all-`cfg(unix)` files (which select 0 tests on Windows) pass with a warning instead of erroring; macOS drops docker-tagged tests via `& not test(~:docker:)`.
- `crates/icp-cli/tests/common/context.rs`: resolve the `icp` binary via the runtime `NEXTEST_BIN_EXE_icp`, falling back to compile-time `env!("CARGO_BIN_EXE_icp")` so plain local `cargo test` is unchanged.
- `fail-fast: false` on both matrices so one platform/binary failing doesn't cancel the rest.

**Why unit tests run in the `build` job (not from the archive):** some unit tests (icp-sync-plugin's runtime tests) read build-script fixtures under `OUT_DIR` that nextest can't carry in the archive (it archives `OUT_DIR` only one level deep) and that don't exist on a runner that never compiled. Running them where the workspace was built also avoids compiling it a second time.

Artifacts use GitHub's **Artifacts** storage — separate from the 10 GB **cache** quota — so this adds no cache pressure. Cache behavior is otherwise unchanged (PRs still save their own dep cache for fast iteration).

## Result (`network_status_tests` on windows-2025)

| step | before | after |
|---|---|---|
| toolchain setup + cache restore | 1m11s | **0m20s** (cache: false) |
| `Run` step | 5m20s (build + test) | **0m54s** (test only) |
| **job total** | **8m22s** | **3m11s** |

Every integration-test job drops the per-job workspace rebuild; the workspace now compiles once per OS instead of ~32×.

## Validation

Full matrix on this PR: all integration jobs green on Ubuntu + Windows (+ macOS `network_tests`); unit tests run in the `build` job, including icp-sync-plugin's `OUT_DIR`-dependent tests. Verified locally too: archive round-trip (integration 8/8 + unit slice 254/254), plain `cargo test` fallback, macOS docker skip, exact `binary(=…)` match, and `--no-tests=warn` (exit 0) vs the default `auto` (exit 4).

## Also included

- `fix(deps)`: upgrade crossbeam-epoch for RUSTSEC-2026-0204 (unblocks the `audit` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
