### PR TITLE
fix: detect frontends by http_request presence and group deploy URLs by kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ bump. Currently experimental: project bundling, project dependencies
 * feat: `icp canister link` assigns an existing canister principal to a project canister
 * feat: `icp canister create --with-icp` (not supported in `icp deploy`) uses the CMC to create canisters. Only needed for deploying to restricted system subnets.
 * feat: `icp deploy --no-create` will error if any canisters do not exist, rather than creating them.
+* fix: `icp deploy` now prints the frontend URL for any canister that exposes an `http_request` endpoint. Previously a canister whose `http_request` signature differed from a hard-coded shape (e.g. some certified-asset canisters) was misdetected and shown a Candid UI URL instead of its site URL. Deploy URLs are also now grouped by kind (frontends vs. Candid UI) instead of interleaved.
 
 # v1.1.0
 

--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -614,20 +614,26 @@ fn is_serving_reject(err: &AgentError) -> bool {
 /// when we can't hand it a valid request. So rather than sending a crafted
 /// request payload — whose Candid type must match the canister's exactly, and
 /// which silently yields a false negative when it doesn't (the bug this
-/// replaces) — we send an empty argument and look only at *why* the call fails.
+/// replaces) — we send a zero-argument call and look only at *why* it fails.
 ///
 /// The replica reports a missing method as `CanisterMethodNotFound` (error code
-/// `IC0536`). Any other outcome means the method exists and ran: a reply, or —
-/// far more likely, since `http_request` won't decode an empty argument — a
-/// trap/decode failure (`IC0502`/`IC0503`/`IC0504`). Note the reject *code*
-/// can't tell these apart: method-not-found and a trap are both `CanisterError`
-/// (5), so only the `error_code` string distinguishes them. Transport/other
-/// errors are inconclusive and, per the false-positive bias, also count as
-/// "has `http_request`".
+/// `IC0536`). Any other outcome means the method exists and ran: a reply (from a
+/// zero-argument `http_request`), or — far more likely — a trap/decode failure
+/// (`IC0502`/`IC0503`/`IC0504`) from feeding a normal single-argument
+/// `http_request` the wrong number of arguments. Note the reject *code* can't
+/// tell these apart: method-not-found and a trap are both `CanisterError` (5),
+/// so only the `error_code` string distinguishes them. Transport/other errors
+/// are inconclusive and, per the false-positive bias, also count as "has
+/// `http_request`".
 async fn has_http_request(agent: &Agent, canister_id: Principal) -> bool {
+    // A valid Candid encoding of zero arguments (`DIDL\0\0`) — *not* raw empty
+    // bytes, which are not a well-formed Candid message. This lets a genuine
+    // zero-argument `http_request` reply, while a single-argument one still
+    // fails to decode and traps; either way the method exists.
+    let empty_args = candid::encode_args(()).expect("encoding () never fails");
     let result = agent
         .query(&canister_id, "http_request")
-        .with_arg(Vec::<u8>::new())
+        .with_arg(empty_args)
         .call()
         .await;
 
@@ -638,17 +644,28 @@ async fn has_http_request(agent: &Agent, canister_id: Principal) -> bool {
 }
 
 /// True when a query error is the replica's definitive "this method does not
-/// exist" signal — `CanisterMethodNotFound` (`IC0536`) — with a message-substring
-/// fallback for replicas that don't populate `error_code`.
+/// exist" signal — `CanisterMethodNotFound` (`IC0536`).
+///
+/// When the replica populates `error_code` we trust it exclusively: a trap or
+/// decode failure (`IC0503`/`IC0504`) is *not* method-absent, even if its
+/// message happens to mention a missing method — treating it as absent would
+/// reintroduce the very false negative this probe exists to avoid. Only when
+/// `error_code` is absent (older replicas) do we fall back to the message, and
+/// then only when it names `http_request`, so a nested "no such method" bubbled
+/// up from an existing handler isn't mistaken for `http_request` being absent.
 fn is_method_not_found(err: &AgentError) -> bool {
     let reject = match err {
         AgentError::CertifiedReject { reject, .. }
         | AgentError::UncertifiedReject { reject, .. } => reject,
         _ => return false,
     };
-    reject.error_code.as_deref() == Some("IC0536")
-        || reject.reject_message.contains("has no query method")
-        || reject.reject_message.contains("has no update method")
+    match reject.error_code.as_deref() {
+        Some(code) => code == "IC0536",
+        None => {
+            reject.reject_message.contains("has no query method")
+                && reject.reject_message.contains("http_request")
+        }
+    }
 }
 
 /// Prints URLs for deployed canisters
@@ -871,16 +888,36 @@ mod tests {
 
     #[test]
     fn method_not_found_detected_by_message_when_error_code_absent() {
-        // Replicas that don't populate `error_code` still carry the message.
+        // Replicas that don't populate `error_code` still carry the message,
+        // which names the missing method (`http_request`, since we query it).
         let query = reject(None, "Canister abc has no query method 'http_request'");
-        let update = reject(None, "Canister abc has no update method 'http_request'");
         assert!(is_method_not_found(&query));
-        assert!(is_method_not_found(&update));
     }
 
     #[test]
-    fn trap_from_empty_arg_is_not_method_not_found() {
-        // The method exists but can't decode the empty argument, so it traps
+    fn present_error_code_wins_over_misleading_message() {
+        // An existing `http_request` that traps (IC0503) is NOT method-absent,
+        // even when its message happens to contain a "has no query method"
+        // phrase (e.g. bubbled up from a downstream call). Trusting the present
+        // error code prevents the false negative this probe exists to avoid.
+        let err = reject(
+            Some("IC0503"),
+            "downstream canister xyz has no query method 'http_request'",
+        );
+        assert!(!is_method_not_found(&err));
+    }
+
+    #[test]
+    fn unrelated_missing_method_message_without_error_code_is_ignored() {
+        // With no `error_code`, a "has no query method" message about some
+        // *other* method must not count as `http_request` being absent.
+        let err = reject(None, "Canister abc has no query method 'greet'");
+        assert!(!is_method_not_found(&err));
+    }
+
+    #[test]
+    fn trap_from_wrong_arg_count_is_not_method_not_found() {
+        // The method exists but can't decode a zero-argument call, so it traps
         // (IC0503) — the canister still speaks the protocol, so this is a
         // frontend, not a missing method.
         let trap = reject(

--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail};
-use candid::{CandidType, Principal};
+use candid::Principal;
 use clap::Args;
 use futures::{StreamExt, future::try_join_all, stream::FuturesOrdered};
 use ic_agent::{Agent, AgentError};
@@ -605,35 +605,50 @@ fn is_serving_reject(err: &AgentError) -> bool {
     !stopped
 }
 
-/// Checks if a canister has an `http_request` function by querying it
+/// Checks whether a canister speaks the HTTP gateway protocol — i.e. exposes an
+/// `http_request` query method — so we print its gateway (frontend) URL instead
+/// of a Candid UI URL.
+///
+/// The probe deliberately errs toward false positives over false negatives: any
+/// canister that *has* an `http_request` method should get a frontend URL, even
+/// when we can't hand it a valid request. So rather than sending a crafted
+/// request payload — whose Candid type must match the canister's exactly, and
+/// which silently yields a false negative when it doesn't (the bug this
+/// replaces) — we send an empty argument and look only at *why* the call fails.
+///
+/// The replica reports a missing method as `CanisterMethodNotFound` (error code
+/// `IC0536`). Any other outcome means the method exists and ran: a reply, or —
+/// far more likely, since `http_request` won't decode an empty argument — a
+/// trap/decode failure (`IC0502`/`IC0503`/`IC0504`). Note the reject *code*
+/// can't tell these apart: method-not-found and a trap are both `CanisterError`
+/// (5), so only the `error_code` string distinguishes them. Transport/other
+/// errors are inconclusive and, per the false-positive bias, also count as
+/// "has `http_request`".
 async fn has_http_request(agent: &Agent, canister_id: Principal) -> bool {
-    #[derive(CandidType, Serialize)]
-    struct HttpRequest {
-        method: String,
-        url: String,
-        headers: Vec<(String, String)>,
-        body: Vec<u8>,
-    }
-
-    // Construct an HttpRequest for '/index.html'
-    let request = HttpRequest {
-        method: "GET".to_string(),
-        url: "/index.html".to_string(),
-        headers: vec![],
-        body: vec![],
-    };
-
-    let args = candid::encode_one(&request).expect("failed to encode request");
-
-    // Try to query the http_request endpoint
     let result = agent
         .query(&canister_id, "http_request")
-        .with_arg(args)
+        .with_arg(Vec::<u8>::new())
         .call()
         .await;
 
-    // If the query succeeds (regardless of the response), the canister has http_request
-    result.is_ok()
+    match result {
+        Ok(_) => true,
+        Err(err) => !is_method_not_found(&err),
+    }
+}
+
+/// True when a query error is the replica's definitive "this method does not
+/// exist" signal — `CanisterMethodNotFound` (`IC0536`) — with a message-substring
+/// fallback for replicas that don't populate `error_code`.
+fn is_method_not_found(err: &AgentError) -> bool {
+    let reject = match err {
+        AgentError::CertifiedReject { reject, .. }
+        | AgentError::UncertifiedReject { reject, .. } => reject,
+        _ => return false,
+    };
+    reject.error_code.as_deref() == Some("IC0536")
+        || reject.reject_message.contains("has no query method")
+        || reject.reject_message.contains("has no update method")
 }
 
 /// Prints URLs for deployed canisters
@@ -660,10 +675,14 @@ async fn print_canister_urls(
     };
 
     let mut json_canisters = Vec::new();
-
-    if !json {
-        println!("Deployed canisters:");
-    }
+    // Human-readable output is grouped by kind so the two URL flavors don't
+    // interleave: frontends (something to open in a browser) first, then
+    // backends (a Candid UI to poke the interface).
+    let mut frontend_lines: Vec<String> = Vec::new();
+    let mut backend_lines: Vec<String> = Vec::new();
+    // Only populated when the network exposes no gateway at all — there is then
+    // nothing to group, so these render as a flat list under the header.
+    let mut no_gateway_lines: Vec<String> = Vec::new();
 
     for name in canister_names {
         let canister_id = match ctx
@@ -677,85 +696,76 @@ async fn print_canister_urls(
             Err(_) => continue,
         };
 
-        if let Some(http_gateway_url) = &http_gateway_url {
-            let has_http = has_http_request(&agent, canister_id).await;
-
-            if has_http {
-                // A canister carries one friendly name normally, or several when
-                // it's a de-duplicated shared dependency canister reached via
-                // multiple alias chains — print one URL for each. Fall back to a
-                // single principal URL when friendly domains are off or no
-                // friendly name is known.
-                let env_name = environment_selection.name();
-                let friendly_names: Vec<String> = if has_friendly {
-                    env.canisters
-                        .get(name)
-                        .map(|(_, c)| c.friendly_names.clone())
-                        .unwrap_or_default()
-                } else {
-                    Vec::new()
-                };
-                let urls = if friendly_names.is_empty() {
-                    vec![canister_gateway_url(http_gateway_url, canister_id, None)]
-                } else {
-                    friendly_names
-                        .iter()
-                        .map(|fname| {
-                            canister_gateway_url(
-                                http_gateway_url,
-                                canister_id,
-                                Some((fname.as_str(), env_name)),
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                };
-                for canister_url in &urls {
-                    if json {
-                        json_canisters.push(JsonDeployedCanister {
-                            name: name.clone(),
-                            canister_id,
-                            url: Some(canister_url.to_string()),
-                        });
-                    } else {
-                        println!("  {name}: {canister_url}");
-                    }
-                }
-            } else {
-                // For canisters without http_request, show the Candid UI URL
-                let url = if let Some(ui_id) = get_candid_ui_id(ctx, environment_selection).await {
-                    let domain = gateway_domain(http_gateway_url);
-                    let mut candid_url = canister_gateway_url(http_gateway_url, ui_id, None);
-                    if domain.is_some() {
-                        candid_url.set_query(Some(&format!("id={canister_id}")));
-                    } else {
-                        candid_url.set_query(Some(&format!("canisterId={ui_id}&id={canister_id}")));
-                    }
-                    if !json {
-                        println!("  {name} (Candid UI): {candid_url}");
-                    }
-                    Some(candid_url.to_string())
-                } else {
-                    if !json {
-                        println!("  {name}: {canister_id} (Candid UI not available)");
-                    }
-                    None
-                };
-                if json {
-                    json_canisters.push(JsonDeployedCanister {
-                        name: name.clone(),
-                        canister_id,
-                        url,
-                    });
-                }
-            }
-        } else if json {
+        let Some(http_gateway_url) = &http_gateway_url else {
             json_canisters.push(JsonDeployedCanister {
                 name: name.clone(),
                 canister_id,
                 url: None,
             });
+            no_gateway_lines.push(format!(
+                "  {name}: {canister_id} (No gateway URL available)"
+            ));
+            continue;
+        };
+
+        if has_http_request(&agent, canister_id).await {
+            // A canister carries one friendly name normally, or several when
+            // it's a de-duplicated shared dependency canister reached via
+            // multiple alias chains — print one URL for each. Fall back to a
+            // single principal URL when friendly domains are off or no
+            // friendly name is known.
+            let env_name = environment_selection.name();
+            let friendly_names: Vec<String> = if has_friendly {
+                env.canisters
+                    .get(name)
+                    .map(|(_, c)| c.friendly_names.clone())
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            let urls = if friendly_names.is_empty() {
+                vec![canister_gateway_url(http_gateway_url, canister_id, None)]
+            } else {
+                friendly_names
+                    .iter()
+                    .map(|fname| {
+                        canister_gateway_url(
+                            http_gateway_url,
+                            canister_id,
+                            Some((fname.as_str(), env_name)),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            };
+            for canister_url in &urls {
+                json_canisters.push(JsonDeployedCanister {
+                    name: name.clone(),
+                    canister_id,
+                    url: Some(canister_url.to_string()),
+                });
+                frontend_lines.push(format!("  {name}: {canister_url}"));
+            }
         } else {
-            println!("  {name}: {canister_id} (No gateway URL available)");
+            // No http_request: offer the Candid UI URL instead.
+            let url = if let Some(ui_id) = get_candid_ui_id(ctx, environment_selection).await {
+                let domain = gateway_domain(http_gateway_url);
+                let mut candid_url = canister_gateway_url(http_gateway_url, ui_id, None);
+                if domain.is_some() {
+                    candid_url.set_query(Some(&format!("id={canister_id}")));
+                } else {
+                    candid_url.set_query(Some(&format!("canisterId={ui_id}&id={canister_id}")));
+                }
+                backend_lines.push(format!("  {name}: {candid_url}"));
+                Some(candid_url.to_string())
+            } else {
+                backend_lines.push(format!("  {name}: {canister_id} (Candid UI not available)"));
+                None
+            };
+            json_canisters.push(JsonDeployedCanister {
+                name: name.clone(),
+                canister_id,
+                url,
+            });
         }
     }
 
@@ -766,6 +776,26 @@ async fn print_canister_urls(
                 canisters: json_canisters,
             },
         )?;
+        return Ok(());
+    }
+
+    println!("Deployed canisters:");
+    if !frontend_lines.is_empty() {
+        println!();
+        println!("Frontends (serving http_request):");
+        for line in &frontend_lines {
+            println!("{line}");
+        }
+    }
+    if !backend_lines.is_empty() {
+        println!();
+        println!("Backends (Candid UI):");
+        for line in &backend_lines {
+            println!("{line}");
+        }
+    }
+    for line in &no_gateway_lines {
+        println!("{line}");
     }
 
     Ok(())
@@ -807,5 +837,65 @@ async fn get_candid_ui_id(
             // For connected networks, use the mainnet Candid UI
             Some(MAINNET_CANDID_UI_CID)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_agent::agent::{RejectCode, RejectResponse};
+
+    fn reject(error_code: Option<&str>, reject_message: &str) -> AgentError {
+        AgentError::UncertifiedReject {
+            reject: RejectResponse {
+                // Both a missing method and a trap surface as `CanisterError`,
+                // so the reject code is intentionally the same across cases —
+                // only `error_code`/message distinguishes them.
+                reject_code: RejectCode::CanisterError,
+                reject_message: reject_message.to_string(),
+                error_code: error_code.map(String::from),
+            },
+            operation: None,
+        }
+    }
+
+    #[test]
+    fn method_not_found_detected_by_error_code() {
+        // IC0536 = CanisterMethodNotFound: the method genuinely does not exist.
+        let err = reject(
+            Some("IC0536"),
+            "Canister abc has no query method 'http_request'",
+        );
+        assert!(is_method_not_found(&err));
+    }
+
+    #[test]
+    fn method_not_found_detected_by_message_when_error_code_absent() {
+        // Replicas that don't populate `error_code` still carry the message.
+        let query = reject(None, "Canister abc has no query method 'http_request'");
+        let update = reject(None, "Canister abc has no update method 'http_request'");
+        assert!(is_method_not_found(&query));
+        assert!(is_method_not_found(&update));
+    }
+
+    #[test]
+    fn trap_from_empty_arg_is_not_method_not_found() {
+        // The method exists but can't decode the empty argument, so it traps
+        // (IC0503) — the canister still speaks the protocol, so this is a
+        // frontend, not a missing method.
+        let trap = reject(
+            Some("IC0503"),
+            "Canister abc trapped explicitly: failed to decode call arguments",
+        );
+        let contract = reject(Some("IC0504"), "Canister abc violated contract");
+        assert!(!is_method_not_found(&trap));
+        assert!(!is_method_not_found(&contract));
+    }
+
+    #[test]
+    fn non_reject_error_is_inconclusive_not_method_not_found() {
+        // Transport/other errors are not evidence the method is absent; the
+        // false-positive bias then treats the canister as a frontend.
+        assert!(!is_method_not_found(&AgentError::InvalidReplicaStatus));
     }
 }

--- a/crates/icp-cli/tests/dependency_tests.rs
+++ b/crates/icp-cli/tests/dependency_tests.rs
@@ -178,8 +178,10 @@ async fn deploy_prints_alias_namespaced_url_for_dependency_frontend() {
         .stdout(contains(
             "http://frontend.openemail.random-environment.localhost:",
         ))
-        // The dependency's compute backend falls back to a Candid UI URL.
-        .stdout(contains("vendor/openemail:backend (Candid UI):"));
+        // The dependency's compute backend falls back to a Candid UI URL, listed
+        // under the grouped "Backends (Candid UI)" header.
+        .stdout(contains("Backends (Candid UI):"))
+        .stdout(contains("vendor/openemail:backend:"));
 }
 
 /// Running `icp deploy` from *inside* a vendored member resolves up to the

--- a/crates/icp-cli/tests/deploy_tests.rs
+++ b/crates/icp-cli/tests/deploy_tests.rs
@@ -583,7 +583,8 @@ async fn deploy_prints_canister_urls() {
         .assert()
         .success()
         .stdout(contains("Deployed canisters:"))
-        .stdout(contains("my-canister (Candid UI):"))
+        .stdout(contains("Backends (Candid UI):"))
+        .stdout(contains("my-canister:"))
         .stdout(contains(".localhost:"))
         .stdout(contains("?id="));
 }
@@ -625,6 +626,77 @@ async fn deploy_prints_friendly_url_for_asset_canister() {
         .assert()
         .success()
         .stdout(contains("Deployed canisters:"))
+        .stdout(contains("Frontends (serving http_request):"))
+        .stdout(contains(
+            "my-canister: http://my-canister.random-environment.localhost:",
+        ));
+}
+
+/// The probe classifies a canister by the *presence* of an `http_request`
+/// method, not by whether it conforms to the HTTP gateway protocol. A canister
+/// exposing a dummy `http_request` — here a zero-arg Motoko query that bears no
+/// resemblance to a real request handler — must still get a frontend URL. This
+/// is the false-positive-tolerant behavior, and it exercises the "call replied"
+/// branch of the probe (the empty argument decodes fine against a no-arg method).
+#[cfg(unix)] // moc
+#[tokio::test]
+async fn deploy_prints_frontend_url_for_canister_with_dummy_http_request() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+
+    write_string(
+        &project_dir.join("mops.toml"),
+        indoc! {r#"
+            [dependencies]
+            base = "0.16.0"
+
+            [toolchain]
+            moc = "0.16.3"
+        "#},
+    )
+    .expect("failed to write mops.toml");
+
+    // A dummy `http_request`: takes no arguments and returns text. It does not
+    // implement the gateway protocol at all — it only needs to *exist*.
+    write_string(
+        &project_dir.join("main.mo"),
+        indoc! {r#"
+            persistent actor {
+                public query func http_request() : async Text {
+                    return "ok";
+                };
+            };
+        "#},
+    )
+    .expect("failed to write main.mo");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            recipe:
+              type: "@dfinity/motoko@v4.0.0"
+              configuration:
+                main: main.mo
+                args: ""
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
+        .mint_cycles(10 * TRILLION);
+
+    // The dummy `http_request` is enough to earn a frontend URL, not Candid UI.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "--environment", "random-environment"])
+        .assert()
+        .success()
+        .stdout(contains("Frontends (serving http_request):"))
         .stdout(contains(
             "my-canister: http://my-canister.random-environment.localhost:",
         ));

--- a/docs/concepts/project-dependencies.md
+++ b/docs/concepts/project-dependencies.md
@@ -53,9 +53,13 @@ On a local network, a dependency canister's frontend subdomain is namespaced by 
 
 ```
 Deployed canisters:
+
+Frontends (serving http_request):
   frontend: http://frontend.local.localhost:8000/
   vendor/openemail:frontend: http://frontend.openemail.local.localhost:8000/
-  vendor/openemail:backend (Candid UI): http://<candid-ui>.localhost:8000/?id=<id>
+
+Backends (Candid UI):
+  vendor/openemail:backend: http://<candid-ui>.localhost:8000/?id=<id>
 ```
 
 A transitive dependency uses its full alias chain (`frontend.libfoo.openemail.<env>.localhost`). A [shared dependency](#shared-dependencies) is deployed once but reached through more than one alias chain, so it prints **one URL per chain**, each resolving to the same canister:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -112,8 +112,12 @@ After deployment, you'll see output like:
 
 ```
 Deployed canisters:
-  backend (Candid UI): http://...localhost:8000/?id=...
+
+Frontends (serving http_request):
   frontend: http://...localhost:8000
+
+Backends (Candid UI):
+  backend: http://...localhost:8000/?id=...
 ```
 
 ## Explore Your App

--- a/examples/icp-project-dependency-shared/README.md
+++ b/examples/icp-project-dependency-shared/README.md
@@ -69,12 +69,16 @@ at the same canister:
 
 ```
 Deployed canisters:
+
+Frontends (serving http_request):
   frontend: http://frontend.local.localhost:<port>/
-  umbrella/service-a:service (Candid UI): ...
-  umbrella/service-b:service (Candid UI): ...
-  umbrella/openemail:backend (Candid UI): ...
   umbrella/openemail:frontend: http://frontend.openemail.service-a.local.localhost:<port>/
   umbrella/openemail:frontend: http://frontend.openemail.service-b.local.localhost:<port>/
+
+Backends (Candid UI):
+  umbrella/service-a:service: ...
+  umbrella/service-b:service: ...
+  umbrella/openemail:backend: ...
 ```
 
 The dependency subdomains are namespaced by the **alias chain**, not the on-disk


### PR DESCRIPTION
## What you'll see

`icp deploy` decides, per canister, whether to print a **frontend URL** (something to open in a browser) or a **Candid UI URL** (a web form to poke the interface). It picks the frontend URL when the canister exposes an `http_request` endpoint.

**Before:** a canister whose `http_request` signature didn't match the exact shape the CLI hard-coded (e.g. the certified-assets canister) was misreported as a backend and shown a Candid UI URL instead of its site URL.

**After:** any canister that exposes an `http_request` method gets a frontend URL.

The output is now also **grouped by kind** instead of interleaving the two URL flavors:

```
Deployed canisters:

Frontends (serving http_request):
  frontend: http://frontend.local.localhost:8000/
  vendor/openemail:frontend: http://frontend.openemail.local.localhost:8000/

Backends (Candid UI):
  vendor/openemail:backend: http://<candid-ui>.localhost:8000/?id=<id>
```

(`--json` output is unchanged — the grouping is display-only.)

## Why the old probe was wrong

It sent a hand-rolled `HttpRequest` payload and treated *any* query error as "no `http_request`". When a canister's `http_request` argument type differed from that struct, decoding failed and the call rejected — a **false negative**.

## How the new probe works

It queries `http_request` with a **zero-argument call** and treats the canister as a frontend **unless** the replica reports the method genuinely doesn't exist (`CanisterMethodNotFound` / `IC0536`). Every other outcome — a reply from a zero-argument handler, or a trap when a normal single-argument `http_request` can't decode a zero-argument call — means the method exists, so it counts as a frontend. The probe deliberately **tolerates false positives over false negatives**: a canister that merely *has* the endpoint should get a URL to open.

One subtlety: both "method not found" and "argument failed to decode" come back as reject code `CanisterError`, so the `error_code` string (`IC0536`), not the reject code, is the discriminator. When the replica provides an `error_code` it is authoritative; the reject-message text is only a fallback for older replicas that omit it, and is scoped to messages that name `http_request`.

## Tests

- Unit tests for the `IC0536` discriminator: error-code match, message fallback when `error_code` is absent, a present non-`IC0536` code winning over a misleading message, an unrelated missing-method message being ignored, decode-trap ≠ method-absent, and inconclusive transport errors.
- Integration test: a canister with a *dummy* `http_request` (a zero-arg Motoko query that isn't a real request handler) still gets a frontend URL — and, with the zero-argument encoding, genuinely exercises the reply path.
- Existing asset-canister and dependency URL tests updated for the grouped output.

## Notes

- Supersedes #662, which fixed the symptom for the specific certified-assets canister; this fixes the probe for any canister speaking the HTTP gateway protocol.
- The same probe exists in other tools (Calm / Ninja) and should be fixed there for consistency — out of scope for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)