### PR TITLE
fix: recognize static-site (certified-assets) canisters as frontends

### DIFF
--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -613,6 +613,12 @@ async fn has_http_request(agent: &Agent, canister_id: Principal) -> bool {
         url: String,
         headers: Vec<(String, String)>,
         body: Vec<u8>,
+        // Signals which HTTP gateway certification version the caller supports.
+        // Modern gateways send `Some(2)`, and V2-only asset canisters (e.g.
+        // dfinity/certified-assets, used by the `static-site` recipe) trap when
+        // it is absent. Sending it keeps the probe accepted by both current and
+        // legacy asset canisters, so they are correctly recognized as frontends.
+        certificate_version: Option<u16>,
     }
 
     // Construct an HttpRequest for '/index.html'
@@ -621,6 +627,7 @@ async fn has_http_request(agent: &Agent, canister_id: Principal) -> bool {
         url: "/index.html".to_string(),
         headers: vec![],
         body: vec![],
+        certificate_version: Some(2),
     };
 
     let args = candid::encode_one(&request).expect("failed to encode request");

--- a/crates/icp-cli/tests/deploy_tests.rs
+++ b/crates/icp-cli/tests/deploy_tests.rs
@@ -630,6 +630,55 @@ async fn deploy_prints_friendly_url_for_asset_canister() {
         ));
 }
 
+/// Regression test: the `static-site` recipe deploys dfinity/certified-assets,
+/// a V2-only asset canister whose `http_request` traps unless the request sets
+/// `certificate_version: Some(2)`. The frontend probe must send it so the
+/// canister is recognized as a frontend and gets the friendly URL rather than a
+/// Candid UI URL. Complements `deploy_prints_friendly_url_for_asset_canister`,
+/// which covers the legacy SDK `assetstorage.wasm` that tolerates its absence.
+#[tokio::test]
+async fn deploy_prints_friendly_url_for_certified_assets_canister() {
+    let ctx = TestContext::new();
+
+    // Setup project
+    let project_dir = ctx.create_project_dir("icp");
+
+    // Project manifest with the pre-built certified-assets canister (the wasm
+    // the `static-site` recipe deploys).
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: pre-built
+                  url: https://github.com/dfinity/certified-assets/releases/download/v0.3.0/canister-release.wasm.gz
+                  sha256: 9363c3f89d0eb9a2dec3111b1123d8ece17d4f76ae9d64e5605cfa0c3e63c427
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    // Start network
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
+        .mint_cycles(10 * TRILLION);
+
+    // Deploy and check that the friendly URL is printed (not the Candid UI form)
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "--environment", "random-environment"])
+        .assert()
+        .success()
+        .stdout(contains("Deployed canisters:"))
+        .stdout(contains(
+            "my-canister: http://my-canister.random-environment.localhost:",
+        ));
+}
+
 #[cfg(unix)] // moc
 #[tokio::test]
 async fn deploy_upgrade_rejects_incompatible_candid() {


### PR DESCRIPTION
## Problem

Deploying a frontend via the new `static-site` recipe prints a **Candid UI** URL instead of the friendly frontend URL:

```
Deployed canisters:
  frontend (Candid UI): http://4mc4g-...-cai.localhost:8000/?id=4caro-...-cai
```

## Root cause

`icp deploy` chooses between a frontend URL and a Candid UI URL purely via a **runtime probe** (`has_http_request` in `deploy.rs`): it sends an `http_request` query for `/index.html` and treats the canister as a frontend iff the query returns `Ok`. No recipe type or wasm metadata is involved.

The probe built its `HttpRequest` **without a `certificate_version` field**, so it decoded to `None` on the canister. The `static-site` recipe deploys [dfinity/certified-assets](https://github.com/dfinity/certified-assets), which is V2-only — its `http_request` starts with `if req.certificate_version != Some(2) { trap("Only support V2 certification") }`. The trap made the probe query error, so the canister was misclassified and fell back to the Candid UI URL.

The site still served correctly in a browser (the real HTTP gateway always sends `certificate_version: Some(2)`); only the CLI's own probe omitted it. The legacy SDK `assetstorage.wasm` used by the old `asset-canister` recipe tolerates a missing `certificate_version`, which is why this was never seen before.

## Fix

Send `certificate_version: Some(2)` in the probe — what modern gateways send. Both the current certified-assets canister and the legacy assetstorage canister accept it.

## Testing

- Added `deploy_prints_friendly_url_for_certified_assets_canister`, deploying the certified-assets v0.3.0 wasm and asserting the friendly URL — the case the `static-site` recipe hits. It fails against the old probe and passes with the fix.
- Existing `deploy_prints_friendly_url_for_asset_canister` (legacy SDK assetstorage) still passes, so both asset-canister flavors are now covered.
- `cargo fmt` and `cargo clippy -p icp-cli` clean.