### PR TITLE
docs: regenerate CLI reference to fix cli-ref inconsistency

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1725,7 +1725,7 @@ Sets the spender's allowance to the given amount, overwriting any existing allow
 * `--from-subaccount <FROM_SUBACCOUNT>` — The caller's subaccount to grant the allowance from (the account debited), as a hex string (32 bytes, left-padded). Defaults to the default subaccount
 * `--expires-in <DURATION>` — Expire the allowance after this duration from now, e.g. `24h`, `30d` (suffixes: s, m, h, d, w; a bare number is seconds). Never expires if omitted
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON
@@ -1751,7 +1751,7 @@ This is a read-only query that works for any owner/spender pair, including accou
 * `--subaccount <SUBACCOUNT>` — The owner's subaccount that granted the allowance, as a hex string (32 bytes, left-padded). Defaults to the default subaccount
 * `--of-principal <OF_PRINCIPAL>` — The allowance owner to look up, instead of the current identity. Lets you inspect allowances granted by any principal
 * `-n`, `--network <NETWORK>` — Name or URL of the network to target, conflicts with environment argument
-* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`
+* `-k`, `--root-key <ROOT_KEY>` — The root key to use if connecting to a network by URL. Required when using `--network <URL>`. One of `mainnet`, `fetch`, or a 266-character hex-encoded root key
 * `-e`, `--environment <ENVIRONMENT>` — Override the environment to connect to. By default, the local environment is used
 * `--identity <IDENTITY>` — The user identity to run this command as
 * `--json` — Output command results as JSON


### PR DESCRIPTION
## Problem

The `cli-ref` required check is failing on `main` because `docs/reference/cli.md` is out of sync with the CLI.

This is a merge artifact between two recently-landed PRs:
- **#645** updated the `--root-key` help text (`One of mainnet, fetch, or a 266-character hex-encoded root key`).
- **#637** (merged after) added the `token approve` / `token allowance` commands, which each carry a `--root-key` flag.

Neither PR regenerated the CLI reference against the *combined* state, so the new commands' `--root-key` entries still show the old help text. `scripts/generate-cli-docs.sh` in CI detects the diff and fails with "Check for uncommitted changes".

## Fix

Regenerated `docs/reference/cli.md` via `./scripts/generate-cli-docs.sh`. The only changes are the two `--root-key` help lines under `token approve` and `token allowance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)