### PR TITLE
refactor: adopt ic-utils with_canister_settings in create_mgmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,7 +3363,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3368,16 +3377,16 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.3"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dbab284eac1806b77833cff143d66ae97aae74d34b0e60fb4ab4edf3d6fa12"
+checksum = "499d1647334e4c8bccd9a96a92bf4be8b332a4507369c0e36d7ab9585a24f725"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
  "async-lock",
  "async-trait",
  "async-watch",
- "backoff",
+ "backon",
  "bytes",
  "cached",
  "candid",
@@ -3501,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.47.3"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577e4411ea208f0bf7e6bf13535660df682fada94f45fbbc79b7e34c946a06ae"
+checksum = "af528049c02d371578ea1dde0ad75b7d572d5f5145a61ff7a5ac0711b151f419"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3541,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51705516ed4d23f24e8d714a70fe9d7ec17106cfd830d5434a1b29f583ef70ee"
+checksum = "3187ba94198a8df0e38a478f289812fcead6a86c658b9552b00f1f8081f06bb3"
 dependencies = [
  "candid",
  "serde",
@@ -3561,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.3"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2116182b3ec5a831d579db0a205b6cf9c2ca96616493bef99480532d0b3c2f5"
+checksum = "9ae3ab1d620565ff148c9fd9486bf2e9da0cfa8d42f7020d0cff13e2d6eff8b5"
 dependencies = [
  "candid",
  "hex",
@@ -3579,15 +3588,15 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.47.3"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f793db5d338dd9d0b659c2ce40080d7c9811cff6f171560f781cd2d6a43b7353"
+checksum = "a143d270c29f00fb6274d43d490d619cd3aaf6d87f128ab1073d14f5842f573a"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
  "ic-agent",
- "ic-management-canister-types 0.7.1",
+ "ic-management-canister-types 0.8.0",
  "once_cell",
  "semver",
  "serde",
@@ -3679,7 +3688,7 @@ dependencies = [
  "ic-ed25519",
  "ic-identity-hsm",
  "ic-ledger-types",
- "ic-management-canister-types 0.7.1",
+ "ic-management-canister-types 0.8.0",
  "ic-utils",
  "icp-canister-interfaces",
  "icp-sync-plugin",
@@ -3730,7 +3739,7 @@ version = "1.1.0"
 dependencies = [
  "bigdecimal",
  "candid",
- "ic-management-canister-types 0.7.1",
+ "ic-management-canister-types 0.8.0",
  "serde",
 ]
 
@@ -3767,7 +3776,7 @@ dependencies = [
  "ic-agent",
  "ic-ed25519",
  "ic-ledger-types",
- "ic-management-canister-types 0.7.1",
+ "ic-management-canister-types 0.8.0",
  "ic-utils",
  "icp",
  "icp-canister-interfaces",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,15 @@ hex = { version = "0.4.3", features = ["serde"] }
 hmac = { version = "0.13", features = ["zeroize"] }
 hybrid-array = { version = "0.4.10", features = ["zeroize"] }
 httptest = "0.16.3"
-ic-agent = { version = "0.47.0" }
+ic-agent = { version = "0.49.1" }
 ic-ed25519 = "0.6.0"
 ic-ledger-types = "0.16.0"
-ic-management-canister-types = { version = "0.7.1" }
-ic-utils = { version = "0.47.0" }
+ic-management-canister-types = { version = "0.8.0" }
+ic-utils = { version = "0.49.1" }
 icp = { path = "crates/icp" }
 icp-canister-interfaces = { path = "crates/icp-canister-interfaces" }
 icp-sync-plugin = { path = "crates/icp-sync-plugin" }
-ic-identity-hsm = "0.47.0"
+ic-identity-hsm = "0.49.1"
 icrc-ledger-types = "0.1.10"
 indexmap = { version = "2", features = ["serde"] }
 indicatif = "0.18.0"

--- a/crates/icp-cli/src/commands/canister/settings/update.rs
+++ b/crates/icp-cli/src/commands/canister/settings/update.rs
@@ -305,6 +305,10 @@ pub(crate) async fn exec(ctx: &Context, args: &UpdateArgs) -> Result<(), anyhow:
         log_memory_limit: args.log_memory_limit.as_ref().map(|m| Nat::from(m.get())),
         log_visibility,
         environment_variables,
+        // TODO: expose snapshot_visibility as a `settings update` flag (with
+        // set/add/remove-viewer sub-flags), mirroring log_visibility. Tracked for
+        // a follow-up PR; until then, leave it unchanged.
+        snapshot_visibility: None,
     };
 
     proxy_management::update_settings(

--- a/crates/icp-cli/src/commands/identity/delegation/sign.rs
+++ b/crates/icp-cli/src/commands/identity/delegation/sign.rs
@@ -57,6 +57,7 @@ pub(crate) async fn exec(ctx: &Context, args: &SignArgs) -> Result<(), SignError
         pubkey: target_pubkey.clone(),
         expiration,
         targets: args.canisters.clone(),
+        permissions: None,
     };
 
     let sig = identity

--- a/crates/icp-cli/src/operations/create.rs
+++ b/crates/icp-cli/src/operations/create.rs
@@ -3,16 +3,14 @@ use std::time::Duration;
 
 use bigdecimal::{BigDecimal, ToPrimitive};
 use candid::{Decode, Encode, IDLArgs, IDLValue, Nat, Principal};
-use ic_agent::{
-    Agent, AgentError,
-    agent::{Subnet, SubnetType},
-};
+use ic_agent::{Agent, AgentError, agent::SubnetType};
 use ic_ledger_types::{
     AccountIdentifier, Memo, Subaccount, Tokens, TransferArgs, TransferError, TransferResult,
 };
 use ic_management_canister_types::{
-    CanisterIdRecord, CanisterSettings, CreateCanisterArgs as MgmtCreateCanisterArgs,
+    CanisterSettings, CreateCanisterArgs as MgmtCreateCanisterArgs,
 };
+use ic_utils::interfaces::ManagementCanister;
 use icp::parsers::to_token_unit_amount;
 use icp::signal::stop_signal;
 use icp_canister_interfaces::{
@@ -216,7 +214,7 @@ impl CreateOperation {
             .await
             .context(GetSubnetSnafu)?;
         let cid = if let Some(SubnetType::CloudEngine) = subnet_info.subnet_type() {
-            self.create_mgmt(settings, &subnet_info).await?
+            self.create_mgmt(settings, selected_subnet).await?
         } else {
             self.create_ledger(settings, selected_subnet).await?
         };
@@ -278,32 +276,22 @@ impl CreateOperation {
     async fn create_mgmt(
         &self,
         settings: &CanisterSettings,
-        selected_subnet: &Subnet,
+        subnet: Principal,
     ) -> Result<Principal, CreateOperationError> {
-        let arg = MgmtCreateCanisterArgs {
-            settings: Some(settings.clone()),
-            sender_canister_version: None,
-        };
-
-        // Call management canister create_canister
-        let resp = self
-            .inner
-            .agent
-            .update(&Principal::management_canister(), "create_canister")
-            .with_arg(Encode!(&arg).context(CandidEncodeSnafu)?)
-            .with_effective_canister_id(
-                *selected_subnet
-                    .iter_canister_ranges()
-                    .next()
-                    .context(CreateCanisterSnafu {
-                        message: "subnet did not contain canister ranges",
-                    })?
-                    .start(),
-            )
+        // Call the management canister's create_canister, routing the request to
+        // the target subnet by its id (subnet-scoped, so no canister on that
+        // subnet is needed to derive an effective canister id) and forwarding the
+        // settings as a whole via `with_canister_settings`. Subnet-scoped routing
+        // requires subnet-administrator permissions, which the CloudEngine path has.
+        let mgmt = ManagementCanister::create(&self.inner.agent);
+        let (canister_id,) = mgmt
+            .create_canister()
+            .with_effective_subnet_id(subnet)
+            .with_canister_settings(settings.clone())
+            .call_and_wait()
             .await
             .context(AgentSnafu)?;
-        let resp: CanisterIdRecord = Decode!(&resp, CanisterIdRecord).context(CandidDecodeSnafu)?;
-        Ok(resp.canister_id)
+        Ok(canister_id)
     }
 
     async fn create_proxy(

--- a/crates/icp-cli/src/operations/settings.rs
+++ b/crates/icp-cli/src/operations/settings.rs
@@ -200,6 +200,10 @@ pub(crate) async fn sync_settings(
         log_memory_limit: log_memory_limit.as_ref().map(|m| Nat::from(m.get())),
         environment_variables: environment_variable_setting,
         controllers: controllers_setting,
+        // TODO: make snapshot_visibility configurable from the manifest and synced
+        // here, mirroring log_visibility (Controllers/Public/AllowedViewers).
+        // Tracked for a follow-up PR; until then, leave it unchanged.
+        snapshot_visibility: None,
     };
 
     proxy_management::update_settings(

--- a/crates/icp-cli/tests/canister_top_up_tests.rs
+++ b/crates/icp-cli/tests/canister_top_up_tests.rs
@@ -56,7 +56,13 @@ async fn canister_top_up() {
 
     let agent = ctx.agent();
     let mgmt = ManagementCanister::create(&agent);
-    let canister_balance = mgmt.canister_status(&canister_id).await.unwrap().0.cycles;
+    let canister_balance = mgmt
+        .canister_status(&canister_id)
+        .call()
+        .await
+        .unwrap()
+        .0
+        .cycles;
 
     ctx.icp()
         .current_dir(&project_dir)
@@ -102,6 +108,12 @@ async fn canister_top_up() {
         ))
         .success();
 
-    let new_canister_balance = mgmt.canister_status(&canister_id).await.unwrap().0.cycles;
+    let new_canister_balance = mgmt
+        .canister_status(&canister_id)
+        .call()
+        .await
+        .unwrap()
+        .0
+        .cycles;
     assert!((canister_balance + 10 * TRILLION) - new_canister_balance < 100_000_000_u128);
 }

--- a/crates/icp/src/identity/delegation.rs
+++ b/crates/icp/src/identity/delegation.rs
@@ -76,6 +76,12 @@ pub fn to_agent_types(
                     pubkey,
                     expiration,
                     targets,
+                    // The wire `DelegationChain` carries no request-kind
+                    // permissions, and the delegations the CLI signs are always
+                    // unrestricted, so every delegation here was signed with
+                    // `permissions` absent. `None` reproduces the exact signed
+                    // bytes (it is `skip_serializing_if`'d out of the hash), so
+                    // the chain still verifies in `DelegatedIdentity::new`.
                     permissions: None,
                 },
                 signature,

--- a/crates/icp/src/identity/delegation.rs
+++ b/crates/icp/src/identity/delegation.rs
@@ -76,6 +76,7 @@ pub fn to_agent_types(
                     pubkey,
                     expiration,
                     targets,
+                    permissions: None,
                 },
                 signature,
             })

--- a/crates/icp/src/identity/key.rs
+++ b/crates/icp/src/identity/key.rs
@@ -477,6 +477,7 @@ fn create_pem_session_and_build_identity(
         pubkey: session_pubkey.clone(),
         expiration,
         targets: None,
+        permissions: None,
     };
 
     let sig = identity


### PR DESCRIPTION
SDK-2674

## What

Adopts the `with_canister_settings` API added in [dfinity/agent-rs#737](https://github.com/dfinity/agent-rs/pull/737) to simplify `create_mgmt`, bumping the agent-rs dependencies first.

## Changes

**Dependency bump** (feature landed in agent-rs 0.49.0; using latest patch):
- `ic-agent`, `ic-utils`, `ic-identity-hsm`: `0.47.0` → `0.49.1`
- `ic-management-canister-types`: `0.7.1` → `0.8.0` (required — `ic-utils` 0.49's `with_canister_settings` takes a `CanisterSettings` from this crate, so the versions must match)

**`create_mgmt` simplification** ([create.rs](../blob/adopt-with-canister-settings/crates/icp-cli/src/operations/create.rs)):
- Builds the call via `ManagementCanister::create_canister().with_canister_settings(settings)` instead of the manual `Encode!` / `agent.update()` / `Decode!` dance.
- Routes to the target subnet with `with_effective_subnet_id(subnet)` (also new in agent-rs), so the function takes the subnet `Principal` directly — no more resolving a canister id from the subnet's ranges.

**Breaking changes handled by the bump:**
- `CanisterSettings` / `DefiniteCanisterSettings` gained `snapshot_visibility`; added to the two exhaustive settings literals. Left `None` for now with TODOs to make it configurable like `log_visibility` — see below.
- `ic_agent::identity::Delegation` gained `permissions`; added `permissions: None` to the three literal constructions.
- `ManagementCanister::canister_status` now returns a `QueryOrUpdateCall` (defaults to a query); switched to `.call()` in the top-up test.

## Follow-up (separate PR)
Full `snapshot_visibility` configurability — manifest field + `settings sync` + `settings update` flags (`--snapshot-visibility`, `--set/add/remove-snapshot-viewer`) + `status`/`settings show` display, mirroring `log_visibility`. Marked with TODOs in `operations/settings.rs` and `commands/canister/settings/update.rs`.

## Testing
- `cargo check --workspace --all-targets`, `cargo clippy` clean; `cargo fmt` applied
- Unit tests (delegation conversion, create recovery-command) pass
- `canister_create_cloud_engine` integration test passes — exercises the rewritten subnet-scoped `create_mgmt` end-to-end against a real replica
- `canister_create_with_settings{,_suffix_in_yaml,_cmdline_override}` pass — confirms the untouched cycles-ledger path still round-trips settings after the type bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)