### PR TITLE
refactor: print deploy canister-phase line per state

### DIFF
--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -182,9 +182,7 @@ pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), anyhow:
     )
     .await?;
 
-    // Ensure the selected canisters exist
-    info!("Ensuring canisters exist:");
-
+    // Ensure the selected canisters exist, creating any that are missing.
     let env = ctx
         .get_environment(&environment_selection)
         .await
@@ -210,6 +208,7 @@ pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), anyhow:
             canisters_to_create.iter().format(", ")
         );
     } else {
+        info!("Creating canisters:");
         let target = match (args.subnet, args.proxy) {
             (Some(subnet), _) => CreateTarget::Subnet(subnet),
             (_, Some(proxy)) => CreateTarget::Proxy(proxy),

--- a/crates/icp-cli/tests/deploy_tests.rs
+++ b/crates/icp-cli/tests/deploy_tests.rs
@@ -173,9 +173,13 @@ async fn deploy_no_create_fails_when_canister_missing() {
         ])
         .assert()
         .failure()
-        .stderr(contains(
-            "`--no-create` was specified but the following canisters do not exist: my-canister",
-        ));
+        // The error prints without a `Creating canisters:` header in front of it.
+        .stderr(
+            contains(
+                "`--no-create` was specified but the following canisters do not exist: my-canister",
+            )
+            .and(contains("Creating canisters:").not()),
+        );
 }
 
 /// `deploy --no-create` succeeds when the canister already exists: it skips
@@ -207,14 +211,16 @@ async fn deploy_no_create_succeeds_when_canister_exists() {
     clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
         .mint_cycles(10 * TRILLION);
 
-    // First deploy creates the canister.
+    // First deploy creates the canister, so it prints the `Creating canisters:` header.
     ctx.icp()
         .current_dir(&project_dir)
         .args(["deploy", "--environment", "random-environment"])
         .assert()
-        .success();
+        .success()
+        .stderr(contains("Creating canisters:"));
 
     // With the canister already created, --no-create has nothing to reject and succeeds.
+    // Nothing is created, so it reports the canisters exist without a `Creating canisters:` header.
     ctx.icp()
         .current_dir(&project_dir)
         .args([
@@ -224,7 +230,8 @@ async fn deploy_no_create_succeeds_when_canister_exists() {
             "--no-create",
         ])
         .assert()
-        .success();
+        .success()
+        .stderr(contains("All canisters already exist").and(contains("Creating canisters:").not()));
 
     // Confirm the canister is installed and callable.
     ctx.icp()


### PR DESCRIPTION
Follow-up to #652, from the discussion on the phase-header wording.

Instead of an always-printed header, the canister phase now prints a line that reflects what actually happens:

| Invocation | State | Output |
|---|---|---|
| `icp deploy` | all exist | `All canisters already exist` |
| `icp deploy` | some missing | `Creating canisters:` → `Created canister …` |
| `icp deploy --no-create` | all exist | `All canisters already exist` |
| `icp deploy --no-create` | some missing | error only (no header) |

### Why
- Drops the awkward `Ensuring canisters exist:` on a normal deploy.
- `Creating canisters:` only appears in the branch that actually creates, so it never sits in front of `All canisters already exist` or the `--no-create` error.
- Output follows the state, not the flag: `deploy` and `deploy --no-create` print the same thing whenever they do the same thing (all canisters exist), and differ only when the behavior genuinely differs.

No behavior change beyond the log wording; no arg/help changes, so CLI docs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)