### PR TITLE
fix(docs): declare @astrojs/markdown-remark for astro 7.1 build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,17 @@ permissions:
 env:
   PUBLIC_SITE: https://cli.internetcomputer.org
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Concurrency is split by event so PR validation never shares a lane with deployments:
+#   - Pull requests get an isolated per-ref lane and cancel superseded builds, so a
+#     burst of unrelated PRs (or pushes) can no longer cancel a PR's own build before
+#     it runs — which previously let a broken docs build slip through review.
+#   - Pushes, tags, and manual runs share the single "pages" lane with
+#     cancel-in-progress: false: only one deployment runs at a time, queued runs
+#     between in-progress and latest are skipped, and in-progress production
+#     deployments are always allowed to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.ref) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Build job - validates that docs build successfully

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,9 @@ concurrency:
 jobs:
   # Build job - validates that docs build successfully
   build:
+    # Explicit :required name follows the repo convention for gating checks and
+    # gives branch-protection an unambiguous context to require (vs. bare "build").
+    name: docs-build:required
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/starlight": "^0.41.1",
         "astro": "^7.1.3",
         "astro-mermaid": "^2.1.0",
@@ -304,6 +305,47 @@
         "prettier-plugin-astro": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/markdown-satteri": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/starlight": "^0.41.1",
     "astro": "^7.1.3",
     "astro-mermaid": "^2.1.0",


### PR DESCRIPTION
Fixes the failing **Documentation** CI job and the CI gap that let it reach `main`.

## 1. Build fix — declare `@astrojs/markdown-remark`

The Documentation build was failing at `astro build` ([failing run](https://github.com/dfinity/icp-cli/actions/runs/30023650633/job/89263936489)):

> `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` run on the `unified` processor from `@astrojs/markdown-remark`, which is no longer installed by default now that Sätteri is the default Markdown processor.

**Root cause:** #665 bumped astro `7.0.3 → 7.1.3`. Astro 7.1 made **Satteri** (`@astrojs/markdown-satteri`) the default Markdown processor and demoted `@astrojs/markdown-remark` to an *optional peer dependency* of starlight, so it's no longer installed at the top level. But `docs-site/astro.config.mjs` uses `markdown.rehypePlugins` (`rehypeRewriteLinks` + `rehypeExternalLinks`), which require the unified processor from that package.

**Fix:** declare `@astrojs/markdown-remark@^7.2.1` as a direct dependency (astro's own recommended remedy) and regenerate the lockfile.

## 2. CI fix — isolate PR build concurrency from the deploy lane

This break reached `main` because the docs build was **cancelled before it ran** on #665, never reporting a failure. The workflow used a single static concurrency group at the workflow level:

```yaml
concurrency:
  group: "pages"          # shared by every PR build AND every push/deploy run
  cancel-in-progress: false
```

Four docs dependabot PRs merged within ~3 minutes; all their runs piled into that one lane, and GitHub kept only the in-progress + latest-queued runs and cancelled the rest — including #665's own PR build.

**Fix:** split the group by event. Pull requests get an isolated per-ref lane that cancels superseded builds; pushes, tags, and manual runs keep the shared `pages` lane with `cancel-in-progress: false`. Deployment serialization (one at a time, in-progress never cancelled) and within-run job parallelism are both preserved unchanged.

> Note: the docs build is also not currently a required status check on `main`, so even a red build wouldn't block merge. That's being addressed separately via repo ruleset settings.

## Verification

Clean `npm ci` + `npm run build` (matching CI) completes: 37 pages built, rehype link-rewriting and og-image generation all working. Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)