### PR TITLE
feat(network): require explicit root-key for connected networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ bump. Currently experimental: project bundling
 # Unreleased
 
 * feat: `icp canister delete` will now send the canister's remaining cycles to the caller
+* feat: Connected networks now take an explicit `root-key`, which accepts a hex-encoded key or one of two new values:
+  * `mainnet`: use the canonical IC mainnet root key — handy for reaching mainnet through a custom boundary node without repeating the literal.
+  * `fetch`: fetch the key from the network on each use. This is trust-on-first-use and does *not* verify the key's provenance, so it's meant only for testnets you or someone you trust operate; `icp` prints a warning whenever it fetches.
+  * `network status` reports where the key came from — a `root_key_source` field in `--json`, and a `(fetched - unverified, trust-on-first-use)` label in text output.
+  * `root-key` is now required for connected networks (previously optional, silently defaulting to the mainnet key). This is technically breaking, but most working projects are unaffected: a non-mainnet connected network already needed an explicit key, so in practice only a mainnet-via-custom-URL network needs to add `root-key: mainnet`. The built-in `ic` network is unchanged.
 
 # v1.0.2
 

--- a/crates/icp-cli/src/commands/network/status.rs
+++ b/crates/icp-cli/src/commands/network/status.rs
@@ -1,6 +1,9 @@
 use anyhow::Context as _;
 use clap::Args;
-use icp::{context::Context, network::Configuration};
+use icp::{
+    context::Context,
+    network::{Configuration, RootKeySource},
+};
 use serde::Serialize;
 
 use super::args::NetworkOrEnvironmentArgs;
@@ -48,6 +51,7 @@ struct NetworkStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     proxy_canister_principal: Option<String>,
     root_key: String,
+    root_key_source: RootKeySource,
 }
 
 pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow::Error> {
@@ -79,6 +83,7 @@ pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow:
                 api_url: network_access.api_url.to_string(),
                 gateway_url: network_access.http_gateway_url.map(|u| u.to_string()),
                 root_key: hex::encode(network_access.root_key),
+                root_key_source: network_access.root_key_source,
                 candid_ui_principal: descriptor.candid_ui_canister_id.map(|p| p.to_string()),
                 proxy_canister_principal: descriptor.proxy_canister_id.map(|p| p.to_string()),
             }
@@ -90,6 +95,7 @@ pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow:
             candid_ui_principal: None,
             proxy_canister_principal: None,
             root_key: hex::encode(network_access.root_key),
+            root_key_source: network_access.root_key_source,
         },
     };
 
@@ -102,7 +108,13 @@ pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow:
         if let Some(gateway_url) = status.gateway_url {
             output.push_str(&format!("Gateway Url: {}\n", gateway_url));
         }
-        output.push_str(&format!("Root Key: {}\n", status.root_key));
+        let root_key_note = match status.root_key_source {
+            RootKeySource::Managed => "",
+            RootKeySource::Mainnet => " (mainnet)",
+            RootKeySource::Configured => " (configured)",
+            RootKeySource::Fetched => " (fetched - unverified, trust-on-first-use)",
+        };
+        output.push_str(&format!("Root Key: {}{root_key_note}\n", status.root_key));
         if let Some(ref principal) = status.candid_ui_principal {
             output.push_str(&format!("Candid UI Principal: {}\n", principal));
         }

--- a/crates/icp-cli/src/options.rs
+++ b/crates/icp-cli/src/options.rs
@@ -2,6 +2,7 @@ use clap::error::ErrorKind;
 use clap::{ArgGroup, ArgMatches, Args, FromArgMatches};
 use icp::context::{EnvironmentSelection, NetworkSelection};
 use icp::identity::IdentitySelection;
+use icp::network::RootKeySpec;
 use icp::prelude::LOCAL;
 use url::Url;
 
@@ -64,19 +65,8 @@ impl From<EnvironmentOpt> for EnvironmentSelection {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct RootKey(pub Vec<u8>);
-
-fn parse_root_key(input: &str) -> Result<RootKey, String> {
-    let v = hex::decode(input).map_err(|e| format!("Invalid root key hex string: {e}"))?;
-    if v.len() != 133 {
-        Err(format!(
-            "Invalid root key. Expected 133 bytes but got {}",
-            v.len()
-        ))
-    } else {
-        Ok(RootKey(v))
-    }
+fn parse_root_key(input: &str) -> Result<RootKeySpec, String> {
+    RootKeySpec::try_from(input.to_string())
 }
 
 #[derive(Clone, Debug)]
@@ -100,16 +90,17 @@ pub(crate) struct NetworkOptInner {
     network: Option<NetworkTarget>,
 
     /// The root key to use if connecting to a network by URL.
-    /// Required when using `--network <URL>`.
+    /// Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a
+    /// 266-character hex-encoded root key.
     #[arg(long, short = 'k', requires = "network", help_heading = heading::NETWORK_PARAMETERS, value_parser = parse_root_key)]
-    root_key: Option<RootKey>,
+    root_key: Option<RootKeySpec>,
 }
 
 // This is wrapper around NetworkOptInner that will do some additional
 // validation to only allow --root-key when the network is a url.
 #[derive(Clone, Debug, Default)]
 pub(crate) enum NetworkOpt {
-    Url(Url, RootKey),
+    Url(Url, RootKeySpec),
 
     Name(String),
 
@@ -169,7 +160,7 @@ impl Args for NetworkOpt {
 impl From<NetworkOpt> for NetworkSelection {
     fn from(v: NetworkOpt) -> Self {
         match v {
-            NetworkOpt::Url(url, RootKey(key)) => NetworkSelection::Url(url, key),
+            NetworkOpt::Url(url, root_key) => NetworkSelection::Url(url, root_key),
             NetworkOpt::Name(name) => NetworkSelection::Named(name),
             NetworkOpt::None => NetworkSelection::Default,
         }

--- a/crates/icp-cli/tests/network_status_tests.rs
+++ b/crates/icp-cli/tests/network_status_tests.rs
@@ -1,4 +1,5 @@
 use icp::fs::write_string;
+use indoc::formatdoc;
 use predicates::str::{PredicateStrExt, contains};
 
 mod common;
@@ -135,6 +136,7 @@ networks:
   - name: connected-network
     mode: connected
     url: https://ic0.app
+    root-key: mainnet
 "#,
     )
     .expect("failed to write project manifest");
@@ -145,6 +147,77 @@ networks:
         .assert()
         .success()
         .stdout(contains("Url: https://ic0.app"));
+}
+
+/// End-to-end test of the `root-key: fetch` path with no external network:
+/// start a managed local network in one project, then in a second project
+/// define a connected network pointing at it with `root-key: fetch`. `icp`
+/// should fetch the running network's root key trust-on-first-use, warn about
+/// it, and `network status` should report the key as `fetched` and match the
+/// real root key.
+#[tokio::test]
+async fn status_connected_network_fetches_root_key() {
+    let ctx = TestContext::new();
+
+    // Provider project: start a managed local network on a random port.
+    let provider = ctx.create_project_dir("provider");
+    write_string(&provider.join("icp.yaml"), NETWORK_RANDOM_PORT)
+        .expect("failed to write provider manifest");
+    let _guard = ctx.start_network_in(&provider, "random-network").await;
+    let network = ctx.wait_for_network_descriptor(&provider, "random-network");
+    ctx.ping_until_healthy(&provider, "random-network");
+
+    // Consumer project: connect to the provider's network and fetch its root key.
+    let consumer = ctx.create_project_dir("consumer");
+    write_string(
+        &consumer.join("icp.yaml"),
+        &formatdoc! {r#"
+            networks:
+              - name: fetched-network
+                mode: connected
+                url: http://localhost:{port}
+                root-key: fetch
+        "#,
+            port = network.gateway_port,
+        },
+    )
+    .expect("failed to write consumer manifest");
+
+    // Text output: key is labeled as fetched, and the CLI warns on stderr.
+    ctx.icp()
+        .current_dir(&consumer)
+        .args(["network", "status", "fetched-network"])
+        .assert()
+        .success()
+        .stdout(contains("Root Key:"))
+        .stdout(contains("(fetched - unverified, trust-on-first-use)"))
+        .stderr(contains("provenance is not verified"));
+
+    // JSON output: root_key_source is "fetched" and the fetched key matches the
+    // running network's actual root key. (The warning lands on stderr, so the
+    // JSON on stdout stays clean.)
+    let output = ctx
+        .icp()
+        .current_dir(&consumer)
+        .args(["network", "status", "fetched-network", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json_str = String::from_utf8(output).expect("output should be valid UTF-8");
+    let json: serde_json::Value =
+        serde_json::from_str(&json_str).expect("output should be valid JSON");
+
+    assert_eq!(json["root_key_source"], "fetched");
+    assert_eq!(
+        json["root_key"]
+            .as_str()
+            .expect("root_key should be a string"),
+        hex::encode(&network.root_key),
+        "fetched root key should match the running network's root key"
+    );
 }
 
 #[test]

--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -612,6 +612,7 @@ async fn cannot_override_ic() {
               - name: ic
                 mode: connected
                 url: http://fake-ic.local
+                root-key: mainnet
         "#},
     )
     .expect("failed to write project manifest");

--- a/crates/icp-cli/tests/project_tests.rs
+++ b/crates/icp-cli/tests/project_tests.rs
@@ -280,6 +280,7 @@ fn redefine_ic_network_disallowed() {
           - name: ic
             mode: connected
             url: https://fake-ic.io
+            root-key: mainnet
         "#,
     )
     .expect("failed to write project manifest");

--- a/crates/icp/src/context/init.rs
+++ b/crates/icp/src/context/init.rs
@@ -128,14 +128,15 @@ pub fn initialize(
         ));
     }
 
+    // Agent creator
+    let agent_creator = Arc::new(agent::Creator);
+
     // Network accessor
     let netaccess = Arc::new(network::Accessor {
         project_root_locate: project_root_locate.clone(),
         descriptors: dirs.port_descriptor(),
+        agent: agent_creator.clone(),
     });
-
-    // Agent creator
-    let agent_creator = Arc::new(agent::Creator);
 
     // Setup environment
     Ok(Context {

--- a/crates/icp/src/context/mod.rs
+++ b/crates/icp/src/context/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     canister::{build::Build, sync::Synchronize},
     directories,
     identity::IdentitySelection,
+    manifest::network::RootKeySpec,
     network::{Configuration as NetworkConfiguration, access::NetworkAccess},
     prelude::*,
     store_id::{IdMapping, LookupIdError},
@@ -30,7 +31,7 @@ pub enum NetworkSelection {
     /// Use a named network
     Named(String),
     /// Use a network by URL
-    Url(Url, Vec<u8>),
+    Url(Url, RootKeySpec),
 }
 
 /// Selection type for environments - similar to IdentitySelection
@@ -180,7 +181,7 @@ impl Context {
                                 http_gateway_url: Some(
                                     IC_MAINNET_NETWORK_GATEWAY_URL.parse().unwrap(),
                                 ),
-                                root_key: IC_ROOT_KEY.to_vec(),
+                                root_key: RootKeySpec::Mainnet,
                             },
                         },
                     }
@@ -197,7 +198,7 @@ impl Context {
                     connected: crate::network::Connected {
                         api_url: url.clone(),
                         http_gateway_url: Some(url.clone()),
-                        root_key: root_key.to_vec(),
+                        root_key: root_key.clone(),
                     },
                 },
             },

--- a/crates/icp/src/context/tests.rs
+++ b/crates/icp/src/context/tests.rs
@@ -350,6 +350,7 @@ async fn test_get_agent_for_env_uses_environment_network() {
                     "local",
                     NetworkAccess {
                         root_key: local_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse("http://localhost:8000").unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -359,6 +360,7 @@ async fn test_get_agent_for_env_uses_environment_network() {
                     "staging",
                     NetworkAccess {
                         root_key: staging_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse("http://staging:9000").unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -433,6 +435,7 @@ async fn test_get_agent_for_network_success() {
             "local",
             NetworkAccess {
                 root_key: root_key.clone(),
+                root_key_source: crate::network::RootKeySource::Configured,
                 api_url: Url::parse("http://localhost:8000").unwrap(),
                 http_gateway_url: None,
                 use_friendly_domains: false,
@@ -647,6 +650,7 @@ async fn test_get_agent_defaults_inside_project_with_default_local() {
             LOCAL,
             NetworkAccess {
                 root_key: local_root_key.clone(),
+                root_key_source: crate::network::RootKeySource::Configured,
                 api_url: Url::parse(DEFAULT_LOCAL_NETWORK_URL).unwrap(),
                 http_gateway_url: None,
                 use_friendly_domains: false,
@@ -720,6 +724,7 @@ async fn test_get_agent_defaults_with_overridden_local_network() {
             LOCAL,
             NetworkAccess {
                 root_key: custom_root_key.clone(),
+                root_key_source: crate::network::RootKeySource::Configured,
                 api_url: Url::parse("http://localhost:9000").unwrap(), // Custom port
                 http_gateway_url: None,
                 use_friendly_domains: false,
@@ -820,6 +825,7 @@ async fn test_get_agent_defaults_with_overridden_local_environment() {
                     LOCAL,
                     NetworkAccess {
                         root_key: local_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse(DEFAULT_LOCAL_NETWORK_URL).unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -829,6 +835,7 @@ async fn test_get_agent_defaults_with_overridden_local_environment() {
                     "custom",
                     NetworkAccess {
                         root_key: custom_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse("http://localhost:7000").unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -864,6 +871,7 @@ async fn test_get_agent_explicit_network_inside_project() {
                     LOCAL,
                     NetworkAccess {
                         root_key: local_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse(DEFAULT_LOCAL_NETWORK_URL).unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -873,6 +881,7 @@ async fn test_get_agent_explicit_network_inside_project() {
                     "staging",
                     NetworkAccess {
                         root_key: staging_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse("http://localhost:8001").unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -909,6 +918,7 @@ async fn test_get_agent_explicit_environment_inside_project() {
                     LOCAL,
                     NetworkAccess {
                         root_key: local_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse(DEFAULT_LOCAL_NETWORK_URL).unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,
@@ -918,6 +928,7 @@ async fn test_get_agent_explicit_environment_inside_project() {
                     "staging",
                     NetworkAccess {
                         root_key: staging_root_key.clone(),
+                        root_key_source: crate::network::RootKeySource::Configured,
                         api_url: Url::parse("http://localhost:8001").unwrap(),
                         http_gateway_url: None,
                         use_friendly_domains: false,

--- a/crates/icp/src/lib.rs
+++ b/crates/icp/src/lib.rs
@@ -349,10 +349,10 @@ impl MockProjectLoader {
     ///   - "prod" (ic network, backend and frontend only)
     pub fn complex() -> Self {
         use crate::{
-            context::IC_ROOT_KEY,
             manifest::{
                 adapter::prebuilt::{Adapter as PrebuiltAdapter, LocalSource, SourceField},
                 canister::{BuildStep, BuildSteps, SyncSteps},
+                network::RootKeySpec,
             },
             network::{
                 Configuration, Connected, Gateway, Managed, ManagedLauncherConfig, ManagedMode,
@@ -460,7 +460,7 @@ impl MockProjectLoader {
                 connected: Connected {
                     api_url: IC_MAINNET_NETWORK_API_URL.parse().unwrap(),
                     http_gateway_url: Some(IC_MAINNET_NETWORK_GATEWAY_URL.parse().unwrap()),
-                    root_key: IC_ROOT_KEY.to_vec(),
+                    root_key: RootKeySpec::Mainnet,
                 },
             },
         };
@@ -711,6 +711,7 @@ mod tests {
               - name: test-network
                 mode: connected
                 url: https://somenetwork.icp
+                root-key: mainnet
             environments:
               - name: local
                 network: test-network

--- a/crates/icp/src/manifest/network.rs
+++ b/crates/icp/src/manifest/network.rs
@@ -123,10 +123,16 @@ pub struct Connected {
     #[serde(flatten)]
     pub endpoints: Endpoints,
 
-    /// The root key of this network
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<String>", regex(pattern = "^[0-9a-f]{266}$"))]
-    pub root_key: Option<RootKey>,
+    /// How to obtain the root key used to verify responses from this network.
+    ///
+    /// One of:
+    /// - `mainnet`: use the canonical IC mainnet root key (e.g. to reach mainnet
+    ///   through a non-default boundary node without repeating the key literal).
+    /// - `fetch`: fetch the root key from the network on each use. This is
+    ///   trust-on-first-use and does *not* verify the key's provenance; only use it
+    ///   for testnets that you (or someone you trust) operate.
+    /// - a 266-character hex-encoded root key (133 bytes).
+    pub root_key: RootKeySpec,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
@@ -150,22 +156,67 @@ pub enum Endpoints {
     },
 }
 
+/// The expected byte length of a root key (133 bytes / 266 hex characters).
+pub const ROOT_KEY_LEN: usize = 133;
+
+/// How to obtain the root key used to verify responses from a connected network.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(try_from = "String", into = "String")]
-pub struct RootKey(pub Vec<u8>);
+pub enum RootKeySpec {
+    /// Use the canonical IC mainnet root key.
+    Mainnet,
+    /// Fetch the root key from the network on each use (trust-on-first-use, unverified).
+    Fetch,
+    /// A specific root key (133 bytes).
+    Explicit(Vec<u8>),
+}
 
-impl TryFrom<String> for RootKey {
-    type Error = hex::FromHexError;
+impl TryFrom<String> for RootKeySpec {
+    type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let bytes = hex::decode(value)?;
-        Ok(RootKey(bytes))
+        match value.as_str() {
+            "mainnet" => Ok(RootKeySpec::Mainnet),
+            "fetch" => Ok(RootKeySpec::Fetch),
+            hex => {
+                let bytes = hex::decode(hex)
+                    .map_err(|e| format!("invalid root key: expected \"mainnet\", \"fetch\", or a hex-encoded key, but failed to decode as hex: {e}"))?;
+                if bytes.len() != ROOT_KEY_LEN {
+                    return Err(format!(
+                        "invalid root key: expected {ROOT_KEY_LEN} bytes but got {}",
+                        bytes.len()
+                    ));
+                }
+                Ok(RootKeySpec::Explicit(bytes))
+            }
+        }
     }
 }
 
-impl From<RootKey> for String {
-    fn from(root_key: RootKey) -> Self {
-        hex::encode(root_key.0)
+impl From<RootKeySpec> for String {
+    fn from(spec: RootKeySpec) -> Self {
+        match spec {
+            RootKeySpec::Mainnet => "mainnet".to_string(),
+            RootKeySpec::Fetch => "fetch".to_string(),
+            RootKeySpec::Explicit(bytes) => hex::encode(bytes),
+        }
+    }
+}
+
+impl JsonSchema for RootKeySpec {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "RootKeySpec".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "description": "Root key: \"mainnet\", \"fetch\", or a 266-character hex-encoded key.",
+            "anyOf": [
+                { "enum": ["mainnet", "fetch"] },
+                { "pattern": "^[0-9a-f]{266}$" }
+            ]
+        })
     }
 }
 
@@ -220,6 +271,7 @@ mod tests {
                 name: my-network
                 mode: connected
                 url: https://ic0.app
+                root-key: mainnet
             "#}),
             NetworkManifest {
                 name: "my-network".to_string(),
@@ -227,10 +279,48 @@ mod tests {
                     endpoints: Endpoints::Implicit {
                         url: "https://ic0.app".parse().unwrap(),
                     },
-                    root_key: None
+                    root_key: RootKeySpec::Mainnet,
                 }),
             },
         );
+    }
+
+    #[test]
+    fn connected_network_fetch() {
+        assert_eq!(
+            validate_network_yaml(indoc! {r#"
+                name: my-network
+                mode: connected
+                url: https://testnet.example.com
+                root-key: fetch
+            "#}),
+            NetworkManifest {
+                name: "my-network".to_string(),
+                configuration: Mode::Connected(Connected {
+                    endpoints: Endpoints::Implicit {
+                        url: "https://testnet.example.com".parse().unwrap(),
+                    },
+                    root_key: RootKeySpec::Fetch,
+                }),
+            },
+        );
+    }
+
+    #[test]
+    fn connected_network_requires_root_key() {
+        match serde_yaml::from_str::<NetworkManifest>(indoc! {r#"
+                name: my-network
+                mode: connected
+                url: https://ic0.app
+            "#})
+        {
+            Ok(_) => panic!("a connected network without a root key should fail"),
+            Err(err) => {
+                if !format!("{err}").contains("root-key") {
+                    panic!("unexpected error for missing root key: {err}");
+                }
+            }
+        };
     }
 
     #[test]
@@ -269,16 +359,14 @@ mod tests {
                     endpoints: Endpoints::Implicit {
                         url: "https://ic0.app".parse().unwrap(),
                     },
-                    root_key: Some(
-                        RootKey::try_from(
-                            "308182301d060d2b0601040182dc7c0503010201060c2b0601040182dc7c050302010\
+                    root_key: RootKeySpec::try_from(
+                        "308182301d060d2b0601040182dc7c0503010201060c2b0601040182dc7c050302010\
                             361008b52b4994f94c7ce4be1c1542d7c81dc79fea17d49efe8fa42e8566373581d4b9\
                             69c4a59e96a0ef51b711fe5027ec01601182519d0a788f4bfe388e593b97cd1d7e4490\
                             4de79422430bca686ac8c21305b3397b5ba4d7037d17877312fb7ee34"
-                                .to_string()
-                        )
-                        .unwrap()
+                            .to_string()
                     )
+                    .unwrap(),
                 }),
             },
         );

--- a/crates/icp/src/network/access.rs
+++ b/crates/icp/src/network/access.rs
@@ -1,15 +1,40 @@
+use std::sync::Arc;
+
+use ic_agent::{AgentError, identity::AnonymousIdentity};
+use serde::Serialize;
 use snafu::{OptionExt, ResultExt, Snafu};
 use url::Url;
 
 use crate::{
+    agent::{Create, CreateAgentError},
+    context::IC_ROOT_KEY,
+    manifest::network::RootKeySpec,
     network::{Connected, NetworkDirectory, directory::LoadNetworkFileError},
     prelude::*,
 };
 
+/// Where a network's root key came from. Used for display so users can tell a
+/// trusted/pinned key apart from one that was fetched trust-on-first-use.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RootKeySource {
+    /// Key belongs to a managed network we launched.
+    Managed,
+    /// The canonical IC mainnet root key.
+    Mainnet,
+    /// An explicit key pinned in the manifest or on the command line.
+    Configured,
+    /// Fetched from the network (trust-on-first-use, provenance unverified).
+    Fetched,
+}
+
 #[derive(Clone)]
 pub struct NetworkAccess {
-    /// Network's root-key
+    /// Network's (resolved) root key.
     pub root_key: Vec<u8>,
+
+    /// Where [`Self::root_key`] came from.
+    pub root_key_source: RootKeySource,
 
     /// Routing configuration
     pub api_url: Url,
@@ -44,6 +69,20 @@ pub enum GetNetworkAccessError {
 
     #[snafu(display("failed to load network descriptor"))]
     LoadNetworkDescriptor { source: LoadNetworkFileError },
+
+    #[snafu(display("failed to create agent to fetch root key from {url}"))]
+    CreateBootstrapAgent {
+        url: Url,
+        #[snafu(source(from(CreateAgentError, Box::new)))]
+        source: Box<CreateAgentError>,
+    },
+
+    #[snafu(display("failed to fetch root key from {url}"))]
+    FetchRootKey {
+        url: Url,
+        #[snafu(source(from(AgentError, Box::new)))]
+        source: Box<AgentError>,
+    },
 }
 
 pub async fn get_managed_network_access(
@@ -81,6 +120,7 @@ pub async fn get_managed_network_access(
     let http_gateway_url = Url::parse(&format!("http://{}:{port}", desc.gateway.host)).unwrap();
     Ok(NetworkAccess {
         root_key: desc.root_key,
+        root_key_source: RootKeySource::Managed,
         api_url: http_gateway_url.clone(),
         http_gateway_url: Some(http_gateway_url),
         use_friendly_domains: desc.use_friendly_domains,
@@ -89,13 +129,47 @@ pub async fn get_managed_network_access(
 
 pub async fn get_connected_network_access(
     connected: &Connected,
+    agent: &Arc<dyn Create>,
 ) -> Result<NetworkAccess, GetNetworkAccessError> {
-    let root_key = connected.root_key.clone();
+    let (root_key, root_key_source) = match &connected.root_key {
+        RootKeySpec::Mainnet => (IC_ROOT_KEY.to_vec(), RootKeySource::Mainnet),
+        RootKeySpec::Explicit(bytes) => (bytes.clone(), RootKeySource::Configured),
+        RootKeySpec::Fetch => {
+            let root_key = fetch_root_key(agent, &connected.api_url).await?;
+            (root_key, RootKeySource::Fetched)
+        }
+    };
 
     Ok(NetworkAccess {
         root_key,
+        root_key_source,
         api_url: connected.api_url.clone(),
         http_gateway_url: connected.http_gateway_url.clone(),
         use_friendly_domains: false,
     })
+}
+
+/// Fetch a network's root key trust-on-first-use. This does *not* verify the
+/// key's provenance, so we warn the user that responses cannot be trusted the
+/// way a pinned key allows.
+async fn fetch_root_key(
+    agent: &Arc<dyn Create>,
+    api_url: &Url,
+) -> Result<Vec<u8>, GetNetworkAccessError> {
+    tracing::warn!(
+        "fetching the root key from {api_url}; its provenance is not verified (trust-on-first-use)"
+    );
+    let bootstrap = agent
+        .create(Arc::new(AnonymousIdentity), api_url.as_str())
+        .await
+        .context(CreateBootstrapAgentSnafu {
+            url: api_url.clone(),
+        })?;
+    bootstrap
+        .fetch_root_key()
+        .await
+        .context(FetchRootKeySnafu {
+            url: api_url.clone(),
+        })?;
+    Ok(bootstrap.read_root_key())
 }

--- a/crates/icp/src/network/mod.rs
+++ b/crates/icp/src/network/mod.rs
@@ -5,6 +5,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use snafu::prelude::*;
 
+pub use crate::manifest::network::RootKeySpec;
+pub use access::RootKeySource;
 pub use directory::{LoadPidError, NetworkDirectory, SavePidError};
 pub use managed::run::{RunNetworkError, run_network};
 use strum::EnumString;
@@ -172,10 +174,8 @@ pub struct Connected {
     /// The URL this network's HTTP gateway can be reached at.
     pub http_gateway_url: Option<Url>,
 
-    /// The root key of this network
-    #[serde(with = "hex::serde")]
-    #[schemars(with = "String")]
-    pub root_key: Vec<u8>,
+    /// How to obtain the root key used to verify responses from this network.
+    pub root_key: RootKeySpec,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, JsonSchema, Serialize)]
@@ -232,9 +232,7 @@ impl From<ManifestGateway> for Gateway {
 
 impl From<ManifestConnected> for Connected {
     fn from(value: ManifestConnected) -> Self {
-        let root_key = value
-            .root_key
-            .map_or_else(|| crate::context::IC_ROOT_KEY.to_vec(), |rk| rk.0);
+        let root_key = value.root_key;
         match value.endpoints {
             Endpoints::Implicit { url } => Connected {
                 api_url: url.clone(),
@@ -358,6 +356,9 @@ pub struct Accessor {
 
     // Port descriptors dir
     pub descriptors: PathBuf,
+
+    // Used to build a bootstrap agent when a connected network fetches its root key
+    pub agent: Arc<dyn crate::agent::Create>,
 }
 
 #[async_trait]
@@ -384,7 +385,7 @@ impl Access for Accessor {
                 Ok(get_managed_network_access(nd).await?)
             }
             Configuration::Connected { connected: cfg } => {
-                Ok(get_connected_network_access(cfg).await?)
+                Ok(get_connected_network_access(cfg, &self.agent).await?)
             }
         }
     }

--- a/crates/icp/src/project.rs
+++ b/crates/icp/src/project.rs
@@ -7,7 +7,6 @@ use snafu::prelude::*;
 use crate::{
     Canister, Environment, InitArgs, Network, Project,
     canister::recipe,
-    context::IC_ROOT_KEY,
     fs,
     manifest::{
         ArgsFormat, CANISTER_MANIFEST, CanisterManifest, EnvironmentManifest, Item,
@@ -16,6 +15,7 @@ use crate::{
         canister::{Instructions, SyncSteps},
         environment::CanisterSelection,
         load_manifest_from_path,
+        network::RootKeySpec,
         recipe::RecipeType,
     },
     network::{
@@ -349,7 +349,7 @@ pub async fn consolidate_manifest(
                 connected: Connected {
                     api_url: IC_MAINNET_NETWORK_API_URL.parse().unwrap(),
                     http_gateway_url: Some(IC_MAINNET_NETWORK_GATEWAY_URL.parse().unwrap()),
-                    root_key: IC_ROOT_KEY.to_vec(),
+                    root_key: RootKeySpec::Mainnet,
                 },
             },
         },

--- a/docs/concepts/environments.md
+++ b/docs/concepts/environments.md
@@ -46,6 +46,7 @@ networks:
   - name: testnet
     mode: connected
     url: https://testnet.ic0.app
+    root-key: fetch
 ```
 
 Use connected networks for shared testnets and production.
@@ -58,6 +59,7 @@ networks:
     mode: connected
     api-url: https://api.testnet.example.com
     http-gateway-url: https://testnet.example.com
+    root-key: fetch
 ```
 
 If `http-gateway-url` is omitted, canister URLs will not be printed during deploy operations.

--- a/docs/concepts/project-model.md
+++ b/docs/concepts/project-model.md
@@ -70,6 +70,7 @@ networks:
     configuration:
       mode: connected
       url: https://icp-api.io
+      root-key: mainnet
   - name: local
     configuration:
       mode: managed

--- a/docs/migration/from-dfx.md
+++ b/docs/migration/from-dfx.md
@@ -263,6 +263,7 @@ networks:
   - name: staging
     mode: connected
     url: https://icp-api.io
+    root-key: mainnet
 
 environments:
   - name: staging
@@ -322,7 +323,7 @@ networks:
 - dfx's `"type": "ephemeral"` maps to icp-cli's `mode: managed` (local networks that icp-cli controls)
 - dfx's `"providers"` array (which can list multiple URLs for redundancy) becomes a single `url` field in icp-cli
 - dfx's `"bind"` address for local networks maps to icp-cli's `gateway.bind` and `gateway.port`
-- **Root key handling**: dfx automatically fetches the root key from non-mainnet networks at runtime. icp-cli requires you to specify the `root-key` explicitly in the configuration for testnets (connected networks). For local managed networks, icp-cli retrieves the root key from the network launcher. The root key is the public key used to verify responses from the network. Explicit configuration ensures the root key comes from a trusted source rather than the network itself.
+- **Root key handling**: dfx automatically fetches the root key from non-mainnet networks at runtime. icp-cli requires you to specify the `root-key` explicitly for connected networks, with one of three values: `mainnet` (use the canonical mainnet key — handy for a custom boundary node), `fetch` (fetch it from the network on each use — the equivalent of dfx's automatic behavior, trust-on-first-use and unverified), or a hex-encoded key to pin. For local managed networks, icp-cli retrieves the root key from the network launcher. Requiring an explicit choice means you opt into fetching rather than getting it silently.
 
 **Note:** icp-cli uses `https://icp-api.io` as the default IC mainnet URL, while dfx currently uses `https://icp0.io`. Both URLs point to the same IC mainnet, but `https://icp-api.io` is the recommended API gateway. The implicit `ic` network in icp-cli is configured with `https://icp-api.io`.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -163,7 +163,7 @@ Make a canister call
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--args-file <ARGS_FILE>` — Path to a file containing call arguments
@@ -239,7 +239,7 @@ Examples:
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--controller <CONTROLLER>` — One or more controllers for the canister. Repeat `--controller` to specify multiple
@@ -275,7 +275,7 @@ Cycles will be sent to the caller via the cycles ledger. This is done by install
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister call through
@@ -332,7 +332,7 @@ Install a built WASM to a canister on a network
 
 * `-y`, `--yes` — Skip confirmation prompts, including the Candid interface compatibility check and the dangerous-operation prompt for `--wasm-memory-persistence replace`
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister call through
@@ -367,7 +367,7 @@ Fetch and display canister logs
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `-f`, `--follow` — Continuously fetch and display new logs until interrupted with Ctrl+C
@@ -396,7 +396,7 @@ Read a metadata section from a canister
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON
@@ -416,7 +416,7 @@ Migrate a canister ID from one subnet to another
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--replace <REPLACE>` — The canister to replace with the source canister's ID
@@ -456,7 +456,7 @@ Queries the canister_status endpoint of the management canister and displays onl
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Format output as JSON
@@ -477,7 +477,7 @@ Change a canister's settings to specified values
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `-f`, `--force` — Force the operation without confirmation prompts
@@ -518,7 +518,7 @@ Synchronize a canister's settings with those defined in the project
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister calls through
@@ -555,7 +555,7 @@ Create a snapshot of a canister's state
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--replace <REPLACE>` — Replace an existing snapshot instead of creating a new one. The old snapshot will be deleted once the new one is successfully created
@@ -579,7 +579,7 @@ Delete a canister snapshot
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister call through
@@ -600,7 +600,7 @@ Download a snapshot to local disk
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `-o`, `--output <OUTPUT>` — Output directory for the snapshot files
@@ -622,7 +622,7 @@ List all snapshots for a canister
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON
@@ -645,7 +645,7 @@ Restore a canister from a snapshot
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister calls through
@@ -665,7 +665,7 @@ Upload a snapshot from local disk
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `-i`, `--input <INPUT>` — Input directory containing the snapshot files
@@ -690,7 +690,7 @@ Start a canister on a network
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister call through
@@ -727,7 +727,7 @@ Examples:
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `-i`, `--id-only` — Only print the canister ids
@@ -750,7 +750,7 @@ Stop a canister on a network
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--proxy <PROXY>` — Principal of a proxy canister to route the management canister call through
@@ -771,7 +771,7 @@ Top up a canister with cycles
 
 * `--amount <AMOUNT>` — Amount of cycles to top up. Supports suffixes: k (thousand), m (million), b (billion), t (trillion)
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 
@@ -800,7 +800,7 @@ Display the cycles balance
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--subaccount <SUBACCOUNT>` — The subaccount to check the balance for
@@ -825,7 +825,7 @@ Exactly one of --icp or --cycles must be provided.
 * `--from-subaccount <FROM_SUBACCOUNT>` — Subaccount to withdraw the ICP from
 * `--to-subaccount <TO_SUBACCOUNT>` — Subaccount to deposit the cycles to
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON
@@ -848,7 +848,7 @@ Transfer cycles to another principal
 * `--to-subaccount <TO_SUBACCOUNT>` — The subaccount to transfer to (only if the receiver is a principal)
 * `--from-subaccount <FROM_SUBACCOUNT>` — The subaccount to transfer cycles from
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON
@@ -1668,7 +1668,7 @@ Display the token balance on the ledger (default token: icp)
 ###### **Options:**
 
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--subaccount <SUBACCOUNT>` — The subaccount to check the balance for
@@ -1694,7 +1694,7 @@ Transfer ICP or ICRC1 tokens through their ledger (default token: icp)
 * `--to-subaccount <TO_SUBACCOUNT>` — The subaccount to transfer to (only if the receiver is a principal)
 * `--from-subaccount <FROM_SUBACCOUNT>` — The subaccount to transfer from
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -294,7 +294,7 @@ networks:
   - name: testnet
     mode: connected
     url: https://testnet.ic0.app
-    root-key: <hex-encoded-key>  # For non-mainnet
+    root-key: fetch  # mainnet | fetch | <hex-encoded-key>
 ```
 
 | Property | Type | Required | Description |
@@ -302,7 +302,15 @@ networks:
 | `name` | string | Yes | Network identifier |
 | `mode` | string | Yes | `connected` |
 | `url` | string | Yes | Network endpoint URL |
-| `root-key` | string | No | Hex-encoded root key (non-mainnet only) |
+| `root-key` | string | Yes | How to obtain the root key: see below |
+
+The `root-key` is the public key used to verify responses from the network, and is required for connected networks. It accepts one of:
+
+- **`mainnet`** — use the canonical IC mainnet root key. Use this to reach mainnet through a non-default boundary node without repeating the key literal; responses are still fully verified against the real mainnet key.
+- **`fetch`** — fetch the root key from the network on each use. This is trust-on-first-use and does **not** verify the key's provenance, so only use it for testnets that you (or someone you trust) operate. `icp` prints a warning whenever it fetches, and `network status` labels such a key as `fetched`.
+- **a 266-character hex-encoded key** — pin a specific root key.
+
+> The built-in `ic` network always uses the mainnet root key and cannot be redefined.
 
 ### Docker Network
 

--- a/docs/schemas/icp-yaml-schema.json
+++ b/docs/schemas/icp-yaml-schema.json
@@ -273,14 +273,13 @@
       ],
       "properties": {
         "root-key": {
-          "description": "The root key of this network",
-          "pattern": "^[0-9a-f]{266}$",
-          "type": [
-            "string",
-            "null"
-          ]
+          "$ref": "#/$defs/RootKeySpec",
+          "description": "How to obtain the root key used to verify responses from this network.\n\nOne of:\n- `mainnet`: use the canonical IC mainnet root key (e.g. to reach mainnet\n  through a non-default boundary node without repeating the key literal).\n- `fetch`: fetch the root key from the network on each use. This is\n  trust-on-first-use and does *not* verify the key's provenance; only use it\n  for testnets that you (or someone you trust) operate.\n- a 266-character hex-encoded root key (133 bytes)."
         }
       },
+      "required": [
+        "root-key"
+      ],
       "type": "object"
     },
     "ControllerRef": {
@@ -797,6 +796,21 @@
         "url"
       ],
       "type": "object"
+    },
+    "RootKeySpec": {
+      "anyOf": [
+        {
+          "enum": [
+            "mainnet",
+            "fetch"
+          ]
+        },
+        {
+          "pattern": "^[0-9a-f]{266}$"
+        }
+      ],
+      "description": "Root key: \"mainnet\", \"fetch\", or a 266-character hex-encoded key.",
+      "type": "string"
     },
     "Settings": {
       "description": "Canister settings, such as compute and memory allocation.",

--- a/docs/schemas/network-yaml-schema.json
+++ b/docs/schemas/network-yaml-schema.json
@@ -39,14 +39,13 @@
       ],
       "properties": {
         "root-key": {
-          "description": "The root key of this network",
-          "pattern": "^[0-9a-f]{266}$",
-          "type": [
-            "string",
-            "null"
-          ]
+          "$ref": "#/$defs/RootKeySpec",
+          "description": "How to obtain the root key used to verify responses from this network.\n\nOne of:\n- `mainnet`: use the canonical IC mainnet root key (e.g. to reach mainnet\n  through a non-default boundary node without repeating the key literal).\n- `fetch`: fetch the root key from the network on each use. This is\n  trust-on-first-use and does *not* verify the key's provenance; only use it\n  for testnets that you (or someone you trust) operate.\n- a 266-character hex-encoded root key (133 bytes)."
         }
       },
+      "required": [
+        "root-key"
+      ],
       "type": "object"
     },
     "Gateway": {
@@ -277,6 +276,21 @@
         }
       ],
       "type": "object"
+    },
+    "RootKeySpec": {
+      "anyOf": [
+        {
+          "enum": [
+            "mainnet",
+            "fetch"
+          ]
+        },
+        {
+          "pattern": "^[0-9a-f]{266}$"
+        }
+      ],
+      "description": "Root key: \"mainnet\", \"fetch\", or a 266-character hex-encoded key.",
+      "type": "string"
     },
     "SubnetKind": {
       "enum": [

--- a/examples/icp-network-connected/README.md
+++ b/examples/icp-network-connected/README.md
@@ -8,8 +8,8 @@ This project defines a `staging` network that is an alias for the mainnet. This 
 
 ## Instructions
 
-To deploy the canister to the `staging` network, run the following command:
+This project also defines a `staging` environment that targets the `staging` network. To deploy the canister to it, run:
 
 ```bash
-icp deploy --network staging
+icp deploy --environment staging
 ```

--- a/examples/icp-network-connected/icp.yaml
+++ b/examples/icp-network-connected/icp.yaml
@@ -11,3 +11,7 @@ canisters:
 
 networks:
   - networks/staging.yaml
+
+environments:
+  - name: staging
+    network: staging

--- a/examples/icp-network-connected/networks/staging.yaml
+++ b/examples/icp-network-connected/networks/staging.yaml
@@ -5,3 +5,4 @@
 name: staging
 mode: connected
 url: https://icp.net
+root-key: mainnet

--- a/examples/icp-network-inline/README.md
+++ b/examples/icp-network-inline/README.md
@@ -8,8 +8,8 @@ This project defines a `staging` network that is an alias for the mainnet. This 
 
 ## Instructions
 
-To deploy the canister to the `staging` network, run the following command:
+This project also defines a `staging` environment that targets the `staging` network. To deploy the canister to it, run:
 
 ```bash
-icp deploy --network staging
+icp deploy --environment staging
 ```

--- a/examples/icp-network-inline/icp.yaml
+++ b/examples/icp-network-inline/icp.yaml
@@ -13,3 +13,8 @@ networks:
   - name: staging
     mode: connected
     url: https://icp.net
+    root-key: mainnet
+
+environments:
+  - name: staging
+    network: staging


### PR DESCRIPTION
## Summary

The `root-key` for a connected network was optional and silently defaulted to the IC mainnet key. That masked misconfiguration: a connected network pointing somewhere non-mainnet would appear to work until the first real message-verification failure.

This makes `root-key` **required** for connected networks and gives it three forms:

- **`mainnet`** — use the canonical IC mainnet root key (e.g. to reach mainnet through a custom boundary node without repeating the 266-char literal). Responses are still fully verified against the real mainnet key.
- **`fetch`** — fetch the key from the network on each use. Trust-on-first-use and **unverified**, so intended only for testnets you (or someone you trust) operate. A `WARN` is printed on every fetch.
- **a hex-encoded key** — pin a specific key, as before.

Only the built-in `ic` network keeps the implicit mainnet key.

## Design notes

- **The `fetch` ordering problem.** `root-key` is needed to verify delegated (Internet Identity) chains *before* the agent exists, but `fetch_root_key()` needs an agent + a round-trip. Resolved by doing the fetch inside the network `Accessor` via an anonymous bootstrap agent, so `NetworkAccess` already carries resolved bytes by the time identity verification runs. Context's agent-build flow is unchanged.
- **No caching.** The motivating use case is "a testnet rebooted and got a new key," so a cache would serve a stale key. Matches dfx: always fetch fresh (one cheap unauthenticated status call).
- **Provenance reporting.** `network status` gains a `root_key_source` field in `--json` (`managed` / `mainnet` / `configured` / `fetched`) and a plain-ASCII label in text output, e.g. `Root Key: 3081… (fetched - unverified, trust-on-first-use)`. The `root_key` field stays a flat hex string (non-breaking for JSON consumers); the warning goes to stderr so `--json` stdout stays clean.

## Breaking change (staying on v1.x)

Technically breaking — a connected network with no `root-key` now fails to load. But non-mainnet connected networks already needed an explicit key to work, so in practice only a mainnet-via-custom-URL network must add `root-key: mainnet`. Small, acceptable radius → no major-version bump. See CHANGELOG.

## Also in this PR

Fixes the `icp-network-inline` / `icp-network-connected` examples, which defined a `staging` network but no matching environment and told users to run `icp deploy --network staging` — but `deploy` takes `--environment`, not `--network`. Both now define a `staging` environment and the READMEs use `icp deploy --environment staging`.

## Testing

- `cargo test`, `cargo fmt --check`, `cargo clippy --tests --benches -- -D warnings` all green.
- New end-to-end test `status_connected_network_fetches_root_key`: starts a managed local network in one project, connects to it from a second project with `root-key: fetch`, and asserts the fetch warning, the `fetched` label/`root_key_source`, and that the fetched key matches the running network's actual root key — no external network required.
- Schemas and CLI docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)