### PR TITLE
ci(docs): fix publish jobs cascade-skipped by always() build gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,8 +110,19 @@ jobs:
 
   # Publish root index, versions list, and IC config files - only runs on main branch
   publish-root-files:
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
+    # `!cancelled()` is a STATUS-CHECK FUNCTION, so GitHub does NOT prepend the
+    # implicit success() gate to this `if`. We then gate explicitly on build having
+    # succeeded via `needs.build.result`. This is required because `build` depends on
+    # the `changes` job, which is SKIPPED on push/workflow_dispatch events. Without a
+    # status-check function here, the implicit success() would evaluate the whole
+    # needs chain (including that skipped `changes` job) and skip this job even though
+    # build itself succeeded — the exact bug that stopped the v1.2 docs from
+    # publishing (see #671).
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -273,8 +284,14 @@ jobs:
 
   # Publish main branch docs for preview (always available at /main/)
   publish-main-docs:
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
+    # See publish-root-files: `!cancelled()` suppresses the implicit success() so the
+    # skipped `changes` job in the needs chain can't cascade-skip this job; we gate
+    # explicitly on build succeeding instead.
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -314,8 +331,15 @@ jobs:
 
   # Publish versioned docs - runs on tags (v*) or docs branches (docs/v*)
   publish-versioned-docs:
-    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/docs/v'))
     needs: build
+    # See publish-root-files: `!cancelled()` suppresses the implicit success() so the
+    # skipped `changes` job in the needs chain can't cascade-skip this job; we gate
+    # explicitly on build succeeding instead. This is the job that publishes /X.Y/;
+    # the cascade-skip here is why the v1.2.0 tag push produced no /1.2/ folder.
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      github.event_name == 'push' &&
+      (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/docs/v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -373,10 +397,20 @@ jobs:
           destination_dir: ${{ env.DOCS_VERSION }}
 
   # Deploy docs-deployment branch to IC asset canister.
-  # Runs when at least one publish job succeeded (skipped on PR builds).
-  # always() prevents auto-skip when publish-versioned-docs is skipped (e.g. on main branch pushes).
+  # always() prevents auto-skip when some publish jobs are skipped (e.g.
+  # publish-versioned-docs is legitimately skipped on main-branch pushes).
+  #
+  # `contains(needs.*.result, 'success')` requires that AT LEAST ONE publish job
+  # actually succeeded. Without it, a run where ALL three publish jobs were skipped
+  # would still deploy — silently re-pushing the stale docs-deployment branch to IC
+  # mainnet and reporting green. That is exactly what masked the v1.2 failure: every
+  # publish job skipped, yet this job ran and redeployed unchanged content. Now, if
+  # nothing was published there is nothing to deploy, and the run makes that visible.
   deploy-to-ic:
     needs: [publish-root-files, publish-main-docs, publish-versioned-docs]
-    if: always() && github.event_name != 'pull_request' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    if: >-
+      always() && github.event_name != 'pull_request' &&
+      !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') &&
+      contains(needs.*.result, 'success')
     uses: ./.github/workflows/docs-deploy.yml
     secrets: inherit


### PR DESCRIPTION
## Problem

v1.2.0 was released and `versions.json` was bumped to `1.2`, but the `docs-deployment` branch never received the v1.2 docs:

- no `/1.2/` folder was created,
- `versions.json` on the branch still lists `1.1` as `latest`,
- the root `index.html` still redirects to `./1.1/`,

**yet every workflow run reported success.** The last real deploy to the branch was #669; #670 (release), #671, and #672 published nothing.

## Root cause

#671 fixed a required-status-check deadlock by adding a PR-only `changes` gate and making `build` depend on it with `always()`:

```
changes ──▶ build ──▶ publish-root-files / publish-main-docs / publish-versioned-docs ──▶ deploy-to-ic
```

`changes` has `if: github.event_name == 'pull_request'`, so on **push and tag events it is skipped**. `build` survives that via `always()`. But the three publish jobs had plain `if:` conditions with **no status-check function**, so GitHub injected an implicit `success()` gate. That implicit gate evaluates the job's ancestry, and because a **skipped** job (`changes`) sits in the chain, it returns `false` — cascade-skipping the publish jobs even though `build` itself succeeded.

`deploy-to-ic` uses `always()` and only excluded `failure`/`cancelled`. Since `skipped` is neither, it still ran and **re-pushed the unchanged `docs-deployment` branch to IC mainnet, reporting green** — which is what masked the failure.

## Why this change is required

Without it, **no versioned docs will ever publish again** on a release, and the root redirect/metadata will never advance past 1.1 — silently, with green runs. Every future release would ship with stale docs. The `always()` on `build` (needed for #671's PR gating) is permanent, so the publish jobs must be made resilient to a skipped ancestor.

## Fix

Add `!cancelled()` (a status-check function — its presence suppresses the implicit `success()`) plus an explicit `needs.build.result == 'success'` gate to each publish job. `needs.build.result` alone is **not** sufficient: it's a context expression, not a status function, so the implicit `success()` would still be injected and still cascade-skip. The `!cancelled()` is load-bearing.

`deploy-to-ic` additionally requires `contains(needs.*.result, 'success')`, so a run where all three publish jobs skipped can no longer redeploy the stale branch and pass as success.

### Correctness across every trigger

| Event | `changes` | `build` | root-files / main-docs | versioned | deploy-to-ic |
|---|---|---|---|---|---|
| Push to `main` (docs) | skipped | success | **run** | skip (not a tag) | **run** (2 successes) |
| Tag `v1.2.0` | skipped | success | skip (not main) | **run** → builds `/1.2/` | **run** (1 success) |
| `docs/v1.2` branch | skipped | success | skip | **run** → `/1.2/` | **run** |
| `workflow_dispatch` on main | skipped | success | **run** | skip (not push) | **run** |
| PR, docs unchanged | success (docs=false) | skipped | skip | skip | skip |
| PR, docs changed | success (docs=true) | success | skip (not main/push) | skip | skip |
| `build` fails | skipped | **failure** | skip | skip | skip → run is red |
| Run cancelled | — | — | skip (`!cancelled()`) | skip | skip |

## Scope / relationship to #671

This touches only `push`/`tag`/`workflow_dispatch` behavior. The PR required-check gating introduced by #671 is **unchanged**: the `changes` and `build` (`docs-build:required`) jobs are not modified, so `docs-build:required` still reports on every PR and docs-less PRs still pass via a skipped build.

## Recovery — republishing v1.2 (do this AFTER merge)

Publishing is not retroactive; merging this does not republish v1.2.

**1. Publish the missing `/1.2/` folder** (only `publish-versioned-docs` creates it, on a tag or `docs/v*` push).

> ⚠️ A `push` event runs the workflow file **as it exists on the pushed ref**. A `docs/v1.2` branch taken straight from tag `v1.2.0` carries the *pre-fix* `docs.yml`, so `publish-versioned-docs` would cascade-skip again and the `/1.2/` recovery would silently fail. The recovery branch must carry this fix. Branch from the tag (for the correct v1.2 docs sources), then overlay the fixed workflow from `main` before pushing:

```bash
git fetch origin --tags
git checkout -b docs/v1.2 v1.2.0                      # v1.2 docs sources from the release tag
git checkout origin/main -- .github/workflows/docs.yml # overlay the fixed workflow (this PR, merged)
git commit -m "ci(docs): apply publish-job fix for v1.2 recovery build"
git push origin docs/v1.2
```

`docs.yml` at `v1.2.0` is byte-identical to this PR's merge base, so the overlay is a clean, docs-only-workflow change and leaves all v1.2 content sources untouched.

**2. Update the root redirect + metadata** (`publish-root-files`, main/dispatch only). `versions.json` on `main` already marks 1.2 as `latest`, so re-run the workflow:
```bash
gh workflow run docs.yml --ref main
```

**Verify:**
```bash
git fetch origin docs-deployment
git ls-tree origin/docs-deployment --name-only | grep 1.2          # 1.2/ exists
git show origin/docs-deployment:versions.json | jq '.versions[0]'  # {"version":"1.2","latest":true}
git show origin/docs-deployment:index.html | grep refresh          # → ./1.2/
```
