### PR TITLE
fix(network): surface launcher stderr on premature exit in background mode

### DIFF
--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -1,4 +1,4 @@
-use std::net::{SocketAddr, TcpListener};
+use std::net::SocketAddr;
 
 use candid::Principal;
 use icp_canister_interfaces::{
@@ -491,6 +491,8 @@ async fn network_run_and_stop_background() {
 #[cfg(unix)]
 #[tokio::test]
 async fn background_start_port_conflict_surfaces_launcher_output() {
+    use std::net::TcpListener;
+
     let ctx = TestContext::new();
     let project_dir = ctx.create_project_dir("portconflict");
 

--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{SocketAddr, TcpListener};
 
 use candid::Principal;
 use icp_canister_interfaces::{
@@ -480,6 +480,66 @@ async fn network_run_and_stop_background() {
         status_result.is_err(),
         "Network should not be reachable after stopping"
     );
+}
+
+/// Regression test for #597: when the native launcher exits prematurely in background mode
+/// (here because its fixed gateway port is already taken), the error must surface the
+/// launcher's captured stderr instead of only the bare exit status.
+///
+/// Unix-only: on Windows `network start` uses the Docker launcher, which does not go through
+/// `spawn_network_launcher`'s stderr-capture path.
+#[cfg(unix)]
+#[tokio::test]
+async fn background_start_port_conflict_surfaces_launcher_output() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("portconflict");
+
+    // Occupy a port with a plain TCP listener. icp-cli's own port check only looks for a live
+    // network descriptor, so it passes; the launcher then fails to bind the gateway and exits.
+    // Binding to :0 lets the OS choose a free port, avoiding collisions with other tests.
+    let blocker = TcpListener::bind("127.0.0.1:0").expect("failed to bind blocker socket");
+    let port = blocker.local_addr().unwrap().port();
+
+    let pm = formatdoc! {r#"
+        networks:
+          - name: portconflict-network
+            mode: managed
+            gateway:
+              bind: 127.0.0.1
+              port: {port}
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["network", "start", "portconflict-network", "--background"])
+        .assert()
+        .failure()
+        // Assert the launcher's captured output was attached to the error (issue #597),
+        // without pinning the exact launcher / pocket-ic wording.
+        .stderr(
+            contains("exited prematurely")
+                .and(contains("Launcher error output").or(contains("See the launcher log at"))),
+        );
+
+    // Hold the socket open until after the launcher has tried (and failed) to bind.
+    drop(blocker);
+
+    // The launcher spawns pocket-ic before it fails to bind the gateway, and on this error
+    // path pocket-ic is left orphaned (no descriptor is written to stop it later). Reap any
+    // process whose binary lives under this test's isolated temp home so we don't leak it;
+    // the home is unique per test, so this can't touch other tests or real networks.
+    {
+        use sysinfo::{ProcessesToUpdate, System};
+        let home = ctx.home_path().as_std_path();
+        let mut system = System::new();
+        system.refresh_processes(ProcessesToUpdate::All, true);
+        for process in system.processes().values() {
+            if process.exe().is_some_and(|exe| exe.starts_with(home)) {
+                process.kill();
+            }
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -493,7 +493,32 @@ async fn network_run_and_stop_background() {
 async fn background_start_port_conflict_surfaces_launcher_output() {
     use std::net::TcpListener;
 
+    // The launcher spawns pocket-ic before it fails to bind the gateway, and on this error
+    // path pocket-ic is left orphaned (no descriptor is written to stop it later). Reap any
+    // process whose binary lives under this test's isolated temp home so we don't leak it;
+    // the home is unique per test, so this can't touch other tests or real networks.
+    //
+    // This runs on `Drop` (not inline after the assertion) so it still fires if an assertion
+    // below panics — the failure path is exactly the one that orphans pocket-ic.
+    struct Reaper(PathBuf);
+    impl Drop for Reaper {
+        fn drop(&mut self) {
+            use sysinfo::{ProcessesToUpdate, System};
+            let mut system = System::new();
+            system.refresh_processes(ProcessesToUpdate::All, true);
+            for process in system.processes().values() {
+                if process
+                    .exe()
+                    .is_some_and(|exe| exe.starts_with(self.0.as_std_path()))
+                {
+                    process.kill();
+                }
+            }
+        }
+    }
+
     let ctx = TestContext::new();
+    let _reaper = Reaper(ctx.home_path().to_path_buf());
     let project_dir = ctx.create_project_dir("portconflict");
 
     // Occupy a port with a plain TCP listener. icp-cli's own port check only looks for a live
@@ -517,31 +542,13 @@ async fn background_start_port_conflict_surfaces_launcher_output() {
         .args(["network", "start", "portconflict-network", "--background"])
         .assert()
         .failure()
-        // Assert the launcher's captured output was attached to the error (issue #597),
-        // without pinning the exact launcher / pocket-ic wording.
-        .stderr(
-            contains("exited prematurely")
-                .and(contains("Launcher error output").or(contains("See the launcher log at"))),
-        );
+        // Require the captured-output header (our own string, not PocketIC's wording): this
+        // proves the real launcher's stderr was read and wired into the error. Accepting the
+        // empty/unreadable fallback here would let a wiring regression pass unnoticed.
+        .stderr(contains("exited prematurely").and(contains("Launcher error output")));
 
     // Hold the socket open until after the launcher has tried (and failed) to bind.
     drop(blocker);
-
-    // The launcher spawns pocket-ic before it fails to bind the gateway, and on this error
-    // path pocket-ic is left orphaned (no descriptor is written to stop it later). Reap any
-    // process whose binary lives under this test's isolated temp home so we don't leak it;
-    // the home is unique per test, so this can't touch other tests or real networks.
-    {
-        use sysinfo::{ProcessesToUpdate, System};
-        let home = ctx.home_path().as_std_path();
-        let mut system = System::new();
-        system.refresh_processes(ProcessesToUpdate::All, true);
-        for process in system.processes().values() {
-            if process.exe().is_some_and(|exe| exe.starts_with(home)) {
-                process.kill();
-            }
-        }
-    }
 }
 
 #[tokio::test]

--- a/crates/icp/src/network/managed/launcher.rs
+++ b/crates/icp/src/network/managed/launcher.rs
@@ -184,6 +184,8 @@ fn premature_exit_detail(background: bool, stderr_file: &Path) -> String {
                 format!("\nLauncher error output (from {stderr_file}):\n{tail}")
             }
         }
+        // The read error is deliberately ignored: this is already an error path, and the
+        // fallback carries `stderr_file` so the user can still find the log.
         Err(_) => format!("\nSee the launcher log at {stderr_file} for details."),
     }
 }

--- a/crates/icp/src/network/managed/launcher.rs
+++ b/crates/icp/src/network/managed/launcher.rs
@@ -39,11 +39,14 @@ pub enum SpawnNetworkLauncherError {
     #[snafu(display("failed to watch launcher status file"))]
     WatchForStatusFile { source: WaitForLauncherStatusError },
     #[snafu(display(
-        "network launcher at {network_launcher_path} exited prematurely with status {exit_status}"
+        "network launcher at {network_launcher_path} exited prematurely with status {exit_status}{detail}"
     ))]
     LauncherExitedPrematurely {
         network_launcher_path: PathBuf,
         exit_status: std::process::ExitStatus,
+        /// Either empty, or a leading-newline suffix carrying the launcher's captured
+        /// stderr tail (background mode only). See [`premature_exit_detail`].
+        detail: String,
     },
     #[snafu(display("failed to watch launcher process for exit code"))]
     WatchLauncher {
@@ -117,9 +120,14 @@ pub async fn spawn_network_launcher(
             let exit_status = res.context(WatchLauncherSnafu {
                 network_launcher_path,
             })?;
+            // In background mode the launcher's stderr was redirected to a file rather than
+            // inherited, so nothing was shown live. Read it back so the error explains *why*
+            // it exited (e.g. a port conflict) instead of just reporting the exit status.
+            let detail = premature_exit_detail(background, stderr_file);
             return LauncherExitedPrematurelySnafu {
                 exit_status,
-                network_launcher_path: &network_launcher_path,
+                network_launcher_path,
+                detail,
             }.fail();
         },
     };
@@ -150,6 +158,51 @@ pub async fn spawn_network_launcher(
         },
         ChildLocator::Pid { pid, start_time },
     ))
+}
+
+/// Upper bounds on how much captured stderr to fold into the premature-exit error, so a
+/// verbose launcher log (e.g. `--debug` with `-d`) can't produce a wall-of-text error.
+const MAX_STDERR_TAIL_LINES: usize = 50;
+const MAX_STDERR_TAIL_BYTES: usize = 8 * 1024;
+
+/// Builds the trailing detail appended to [`SpawnNetworkLauncherError::LauncherExitedPrematurely`].
+///
+/// In foreground mode the launcher's stderr is inherited and was already shown live, so this
+/// returns an empty string. In background mode it was redirected to `stderr_file`; we read the
+/// tail back so the cause travels with the error. The read is best-effort: if it fails or the
+/// file is empty we fall back to pointing at the log path rather than masking the exit status.
+fn premature_exit_detail(background: bool, stderr_file: &Path) -> String {
+    if !background {
+        return String::new();
+    }
+    match crate::fs::read_to_string(stderr_file) {
+        Ok(contents) => {
+            let tail = stderr_tail(&contents);
+            if tail.is_empty() {
+                format!("\nSee the launcher log at {stderr_file} for details.")
+            } else {
+                format!("\nLauncher error output (from {stderr_file}):\n{tail}")
+            }
+        }
+        Err(_) => format!("\nSee the launcher log at {stderr_file} for details."),
+    }
+}
+
+/// Returns the trailing portion of `contents`, capped to the last [`MAX_STDERR_TAIL_LINES`]
+/// lines and then to [`MAX_STDERR_TAIL_BYTES`] (cutting on a char boundary), trimmed.
+fn stderr_tail(contents: &str) -> String {
+    let lines: Vec<&str> = contents.lines().collect();
+    let start = lines.len().saturating_sub(MAX_STDERR_TAIL_LINES);
+    let by_lines = lines[start..].join("\n");
+    let by_lines = by_lines.trim();
+    if by_lines.len() <= MAX_STDERR_TAIL_BYTES {
+        return by_lines.to_string();
+    }
+    let mut cut = by_lines.len() - MAX_STDERR_TAIL_BYTES;
+    while !by_lines.is_char_boundary(cut) {
+        cut += 1;
+    }
+    by_lines[cut..].trim_start().to_string()
 }
 
 pub async fn stop_launcher(pid: Pid) {
@@ -374,5 +427,67 @@ struct WatchRecv(Sender<notify::Result<notify::Event>>);
 impl EventHandler for WatchRecv {
     fn handle_event(&mut self, event: notify::Result<notify::Event>) {
         let _ = self.0.blocking_send(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stderr_tail_keeps_short_content_verbatim() {
+        assert_eq!(stderr_tail("line one\nline two"), "line one\nline two");
+    }
+
+    #[test]
+    fn stderr_tail_trims_surrounding_whitespace() {
+        assert_eq!(stderr_tail("\n\n  boom  \n\n"), "boom");
+    }
+
+    #[test]
+    fn stderr_tail_keeps_only_last_lines() {
+        let input = (0..200)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tail = stderr_tail(&input);
+        let lines: Vec<&str> = tail.lines().collect();
+        assert_eq!(lines.len(), MAX_STDERR_TAIL_LINES);
+        assert_eq!(*lines.first().unwrap(), "150");
+        assert_eq!(*lines.last().unwrap(), "199");
+    }
+
+    #[test]
+    fn stderr_tail_caps_bytes_on_a_single_long_line() {
+        let input = "x".repeat(MAX_STDERR_TAIL_BYTES * 2);
+        let tail = stderr_tail(&input);
+        assert!(tail.len() <= MAX_STDERR_TAIL_BYTES);
+        assert!(!tail.is_empty());
+    }
+
+    #[test]
+    fn premature_exit_detail_is_empty_in_foreground() {
+        // Foreground inherits stderr, so there is nothing to read back.
+        let missing = Path::new("/nonexistent/stderr.log");
+        assert_eq!(premature_exit_detail(false, missing), "");
+    }
+
+    #[test]
+    fn premature_exit_detail_includes_captured_output() {
+        let dir = camino_tempfile::Utf8TempDir::new().unwrap();
+        let file = dir.path().join("stderr.log");
+        crate::fs::write(&file, b"Address already in use (os error 48)\n").unwrap();
+        let detail = premature_exit_detail(true, &file);
+        assert!(detail.starts_with('\n'));
+        assert!(detail.contains("Address already in use"));
+        assert!(detail.contains(file.as_str()));
+    }
+
+    #[test]
+    fn premature_exit_detail_falls_back_to_log_path_when_unreadable() {
+        let missing = Path::new("/nonexistent/stderr.log");
+        let detail = premature_exit_detail(true, missing);
+        assert!(detail.contains("See the launcher log at"));
+        assert!(detail.contains(missing.as_str()));
     }
 }


### PR DESCRIPTION
## What

Follow-up to #675 for issue #597. In **background mode** the native launcher's stderr is redirected to a log file rather than inherited, so when it exits prematurely (e.g. its fixed gateway port is already in use by Docker) the user only saw:

```
network launcher at ... exited prematurely with status 101
```

with no indication of *why*.

This reads the launcher's captured stderr back and folds the tail into the `LauncherExitedPrematurely` error, so the cause travels with the error:

```
... exited prematurely with status 101
Launcher error output (from .../network-launcher/stderr.log):
<tail>
```

## How

- New `premature_exit_detail(background, stderr_file)` in `launcher.rs`, called from the premature-exit arm of the `select!`:
  - **Foreground:** returns empty — stderr is already inherited and streamed live by #675, so the detail is shown, just rendered differently. No change.
  - **Background:** reads `stderr.log`, tails it (last 50 lines, then 8 KB, cut on a char boundary), and embeds it. Best-effort: on an unreadable/empty file it falls back to pointing at the log path rather than masking the exit status.
- Adds a `detail: String` field to the error variant and appends `{detail}` to the `#[snafu(display)]`.

## Tests

- Unit tests for the tail bounds (line cap, byte cap, trimming), the foreground no-op, the captured-output path, and the unreadable-file fallback.
- A `#[cfg(unix)]` integration test that occupies a port with a raw `TcpListener` (which passes icp-cli's own descriptor-based port check but makes the launcher fail to bind the gateway), runs `network start --background`, and asserts the captured output is attached to the error **without pinning the exact launcher / pocket-ic wording**. It also reaps any process spawned under the test's isolated temp home so it doesn't leak an orphaned pocket-ic.

## Scope / follow-ups

Uses `Refs #597` rather than `Fixes` because two related items are intentionally **out of scope** and are tracked separately:

1. **Docker launcher path** — `spawn_docker_launcher` has the same class of bug via a separate `ContainerExitedPrematurely` error and a different mechanism (needs `docker logs`, and can't be covered by this unix/native integration test). → #677
2. **Orphaned pocket-ic on the failure path** — the launcher spawns pocket-ic and only cleans it up on the success path; on error/panic it's left running. → dfinity/icp-cli-network-launcher#76

🤖 Generated with [Claude Code](https://claude.com/claude-code)