### PR TITLE
chore: update docs site to v1.1

### DIFF
--- a/docs-site/versions.json
+++ b/docs-site/versions.json
@@ -2,8 +2,11 @@
   "$comment": "Before first release: Empty array redirects to /main/. After releases: Add versions here (newest first). Only 'version' is required; 'latest: true' marks the current release.",
   "versions": [
     {
-      "version": "1.0",
+      "version": "1.1",
       "latest": true
+    },
+    {
+      "version": "1.0"
     },
     {
       "version": "0.3"


### PR DESCRIPTION
Marks **1.1** as the latest/default documentation version.

The `v1.1.0` tag already deployed the built docs to `/1.1/` on the `docs-deployment` branch. This updates `docs-site/versions.json` so that merging to `main` triggers the `publish-root-files` job to:
- point the root redirect (`cli.internetcomputer.org/`) at `/1.1/`
- add 1.1 (and demote 1.0) in the version-switcher dropdown
- refresh the root `llms.txt` from the 1.1 build

Follows the same pattern as #606 (v1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)