### PR TITLE
ci(docs): run docs-build:required on every PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,9 +73,16 @@ jobs:
     # Always build for pushes, tags, and manual runs (the workflow-level push
     # paths filter already gates those). On pull requests, build only when docs
     # changed; otherwise the job is skipped and docs-build:required reports as a
-    # passing (skipped) required check. always() is required because `changes`
-    # is skipped on non-PR events and would otherwise skip this job too.
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true')
+    # passing (skipped) required check.
+    #
+    # Fail closed: if `changes` did not succeed (e.g. checkout or the paths-filter
+    # step failed) its `docs` output is empty, which would skip the build and let
+    # the required check pass vacuously — bypassing the gate. Building whenever
+    # `changes.result != 'success'` ensures a broken detection step can't do that.
+    #
+    # always() is required because `changes` is skipped on non-PR events and would
+    # otherwise cascade-skip this job.
+    if: always() && (github.event_name != 'pull_request' || needs.changes.result != 'success' || needs.changes.outputs.docs == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,11 +13,14 @@ on:
       - 'docs/**'
       - 'docs-site/**'
       - '.github/workflows/docs.yml'
+  # No paths filter here on purpose. docs-build:required is a required status
+  # check, so it must report a conclusion on EVERY pull request. A workflow-level
+  # paths filter would skip the whole workflow on docs-less PRs, leaving the
+  # required check permanently "expected" and blocking the merge (e.g. release
+  # PRs that only touch Cargo.toml/CHANGELOG.md). Instead the `changes` job below
+  # gates the build, so unrelated PRs report a passing (skipped) check. This
+  # mirrors checks.yml / validate-examples.yml.
   pull_request:
-    paths:
-      - 'docs/**'
-      - 'docs-site/**'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -39,11 +42,40 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Detect whether documentation sources changed. Runs only on pull requests;
+  # pushes/tags/manual runs skip it and rely on always() in `build` below.
+  # This lets docs-build:required report a passing (skipped) check on PRs that
+  # don't touch docs, instead of the workflow being filtered out entirely.
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'docs-site/**'
+              - '.github/workflows/docs.yml'
+
   # Build job - validates that docs build successfully
   build:
     # Explicit :required name follows the repo convention for gating checks and
     # gives branch-protection an unambiguous context to require (vs. bare "build").
     name: docs-build:required
+    needs: changes
+    # Always build for pushes, tags, and manual runs (the workflow-level push
+    # paths filter already gates those). On pull requests, build only when docs
+    # changed; otherwise the job is skipped and docs-build:required reports as a
+    # passing (skipped) required check. always() is required because `changes`
+    # is skipped on non-PR events and would otherwise skip this job too.
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

`docs-build:required` is now a required status check on the `main` ruleset (added today, right after #668 named the docs build job `docs-build:required`). But the Documentation workflow still has a **workflow-level `paths:` filter** on its `pull_request` trigger:

```yaml
pull_request:
  paths: ['docs/**', 'docs-site/**', '.github/workflows/docs.yml']
```

On any PR that doesn't touch docs paths — e.g. the **release PR** (#670), which only changes `Cargo.toml` / `Cargo.lock` / `CHANGELOG.md` — the whole workflow is filtered out and **never runs**. So `docs-build:required` is never reported, stays permanently "expected", and **blocks the merge**.

Key distinction:
- A workflow filtered out by a **workflow-level `paths:`** filter → required check never reported → **blocks**.
- A **job skipped via `if:`** → required check reports `skipped` → GitHub treats it as **passing**. (Verified: docs-site-only PRs #667/#664 merged today with `fmt`/`lint`/`test:required` = SKIPPED.)

## Fix

Adopt the pattern `checks.yml` / `validate-examples.yml` already use for required checks:

- Drop the `pull_request` paths filter so the workflow triggers on **every** PR.
- Add a `changes` job (`dorny/paths-filter`) that decides whether the build runs.
- Gate `build` (`docs-build:required`) with
  `if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true')`.
  - On docs-less PRs the build is **skipped** → reports as a passing required check.
  - `always()` is required so the `changes` job being skipped on non-PR events doesn't cascade-skip the build.

Push / tag / manual runs are unchanged — still gated by the **push-level** paths filter — and continue to build → publish → deploy.

## Note on the release PR

Merging this to `main` does not by itself unblock #670: `pull_request` triggers are evaluated from the PR's own branch, so `release/v1.2.0` needs to pick up the fixed `docs.yml` (merge `main` in or regenerate the release branch) to re-trigger and get a passing `docs-build:required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)