### PR TITLE
fix(network): make docker network log behavior match the native launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ bump. Currently experimental: project bundling, project dependencies
 # Unreleased
 
 * fix: `icp network start` now explains why a Docker-based network failed to come up. A container that exited before the network was ready was reported as `failed to watch docker container <id> for exit` with an empty cause, discarding the actual reason (e.g. the gateway port already being taken); the container's output is now attached to the error.
+* feat: Docker-based networks now show the launcher's output like non-containerized ones do. In the foreground the container's stdout and stderr are streamed to your terminal as it runs; in background mode `icp network start` prints the `docker logs -f <container-id>` command to follow it. Previously container output was never shown at all — which on Windows, where the launcher always runs in a container, meant `icp network start` was silent.
 
 # v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: project bundling, project dependencies
 
 # Unreleased
 
+* fix: `icp network start` now explains why a Docker-based network failed to come up. A container that exited before the network was ready was reported as `failed to watch docker container <id> for exit` with an empty cause, discarding the actual reason (e.g. the gateway port already being taken); the container's output is now attached to the error.
+
 # v1.2.0
 
 * feat(sync-plugin): the compute-time limit for `plugin` sync steps is now configurable via the `ICP_CLI_PLUGIN_COMPUTE_LIMIT_SECS` environment variable (default `60`). Raise it for compute-heavy plugins (e.g. brotli-compressing a large asset bundle) that legitimately exceed the default, especially on slower CI runners. The limit-exceeded error now names the variable and the current limit, and a malformed value is rejected rather than silently ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ bump. Currently experimental: project bundling, project dependencies
 
 * fix: `icp network start` now explains why a Docker-based network failed to come up. A container that exited before the network was ready was reported as `failed to watch docker container <id> for exit` with an empty cause, discarding the actual reason (e.g. the gateway port already being taken); the container's output is now attached to the error.
 * feat: Docker-based networks now show the launcher's output like non-containerized ones do. In the foreground the container's stdout and stderr are streamed to your terminal as it runs; in background mode `icp network start` prints the `docker logs -f <container-id>` command to follow it. Previously container output was never shown at all — which on Windows, where the launcher always runs in a container, meant `icp network start` was silent.
+* fix: a network launcher running in a container (`icp settings autocontainerize true`, and always on Windows) now receives `--verbose` when `icp -d` is used, matching the non-containerized launcher.
 
 # v1.2.0
 

--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -638,6 +638,62 @@ async fn network_docker() {
     assert!(balance > 0_u128);
 }
 
+/// A docker-mode manifest whose container writes a known line to stderr and exits nonzero without
+/// ever writing status.json — exactly the premature-exit path.
+///
+/// Overriding the entrypoint is far more deterministic than trying to make the real launcher fail
+/// from outside the container: it tolerates unrecognized arguments, and its ports live in the
+/// container's namespace so they can't be made to conflict. What is under test is icp-cli's log
+/// plumbing, not the launcher — whatever the container printed has to reach the user.
+///
+/// `rm-on-exit` also makes the container clean itself up, which additionally pins the ordering:
+/// the logs must be read before the drop guard removes the container.
+const FAILING_CONTAINER_MARKER: &str = "simulated-launcher-startup-failure";
+
+fn failing_docker_manifest() -> String {
+    formatdoc! {r#"
+        {NETWORK_DOCKER}
+            rm-on-exit: true
+            entrypoint:
+              - /bin/sh
+              - -c
+            args:
+              - "echo {FAILING_CONTAINER_MARKER} >&2; exit 3"
+    "#}
+}
+
+/// Regression test for #677: when the container exits prematurely, the error must surface the
+/// container's log tail instead of only the bare exit status. This is the Docker counterpart of
+/// `background_start_port_conflict_surfaces_launcher_output` — the container's stdio belongs to
+/// the daemon, so the cause comes back over `docker logs` rather than from a local file.
+#[tag(docker)]
+#[tokio::test]
+async fn docker_start_surfaces_container_output_on_premature_exit() {
+    let ctx = TestContext::new();
+
+    let project_dir = ctx.create_project_dir("docker-premature-exit");
+    write_string(&project_dir.join("icp.yaml"), &failing_docker_manifest())
+        .expect("failed to write project manifest");
+
+    ctx.docker_pull_network();
+
+    // `--background` bounds the test: were the container to stay up, the command returns
+    // instead of blocking, and the `failure()` assertion fails fast.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["network", "start", "docker-network", "--background"])
+        .assert()
+        .failure()
+        // The header is our own string, and the marker is the container's actual bytes: together
+        // they prove the log was fetched and folded into the error. Accepting the no-output
+        // fallback here would let a wiring regression pass unnoticed.
+        .stderr(
+            contains("exited prematurely with status 3")
+                .and(contains("Container output"))
+                .and(contains(FAILING_CONTAINER_MARKER)),
+        );
+}
+
 #[tokio::test]
 #[file_serial(default_local_network)]
 async fn override_local_network_with_custom_port() {

--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -687,13 +687,15 @@ async fn docker_background_start_surfaces_container_output_on_premature_exit() {
         .failure()
         // The header is our own string, and the marker is the container's actual bytes: together
         // they prove the log was fetched and folded into the error. Accepting the no-output
-        // fallback here would let a wiring regression pass unnoticed. The `docker logs` hint
-        // stands in for native background mode's "stderr: <path>" message.
+        // fallback here would let a wiring regression pass unnoticed.
         .stderr(
             contains("exited prematurely with status 3")
                 .and(contains("Container output"))
                 .and(contains(FAILING_CONTAINER_MARKER))
-                .and(contains("view with: docker logs -f")),
+                // The `docker logs` hint is deferred until the network is up, so a start that
+                // failed must not advertise it — this manifest sets `rm-on-exit`, so the
+                // container is already gone by the time anyone could run it.
+                .and(contains("docker logs").not()),
         );
 }
 
@@ -724,7 +726,7 @@ async fn docker_foreground_streams_container_output() {
                 .and(contains("exited prematurely with status 3"))
                 .and(contains("Container output").not())
                 // Streaming replaces the retrieval hint; it is background-only.
-                .and(contains("docker logs -f").not()),
+                .and(contains("docker logs").not()),
         );
 }
 

--- a/crates/icp-cli/tests/network_tests.rs
+++ b/crates/icp-cli/tests/network_tests.rs
@@ -662,13 +662,14 @@ fn failing_docker_manifest() -> String {
     "#}
 }
 
-/// Regression test for #677: when the container exits prematurely, the error must surface the
-/// container's log tail instead of only the bare exit status. This is the Docker counterpart of
-/// `background_start_port_conflict_surfaces_launcher_output` — the container's stdio belongs to
-/// the daemon, so the cause comes back over `docker logs` rather than from a local file.
+/// Regression test for #677: when the container exits prematurely in **background** mode, the
+/// error must surface the container's log tail instead of only the bare exit status. This is the
+/// Docker counterpart of `background_start_port_conflict_surfaces_launcher_output` — the
+/// container's stdio belongs to the daemon, so the cause comes back over `docker logs` rather than
+/// from a local file.
 #[tag(docker)]
 #[tokio::test]
-async fn docker_start_surfaces_container_output_on_premature_exit() {
+async fn docker_background_start_surfaces_container_output_on_premature_exit() {
     let ctx = TestContext::new();
 
     let project_dir = ctx.create_project_dir("docker-premature-exit");
@@ -686,11 +687,44 @@ async fn docker_start_surfaces_container_output_on_premature_exit() {
         .failure()
         // The header is our own string, and the marker is the container's actual bytes: together
         // they prove the log was fetched and folded into the error. Accepting the no-output
-        // fallback here would let a wiring regression pass unnoticed.
+        // fallback here would let a wiring regression pass unnoticed. The `docker logs` hint
+        // stands in for native background mode's "stderr: <path>" message.
         .stderr(
             contains("exited prematurely with status 3")
                 .and(contains("Container output"))
-                .and(contains(FAILING_CONTAINER_MARKER)),
+                .and(contains(FAILING_CONTAINER_MARKER))
+                .and(contains("view with: docker logs -f")),
+        );
+}
+
+/// In **foreground** mode the container's output must be streamed live, the way the native
+/// launcher's inherited stdio is. Asserting the absence of the `Container output` header is the
+/// point: it proves the marker arrived over the live stream rather than the premature-exit tail,
+/// and that the two don't both fire and print the cause twice.
+#[tag(docker)]
+#[tokio::test]
+async fn docker_foreground_streams_container_output() {
+    let ctx = TestContext::new();
+
+    let project_dir = ctx.create_project_dir("docker-foreground-logs");
+    write_string(&project_dir.join("icp.yaml"), &failing_docker_manifest())
+        .expect("failed to write project manifest");
+
+    ctx.docker_pull_network();
+
+    // No `--background`, and the container exits on its own, so this terminates without needing
+    // to interrupt a healthy network.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["network", "start", "docker-network"])
+        .assert()
+        .failure()
+        .stderr(
+            contains(FAILING_CONTAINER_MARKER)
+                .and(contains("exited prematurely with status 3"))
+                .and(contains("Container output").not())
+                // Streaming replaces the retrieval hint; it is background-only.
+                .and(contains("docker logs -f").not()),
         );
 }
 

--- a/crates/icp/src/network/managed/docker.rs
+++ b/crates/icp/src/network/managed/docker.rs
@@ -7,7 +7,7 @@ use bollard::{
     errors::Error as BollardError,
     models::{ContainerCreateBody, HostConfig, Mount, MountTypeEnum, PortBinding},
     query_parameters::{
-        CreateContainerOptions, CreateImageOptions, InspectContainerOptions,
+        CreateContainerOptions, CreateImageOptions, InspectContainerOptions, LogsOptions,
         RemoveContainerOptions, StartContainerOptions, StopContainerOptions, WaitContainerOptions,
     },
 };
@@ -26,7 +26,7 @@ use crate::network::{
 };
 use crate::prelude::*;
 
-use super::launcher::wait_for_launcher_status;
+use super::launcher::{MAX_OUTPUT_TAIL_LINES, output_tail, wait_for_launcher_status};
 
 /// Error converting a path for WSL2.
 #[derive(Debug, Snafu)]
@@ -384,7 +384,7 @@ pub async fn spawn_docker_launcher(
         .await
         .context(CreateContainerSnafu { image_name: image })?;
     let container_id = container_resp.id;
-    info!("Created container {}", &container_id[..12]);
+    info!("Created container {}", short_id(&container_id));
     let guard = AsyncDropper::new(DockerDropGuard {
         container_id: Some(container_id),
         docker: Some(docker),
@@ -401,18 +401,28 @@ pub async fn spawn_docker_launcher(
     let launcher_status = select! {
         content = watcher => content?,
         res = wait_container.try_next() => {
-            let exit = res.context(WatchContainerSnafu { container_id })?;
-            if let Some(exit) = exit {
-                return ContainerExitedPrematurelySnafu {
-                    container_id,
-                    exit_status: exit.status_code,
-                }.fail();
-            } else {
-                return RequiredFieldMissingSnafu {
+            // bollard turns any nonzero exit into `DockerContainerWaitError` instead of an `Ok`
+            // response carrying the status code, so both shapes have to reach the same error.
+            // Otherwise the case that matters — a container that *failed* — surfaced as an
+            // opaque "failed to watch container for exit" with an empty cause.
+            let (exit_status, wait_error) = match res {
+                Ok(Some(exit)) => (
+                    exit.status_code,
+                    exit.error.and_then(|e| e.message).unwrap_or_default(),
+                ),
+                Ok(None) => return RequiredFieldMissingSnafu {
                     field: "StatusCode",
                     route: "wait_container",
-                }.fail()
-            }
+                }.fail(),
+                Err(BollardError::DockerContainerWaitError { code, error }) => (code, error),
+                Err(source) => return Err(source).context(WatchContainerSnafu { container_id }),
+            };
+            let detail = premature_exit_detail(docker, container_id, &wait_error).await;
+            return ContainerExitedPrematurelySnafu {
+                container_id,
+                exit_status,
+                detail,
+            }.fail();
         },
     };
     let container_info = docker
@@ -510,6 +520,64 @@ pub async fn spawn_docker_launcher(
         locator,
         gateway_port_was_fixed,
     ))
+}
+
+/// Docker resolves an unambiguous id prefix, so log messages use the short form users see in
+/// `docker ps`. `min` keeps this from panicking on an error path if the daemon ever hands back
+/// something shorter than a full id.
+fn short_id(container_id: &str) -> &str {
+    &container_id[..container_id.len().min(12)]
+}
+
+/// Builds the trailing detail appended to [`DockerLauncherError::ContainerExitedPrematurely`].
+///
+/// The native launcher's stderr is either inherited or redirected to a local file, so its
+/// premature-exit path can read the cause back from disk. Here the daemon owns the container's
+/// stdio and nothing local mirrors it, so the only way to recover the cause is to ask the daemon
+/// for the log tail. Docker's own `tail` bounds the request, and [`output_tail`] applies the same
+/// caps as the native path on top of it so a chatty image can't produce a wall-of-text error.
+///
+/// Best-effort: if the fetch fails or the container logged nothing, this points at `docker logs`
+/// rather than masking the exit status.
+///
+/// `wait_error` is the daemon's own wait-level message, which is normally empty but is the only
+/// explanation available when the container itself printed nothing.
+async fn premature_exit_detail(docker: &Docker, container_id: &str, wait_error: &str) -> String {
+    let mut detail = String::new();
+    if !wait_error.is_empty() {
+        detail.push_str(&format!("\nDocker reported: {wait_error}"));
+    }
+    let mut logs = std::pin::pin!(docker.logs(
+        container_id,
+        Some(LogsOptions {
+            stdout: true,
+            stderr: true,
+            tail: MAX_OUTPUT_TAIL_LINES.to_string(),
+            ..<_>::default()
+        }),
+    ));
+    let mut output = String::new();
+    while let Some(chunk) = logs.next().await {
+        match chunk {
+            Ok(chunk) => output.push_str(&chunk.to_string()),
+            // The stream error is deliberately ignored: this is already an error path, and
+            // whatever arrived before it is still worth showing.
+            Err(_) => break,
+        }
+    }
+    // The full id is already on the error's first line, so the hint uses the short form.
+    let short_id = short_id(container_id);
+    let tail = output_tail(&output);
+    if tail.is_empty() {
+        detail.push_str(&format!(
+            "\nNo output was captured; see `docker logs {short_id}` for details."
+        ));
+    } else {
+        detail.push_str(&format!(
+            "\nContainer output (from `docker logs {short_id}`):\n{tail}"
+        ));
+    }
+    detail
 }
 
 /// Connect to the Docker daemon at the given socket.
@@ -699,11 +767,14 @@ pub enum DockerLauncherError {
         container_id: String,
     },
     #[snafu(display(
-        "docker container {container_id} exited prematurely with status {exit_status}"
+        "docker container {container_id} exited prematurely with status {exit_status}{detail}"
     ))]
     ContainerExitedPrematurely {
         container_id: String,
         exit_status: i64,
+        /// A leading-newline suffix carrying the container's log tail, or a pointer to
+        /// `docker logs` when none could be read. See [`premature_exit_detail`].
+        detail: String,
     },
     #[snafu(display("failed to query docker image {image}"))]
     QueryImage {

--- a/crates/icp/src/network/managed/docker.rs
+++ b/crates/icp/src/network/managed/docker.rs
@@ -28,7 +28,7 @@ use crate::network::{
 use crate::prelude::*;
 
 use super::launcher::{
-    MAX_OUTPUT_TAIL_BYTES, MAX_OUTPUT_TAIL_LINES, output_tail, tail_bytes, wait_for_launcher_status,
+    MAX_OUTPUT_TAIL_BYTES, MAX_OUTPUT_TAIL_LINES, output_tail, wait_for_launcher_status,
 };
 
 /// Error converting a path for WSL2.
@@ -404,15 +404,9 @@ pub async fn spawn_docker_launcher(
     // Foreground mirrors the native launcher's inherited stdio by streaming the container's
     // output live. Background can't: the CLI exits while the container keeps running, and unlike
     // a native child process — whose fds keep the log files filling after we're gone — the
-    // daemon owns the stdio and there is nothing left here to pump it. Point at `docker logs`
-    // instead, which is where the daemon already persists it.
-    let log_follower = if background {
-        info!("For background mode, network output is captured by Docker:");
-        info!("  view with: docker logs -f {}", short_id(container_id));
-        None
-    } else {
-        Some(follow_container_logs(docker, container_id))
-    };
+    // daemon owns the stdio and there is nothing left here to pump it. Those runs are pointed at
+    // `docker logs` once the network is up, which is where the daemon already persists it.
+    let log_follower = (!background).then(|| follow_container_logs(docker, container_id));
     let mut wait_container = docker.wait_container(container_id, None::<WaitContainerOptions>);
     let launcher_status = select! {
         content = watcher => content?,
@@ -438,7 +432,9 @@ pub async fn spawn_docker_launcher(
             if let Some(follower) = log_follower {
                 drain_log_follower(follower).await;
             }
-            let detail = premature_exit_detail(docker, container_id, &wait_error, background).await;
+            let detail = premature_exit_detail(
+                docker, container_id, &wait_error, background, *rm_on_exit,
+            ).await;
             return ContainerExitedPrematurelySnafu {
                 container_id,
                 exit_status,
@@ -446,6 +442,13 @@ pub async fn spawn_docker_launcher(
             }.fail();
         },
     };
+    if background {
+        // Deferred until the network is actually up. Advertised any earlier it would also print
+        // on the failure path above, where `rm-on-exit` may already have deleted the container
+        // out from under the reader — and where the error carries the output anyway.
+        info!("For background mode, network output is captured by Docker:");
+        info!("  view with: docker logs -f {}", short_id(container_id));
+    }
     let container_info = docker
         .inspect_container(container_id, None::<InspectContainerOptions>)
         .await
@@ -647,6 +650,7 @@ async fn premature_exit_detail(
     container_id: &str,
     wait_error: &str,
     background: bool,
+    rm_on_exit: bool,
 ) -> String {
     let mut detail = String::new();
     if !wait_error.is_empty() {
@@ -667,33 +671,48 @@ async fn premature_exit_detail(
             ..<_>::default()
         }),
     ));
-    let mut output = String::new();
+    // Accumulate bytes and decode once at the end rather than decoding each chunk, so the
+    // boundaries the daemon happens to frame on can't affect the result.
+    //
+    // This does not rescue a multi-byte character split across those frames: the json-file driver
+    // stores each entry as a JSON string, so the daemon has already replaced the bisected halves
+    // with U+FFFD before we see them. Plain `docker logs` shows the same replacements.
+    let mut output: Vec<u8> = Vec::new();
     while let Some(chunk) = logs.next().await {
         match chunk {
-            Ok(chunk) => output.push_str(&chunk.to_string()),
+            Ok(chunk) => output.extend_from_slice(chunk.as_ref()),
             // The stream error is deliberately ignored: this is already an error path, and
             // whatever arrived before it is still worth showing.
             Err(_) => break,
         }
         // Docker's `tail` caps the number of lines, not their length, so a container emitting a
         // few enormous lines would otherwise be held whole in memory just to have nearly all of
-        // it discarded below. Trim as we go instead. This is a raw byte cut, not `output_tail`:
-        // that one trims trailing whitespace, which mid-stream would glue the next chunk onto
-        // the end of the current line.
+        // it discarded below. Drop the excess from the front as we go.
         if output.len() > MAX_LOG_BUFFER_BYTES {
-            output = tail_bytes(&output, MAX_LOG_BUFFER_BYTES).to_string();
+            let mut cut = output.len() - MAX_LOG_BUFFER_BYTES;
+            // Step over continuation bytes so the cut lands on a character boundary; otherwise
+            // this trim would itself bisect a character and the decode below would replace it.
+            while cut < output.len() && output[cut] & 0b1100_0000 == 0b1000_0000 {
+                cut += 1;
+            }
+            output.drain(..cut);
         }
     }
-    // The full id is already on the error's first line, so the hint uses the short form.
-    let short_id = short_id(container_id);
-    let tail = output_tail(&output);
-    if tail.is_empty() {
-        detail.push_str(&format!(
-            "\nNo output was captured; see `docker logs {short_id}` for details."
-        ));
+    let tail = output_tail(&String::from_utf8_lossy(&output));
+    if !tail.is_empty() {
+        // No `docker logs` attribution here: the output is inline, and naming a command that may
+        // no longer work (see below) would just send the reader somewhere empty.
+        detail.push_str(&format!("\nContainer output:\n{tail}"));
+    } else if rm_on_exit {
+        // The drop guard removes the container as this error propagates, so by the time anyone
+        // reads this there is nothing left to inspect. Say that instead of pointing at a
+        // container that has been deleted — which is the *common* case, since autocontainerized
+        // networks (always, on Windows) set `rm-on-exit`.
+        detail.push_str("\nThe container produced no output, and was removed on exit.");
     } else {
         detail.push_str(&format!(
-            "\nContainer output (from `docker logs {short_id}`):\n{tail}"
+            "\nThe container produced no output; see `docker logs {}` for details.",
+            short_id(container_id)
         ));
     }
     detail

--- a/crates/icp/src/network/managed/docker.rs
+++ b/crates/icp/src/network/managed/docker.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use async_dropper::{AsyncDrop, AsyncDropper};
 use async_trait::async_trait;
 use bollard::{
     Docker,
+    container::LogOutput,
     errors::Error as BollardError,
     models::{ContainerCreateBody, HostConfig, Mount, MountTypeEnum, PortBinding},
     query_parameters::{
@@ -15,8 +16,8 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use snafu::ResultExt;
 use snafu::{OptionExt, Snafu};
-use tokio::select;
-use tracing::info;
+use tokio::{io::AsyncWriteExt, select, task::JoinHandle};
+use tracing::{debug, info};
 use wslpath2::Conversion;
 
 use crate::network::{
@@ -241,6 +242,7 @@ pub(super) fn translate_launcher_args_for_docker(args: Vec<String>) -> Vec<Strin
 pub async fn spawn_docker_launcher(
     options: &ManagedImageOptions,
     host_status_dir: &Path,
+    background: bool,
 ) -> Result<
     (
         AsyncDropper<DockerDropGuard>,
@@ -397,6 +399,18 @@ pub async fn spawn_docker_launcher(
         .start_container(container_id, None::<StartContainerOptions>)
         .await
         .context(StartContainerSnafu { container_id })?;
+    // Foreground mirrors the native launcher's inherited stdio by streaming the container's
+    // output live. Background can't: the CLI exits while the container keeps running, and unlike
+    // a native child process — whose fds keep the log files filling after we're gone — the
+    // daemon owns the stdio and there is nothing left here to pump it. Point at `docker logs`
+    // instead, which is where the daemon already persists it.
+    let log_follower = if background {
+        info!("For background mode, network output is captured by Docker:");
+        info!("  view with: docker logs -f {}", short_id(container_id));
+        None
+    } else {
+        Some(follow_container_logs(docker, container_id))
+    };
     let mut wait_container = docker.wait_container(container_id, None::<WaitContainerOptions>);
     let launcher_status = select! {
         content = watcher => content?,
@@ -417,7 +431,12 @@ pub async fn spawn_docker_launcher(
                 Err(BollardError::DockerContainerWaitError { code, error }) => (code, error),
                 Err(source) => return Err(source).context(WatchContainerSnafu { container_id }),
             };
-            let detail = premature_exit_detail(docker, container_id, &wait_error).await;
+            // The container has exited, so the follower's stream is ending; let it finish first
+            // so its output lands *before* the error explaining it rather than racing it.
+            if let Some(follower) = log_follower {
+                drain_log_follower(follower).await;
+            }
+            let detail = premature_exit_detail(docker, container_id, &wait_error, background).await;
             return ContainerExitedPrematurelySnafu {
                 container_id,
                 exit_status,
@@ -529,6 +548,73 @@ fn short_id(container_id: &str) -> &str {
     &container_id[..container_id.len().min(12)]
 }
 
+/// Streams the container's stdout and stderr onto the CLI's own stdout and stderr for as long as
+/// the container runs, so a containerized launcher is as observable as a native one — which gets
+/// this for free from [`Stdio::inherit`](std::process::Stdio::inherit).
+///
+/// The follow request replays from the start of the container's log, so nothing written between
+/// `start_container` and this call is lost. The task ends on its own when the container stops and
+/// the stream closes; on the premature-exit path it is drained first by [`drain_log_follower`].
+fn follow_container_logs(docker: &Docker, container_id: &str) -> JoinHandle<()> {
+    let docker = docker.clone();
+    let container_id = container_id.to_string();
+    tokio::spawn(async move {
+        let mut logs = std::pin::pin!(docker.logs(
+            &container_id,
+            Some(LogsOptions {
+                follow: true,
+                stdout: true,
+                stderr: true,
+                ..<_>::default()
+            }),
+        ));
+        let mut stdout = tokio::io::stdout();
+        let mut stderr = tokio::io::stderr();
+        while let Some(chunk) = logs.next().await {
+            let written = match chunk {
+                Ok(LogOutput::StdErr { message }) => stderr.write_all(&message).await,
+                // `Console` only appears for tty containers, which we never create; route it to
+                // stdout rather than dropping it in case an image is run that way.
+                Ok(LogOutput::StdOut { message }) | Ok(LogOutput::Console { message }) => {
+                    stdout.write_all(&message).await
+                }
+                Ok(LogOutput::StdIn { .. }) => Ok(()),
+                Err(source) => {
+                    debug!("stopped following logs of container {container_id}: {source}");
+                    break;
+                }
+            };
+            // Losing the stream is not worth failing a running network over: the launcher itself
+            // is unaffected, so report once and stop mirroring.
+            if let Err(source) = written {
+                debug!("failed to write output of container {container_id}: {source}");
+                break;
+            }
+        }
+        // Both handles are unbuffered wrappers, but flush so a final partial line can't be left
+        // sitting behind whatever the CLI prints next.
+        let _ = stdout.flush().await;
+        let _ = stderr.flush().await;
+    })
+}
+
+/// How long to wait for the log follower to drain after the container has exited. Generous enough
+/// for the daemon to close a stream it has already finished, short enough that a wedged stream
+/// delays the error instead of hanging `network start`.
+const LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Waits for [`follow_container_logs`] to finish so its output is on the terminal before the
+/// premature-exit error is rendered. Bounded, and deliberately ignores both outcomes: the error
+/// is reported either way, at worst without the container's last few lines.
+async fn drain_log_follower(follower: JoinHandle<()>) {
+    if tokio::time::timeout(LOG_DRAIN_TIMEOUT, follower)
+        .await
+        .is_err()
+    {
+        debug!("timed out draining container log output");
+    }
+}
+
 /// Builds the trailing detail appended to [`DockerLauncherError::ContainerExitedPrematurely`].
 ///
 /// The native launcher's stderr is either inherited or redirected to a local file, so its
@@ -542,10 +628,21 @@ fn short_id(container_id: &str) -> &str {
 ///
 /// `wait_error` is the daemon's own wait-level message, which is normally empty but is the only
 /// explanation available when the container itself printed nothing.
-async fn premature_exit_detail(docker: &Docker, container_id: &str, wait_error: &str) -> String {
+async fn premature_exit_detail(
+    docker: &Docker,
+    container_id: &str,
+    wait_error: &str,
+    background: bool,
+) -> String {
     let mut detail = String::new();
     if !wait_error.is_empty() {
         detail.push_str(&format!("\nDocker reported: {wait_error}"));
+    }
+    if !background {
+        // Foreground streamed the container's output live and the follower has been drained, so
+        // the cause is already on the terminal — appending the tail would only repeat it. This is
+        // the same split the native path makes for its inherited stderr.
+        return detail;
     }
     let mut logs = std::pin::pin!(docker.logs(
         container_id,

--- a/crates/icp/src/network/managed/docker.rs
+++ b/crates/icp/src/network/managed/docker.rs
@@ -27,7 +27,9 @@ use crate::network::{
 };
 use crate::prelude::*;
 
-use super::launcher::{MAX_OUTPUT_TAIL_LINES, output_tail, wait_for_launcher_status};
+use super::launcher::{
+    MAX_OUTPUT_TAIL_BYTES, MAX_OUTPUT_TAIL_LINES, output_tail, tail_bytes, wait_for_launcher_status,
+};
 
 /// Error converting a path for WSL2.
 #[derive(Debug, Snafu)]
@@ -603,16 +605,28 @@ fn follow_container_logs(docker: &Docker, container_id: &str) -> JoinHandle<()> 
 /// delays the error instead of hanging `network start`.
 const LOG_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Ceiling on the buffer held while reading the container's log for a premature-exit error. Twice
+/// the final byte cap, so the line-based trim in [`output_tail`] still has its full budget to
+/// choose from after the incremental trimming.
+const MAX_LOG_BUFFER_BYTES: usize = 2 * MAX_OUTPUT_TAIL_BYTES;
+
 /// Waits for [`follow_container_logs`] to finish so its output is on the terminal before the
-/// premature-exit error is rendered. Bounded, and deliberately ignores both outcomes: the error
-/// is reported either way, at worst without the container's last few lines.
-async fn drain_log_follower(follower: JoinHandle<()>) {
-    if tokio::time::timeout(LOG_DRAIN_TIMEOUT, follower)
+/// premature-exit error is rendered. Bounded, and deliberately ignores the task's own outcome: the
+/// error is reported either way, at worst without the container's last few lines.
+async fn drain_log_follower(mut follower: JoinHandle<()>) {
+    if tokio::time::timeout(LOG_DRAIN_TIMEOUT, &mut follower)
         .await
-        .is_err()
+        .is_ok()
     {
-        debug!("timed out draining container log output");
+        return;
     }
+    debug!("timed out draining container log output");
+    // Dropping a `JoinHandle` detaches the task rather than cancelling it, so returning here
+    // would leave the follower free to write *after* the error — the interleaving this drain
+    // exists to prevent. Abort it, then wait for it to actually stop, under the same bound again
+    // so a wedged write degrades to a late error rather than a hung `network start`.
+    follower.abort();
+    let _ = tokio::time::timeout(LOG_DRAIN_TIMEOUT, follower).await;
 }
 
 /// Builds the trailing detail appended to [`DockerLauncherError::ContainerExitedPrematurely`].
@@ -660,6 +674,14 @@ async fn premature_exit_detail(
             // The stream error is deliberately ignored: this is already an error path, and
             // whatever arrived before it is still worth showing.
             Err(_) => break,
+        }
+        // Docker's `tail` caps the number of lines, not their length, so a container emitting a
+        // few enormous lines would otherwise be held whole in memory just to have nearly all of
+        // it discarded below. Trim as we go instead. This is a raw byte cut, not `output_tail`:
+        // that one trims trailing whitespace, which mid-stream would glue the next chunk onto
+        // the end of the current line.
+        if output.len() > MAX_LOG_BUFFER_BYTES {
+            output = tail_bytes(&output, MAX_LOG_BUFFER_BYTES).to_string();
         }
     }
     // The full id is already on the error's first line, so the hint uses the short form.

--- a/crates/icp/src/network/managed/launcher.rs
+++ b/crates/icp/src/network/managed/launcher.rs
@@ -165,7 +165,7 @@ pub async fn spawn_network_launcher(
 ///
 /// Shared with the Docker path, which applies the same bounds to the container log tail.
 pub(super) const MAX_OUTPUT_TAIL_LINES: usize = 50;
-const MAX_OUTPUT_TAIL_BYTES: usize = 8 * 1024;
+pub(super) const MAX_OUTPUT_TAIL_BYTES: usize = 8 * 1024;
 
 /// Builds the trailing detail appended to [`SpawnNetworkLauncherError::LauncherExitedPrematurely`].
 ///
@@ -199,14 +199,24 @@ pub(super) fn output_tail(contents: &str) -> String {
     let start = lines.len().saturating_sub(MAX_OUTPUT_TAIL_LINES);
     let by_lines = lines[start..].join("\n");
     let by_lines = by_lines.trim();
-    if by_lines.len() <= MAX_OUTPUT_TAIL_BYTES {
-        return by_lines.to_string();
+    tail_bytes(by_lines, MAX_OUTPUT_TAIL_BYTES)
+        .trim_start()
+        .to_string()
+}
+
+/// Returns at most the trailing `max_bytes` of `contents`, cutting on a char boundary.
+///
+/// Split out of [`output_tail`] so a caller streaming output in can hold a bounded buffer
+/// without duplicating the boundary handling.
+pub(super) fn tail_bytes(contents: &str, max_bytes: usize) -> &str {
+    if contents.len() <= max_bytes {
+        return contents;
     }
-    let mut cut = by_lines.len() - MAX_OUTPUT_TAIL_BYTES;
-    while !by_lines.is_char_boundary(cut) {
+    let mut cut = contents.len() - max_bytes;
+    while !contents.is_char_boundary(cut) {
         cut += 1;
     }
-    by_lines[cut..].trim_start().to_string()
+    &contents[cut..]
 }
 
 pub async fn stop_launcher(pid: Pid) {
@@ -467,6 +477,21 @@ mod tests {
         let tail = output_tail(&input);
         assert!(tail.len() <= MAX_OUTPUT_TAIL_BYTES);
         assert!(!tail.is_empty());
+    }
+
+    #[test]
+    fn tail_bytes_returns_everything_within_the_limit() {
+        assert_eq!(tail_bytes("line one\nline two", 1024), "line one\nline two");
+    }
+
+    #[test]
+    fn tail_bytes_cuts_on_a_char_boundary() {
+        // Each 'é' is two bytes, so cutting at a raw byte offset can land mid-character — which
+        // would panic when slicing rather than merely truncate.
+        let input = "é".repeat(8);
+        let tail = tail_bytes(&input, 5);
+        assert!(tail.len() <= 5, "{}", tail.len());
+        assert!(tail.chars().all(|c| c == 'é'), "{tail}");
     }
 
     #[test]

--- a/crates/icp/src/network/managed/launcher.rs
+++ b/crates/icp/src/network/managed/launcher.rs
@@ -208,7 +208,7 @@ pub(super) fn output_tail(contents: &str) -> String {
 ///
 /// Split out of [`output_tail`] so a caller streaming output in can hold a bounded buffer
 /// without duplicating the boundary handling.
-pub(super) fn tail_bytes(contents: &str, max_bytes: usize) -> &str {
+fn tail_bytes(contents: &str, max_bytes: usize) -> &str {
     if contents.len() <= max_bytes {
         return contents;
     }

--- a/crates/icp/src/network/managed/launcher.rs
+++ b/crates/icp/src/network/managed/launcher.rs
@@ -160,10 +160,12 @@ pub async fn spawn_network_launcher(
     ))
 }
 
-/// Upper bounds on how much captured stderr to fold into the premature-exit error, so a
+/// Upper bounds on how much captured output to fold into a premature-exit error, so a
 /// verbose launcher log (e.g. `--debug` with `-d`) can't produce a wall-of-text error.
-const MAX_STDERR_TAIL_LINES: usize = 50;
-const MAX_STDERR_TAIL_BYTES: usize = 8 * 1024;
+///
+/// Shared with the Docker path, which applies the same bounds to the container log tail.
+pub(super) const MAX_OUTPUT_TAIL_LINES: usize = 50;
+const MAX_OUTPUT_TAIL_BYTES: usize = 8 * 1024;
 
 /// Builds the trailing detail appended to [`SpawnNetworkLauncherError::LauncherExitedPrematurely`].
 ///
@@ -177,7 +179,7 @@ fn premature_exit_detail(background: bool, stderr_file: &Path) -> String {
     }
     match crate::fs::read_to_string(stderr_file) {
         Ok(contents) => {
-            let tail = stderr_tail(&contents);
+            let tail = output_tail(&contents);
             if tail.is_empty() {
                 format!("\nSee the launcher log at {stderr_file} for details.")
             } else {
@@ -190,17 +192,17 @@ fn premature_exit_detail(background: bool, stderr_file: &Path) -> String {
     }
 }
 
-/// Returns the trailing portion of `contents`, capped to the last [`MAX_STDERR_TAIL_LINES`]
-/// lines and then to [`MAX_STDERR_TAIL_BYTES`] (cutting on a char boundary), trimmed.
-fn stderr_tail(contents: &str) -> String {
+/// Returns the trailing portion of `contents`, capped to the last [`MAX_OUTPUT_TAIL_LINES`]
+/// lines and then to [`MAX_OUTPUT_TAIL_BYTES`] (cutting on a char boundary), trimmed.
+pub(super) fn output_tail(contents: &str) -> String {
     let lines: Vec<&str> = contents.lines().collect();
-    let start = lines.len().saturating_sub(MAX_STDERR_TAIL_LINES);
+    let start = lines.len().saturating_sub(MAX_OUTPUT_TAIL_LINES);
     let by_lines = lines[start..].join("\n");
     let by_lines = by_lines.trim();
-    if by_lines.len() <= MAX_STDERR_TAIL_BYTES {
+    if by_lines.len() <= MAX_OUTPUT_TAIL_BYTES {
         return by_lines.to_string();
     }
-    let mut cut = by_lines.len() - MAX_STDERR_TAIL_BYTES;
+    let mut cut = by_lines.len() - MAX_OUTPUT_TAIL_BYTES;
     while !by_lines.is_char_boundary(cut) {
         cut += 1;
     }
@@ -437,33 +439,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stderr_tail_keeps_short_content_verbatim() {
-        assert_eq!(stderr_tail("line one\nline two"), "line one\nline two");
+    fn output_tail_keeps_short_content_verbatim() {
+        assert_eq!(output_tail("line one\nline two"), "line one\nline two");
     }
 
     #[test]
-    fn stderr_tail_trims_surrounding_whitespace() {
-        assert_eq!(stderr_tail("\n\n  boom  \n\n"), "boom");
+    fn output_tail_trims_surrounding_whitespace() {
+        assert_eq!(output_tail("\n\n  boom  \n\n"), "boom");
     }
 
     #[test]
-    fn stderr_tail_keeps_only_last_lines() {
+    fn output_tail_keeps_only_last_lines() {
         let input = (0..200)
             .map(|i| i.to_string())
             .collect::<Vec<_>>()
             .join("\n");
-        let tail = stderr_tail(&input);
+        let tail = output_tail(&input);
         let lines: Vec<&str> = tail.lines().collect();
-        assert_eq!(lines.len(), MAX_STDERR_TAIL_LINES);
+        assert_eq!(lines.len(), MAX_OUTPUT_TAIL_LINES);
         assert_eq!(*lines.first().unwrap(), "150");
         assert_eq!(*lines.last().unwrap(), "199");
     }
 
     #[test]
-    fn stderr_tail_caps_bytes_on_a_single_long_line() {
-        let input = "x".repeat(MAX_STDERR_TAIL_BYTES * 2);
-        let tail = stderr_tail(&input);
-        assert!(tail.len() <= MAX_STDERR_TAIL_BYTES);
+    fn output_tail_caps_bytes_on_a_single_long_line() {
+        let input = "x".repeat(MAX_OUTPUT_TAIL_BYTES * 2);
+        let tail = output_tail(&input);
+        assert!(tail.len() <= MAX_OUTPUT_TAIL_BYTES);
         assert!(!tail.is_empty());
     }
 

--- a/crates/icp/src/network/managed/run.rs
+++ b/crates/icp/src/network/managed/run.rs
@@ -182,7 +182,7 @@ async fn run_network_launcher(
             match launch_mode {
                 LaunchMode::Image(options) => {
                     let (guard, instance, locator, fixed) =
-                        spawn_docker_launcher(&options, status_dir.path()).await?;
+                        spawn_docker_launcher(&options, status_dir.path(), background).await?;
                     let gateway = NetworkDescriptorGatewayPort {
                         port: instance.gateway_port,
                         fixed,

--- a/crates/icp/src/network/managed/run.rs
+++ b/crates/icp/src/network/managed/run.rs
@@ -140,7 +140,7 @@ async fn run_network_launcher(
             (LaunchMode::Image(options), fixed_ports)
         }
         ManagedMode::Launcher(launcher_config) if autocontainerize => {
-            let options = transform_native_launcher_to_container(launcher_config);
+            let options = transform_native_launcher_to_container(launcher_config, verbose);
             let fixed_ports = options.fixed_host_ports();
             (LaunchMode::Image(options), fixed_ports)
         }
@@ -314,7 +314,10 @@ async fn run_network_launcher(
     Ok(())
 }
 
-fn transform_native_launcher_to_container(config: &ManagedLauncherConfig) -> ManagedImageOptions {
+fn transform_native_launcher_to_container(
+    config: &ManagedLauncherConfig,
+    verbose: bool,
+) -> ManagedImageOptions {
     use bollard::models::PortBinding;
     use std::collections::HashMap;
 
@@ -324,7 +327,14 @@ fn transform_native_launcher_to_container(config: &ManagedLauncherConfig) -> Man
         Port::Fixed(port) => port,
         Port::Random => 0,
     };
-    let args = launcher_settings_flags(config);
+    let mut args = launcher_settings_flags(config);
+    // `launcher_settings_flags` covers only the manifest-derived settings; the native path adds
+    // `--verbose` separately from the CLI's own debug flag, so an autocontainerized launcher would
+    // otherwise stay quiet under `-d`. Only done here, not for an explicit `image:` network, whose
+    // `args` are the user's to compose (and whose image need not understand the flag at all).
+    if verbose {
+        args.push("--verbose".to_string());
+    }
     let args = translate_launcher_args_for_docker(args);
 
     let all_addrs: Vec<String> = config
@@ -828,7 +838,7 @@ mod tests {
             dogecoind_addr: None,
             version: None,
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         assert_eq!(
             opts.image,
             "ghcr.io/dfinity/icp-cli-network-launcher:latest"
@@ -844,6 +854,34 @@ mod tests {
             .as_ref()
             .unwrap();
         assert_eq!(binding[0].host_port.as_deref(), Some("8000"));
+    }
+
+    /// The native path adds `--verbose` from the CLI's debug flag rather than from the manifest,
+    /// so `launcher_settings_flags` alone would leave an autocontainerized launcher quiet under
+    /// `-d`. `transform_native_launcher_default_config` covers the off case by asserting the
+    /// full argument list.
+    #[test]
+    fn transform_native_launcher_passes_verbose_through() {
+        let config = ManagedLauncherConfig {
+            gateway: Gateway {
+                bind: "127.0.0.1".to_string(),
+                port: Port::Fixed(8000),
+                domains: vec!["localhost".to_string()],
+            },
+            artificial_delay_ms: None,
+            ii: false,
+            nns: false,
+            subnets: None,
+            bitcoind_addr: None,
+            dogecoind_addr: None,
+            version: None,
+        };
+        let opts = transform_native_launcher_to_container(&config, true);
+        assert!(
+            opts.args.iter().any(|a| a == "--verbose"),
+            "{:?}",
+            opts.args
+        );
     }
 
     #[test]
@@ -862,7 +900,7 @@ mod tests {
             dogecoind_addr: None,
             version: Some("v12.0.0-2026-04-16-04-20".to_string()),
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         assert_eq!(
             opts.image,
             "ghcr.io/dfinity/icp-cli-network-launcher:12.0.0-2026-04-16-04-20"
@@ -885,7 +923,7 @@ mod tests {
             dogecoind_addr: None,
             version: None,
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         let binding = opts
             .port_bindings
             .get("4943/tcp")
@@ -907,7 +945,7 @@ mod tests {
             dogecoind_addr: None,
             version: None,
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         assert!(opts.args.contains(&"--ii".to_string()));
         assert!(
             opts.args
@@ -931,7 +969,7 @@ mod tests {
             dogecoind_addr: Some(vec!["localhost:22556".to_string()]),
             version: None,
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         assert!(opts.args.contains(&"--nns".to_string()));
         assert!(opts.args.contains(&"--artificial-delay-ms=50".to_string()));
         assert!(
@@ -956,7 +994,7 @@ mod tests {
             dogecoind_addr: None,
             version: None,
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         assert!(
             opts.args
                 .contains(&"--bitcoind-addr=192.168.1.5:18444".to_string())
@@ -976,7 +1014,7 @@ mod tests {
             dogecoind_addr: None,
             version: None,
         };
-        let opts = transform_native_launcher_to_container(&config);
+        let opts = transform_native_launcher_to_container(&config, false);
         assert!(
             opts.args
                 .contains(&"--bitcoind-addr=host.docker.internal:18444".to_string())

--- a/docs/guides/containerized-networks.md
+++ b/docs/guides/containerized-networks.md
@@ -331,6 +331,21 @@ docker ps -a | grep icp-cli-network-launcher
 docker logs <container-id>
 ```
 
+### Viewing network output
+
+In the foreground, the container's output is streamed to your terminal as it runs, the same as a non-containerized network:
+
+```bash
+icp network start my-network
+```
+
+In background mode the output stays with the Docker daemon, since icp-cli exits while the container keeps running. `icp network start` prints the command to follow it:
+
+```
+For background mode, network output is captured by Docker:
+  view with: docker logs -f 63ded6aedbbd
+```
+
 ### "Network unreachable after start"
 
 **Problem**: `icp network start` succeeds but cannot connect.

--- a/docs/guides/containerized-networks.md
+++ b/docs/guides/containerized-networks.md
@@ -312,7 +312,7 @@ sudo systemctl start docker  # Linux
 
 ```
 Error: docker container 63ded6aedbbd... exited prematurely with status 101
-Container output (from `docker logs 63ded6aedbbd`):
+Container output:
 gateway bind failed: Address already in use (os error 98)
 ```
 
@@ -321,7 +321,7 @@ Common issues:
 - Port conflict inside container (check `port-mapping`)
 - Insufficient resources (increase Docker memory/CPU limits)
 
-If the container was removed before you could inspect it (`rm-on-exit: true`), re-run with that setting off and read the full log directly:
+The attached output is the tail of the log, capped so a chatty image can't bury the error. To read all of it, note that a failed container is deleted straight away when `rm-on-exit: true` is set (which is also the case for [autocontainerized](#always-use-containers) networks) — re-run with it off, then inspect the container directly:
 
 ```bash
 # Find container ID

--- a/docs/guides/containerized-networks.md
+++ b/docs/guides/containerized-networks.md
@@ -308,7 +308,21 @@ sudo systemctl start docker  # Linux
 
 **Problem**: Container exits immediately or fails to start.
 
-**Solution**: Check container logs:
+**Solution**: `icp network start` reports the cause itself — the container's output is attached to the error:
+
+```
+Error: docker container 63ded6aedbbd... exited prematurely with status 101
+Container output (from `docker logs 63ded6aedbbd`):
+gateway bind failed: Address already in use (os error 98)
+```
+
+Common issues:
+- Image pull failed (check internet connection)
+- Port conflict inside container (check `port-mapping`)
+- Insufficient resources (increase Docker memory/CPU limits)
+
+If the container was removed before you could inspect it (`rm-on-exit: true`), re-run with that setting off and read the full log directly:
+
 ```bash
 # Find container ID
 docker ps -a | grep icp-cli-network-launcher
@@ -316,11 +330,6 @@ docker ps -a | grep icp-cli-network-launcher
 # View logs
 docker logs <container-id>
 ```
-
-Common issues:
-- Image pull failed (check internet connection)
-- Port conflict inside container (check `port-mapping`)
-- Insufficient resources (increase Docker memory/CPU limits)
 
 ### "Network unreachable after start"
 


### PR DESCRIPTION
## Why

Docker-based networks never showed the launcher's output. Nothing ever attached to the container's stdio, so on a normal start you saw nothing, and on a failed start you got only:

```
Error: failed to watch docker container <id> for exit
Caused by:
    Docker container wait error:
```

On Windows, where the launcher always runs in a container, that meant `icp network start` was silent. #675/#676 fixed this class of bug for the native launcher; this does the same for the container path.

Two root causes on the error path: bollard's `wait_container` turns any nonzero exit into `DockerContainerWaitError` rather than an `Ok` response, so `ContainerExitedPrematurely` was unreachable for exactly the failures that matter — and even when reached, it carried no output, because the daemon owns the container's stdio and there is no local `stderr.log` to read back.

## How

- **Premature exit** — both `wait_container` shapes funnel into `ContainerExitedPrematurely`; the cause is fetched over bollard's `logs()`, bounded by the same 50-line/8&nbsp;KB caps as the native path (`stderr_tail` → shared `output_tail`).
- **Foreground** — a task follows the container and demuxes stdout/stderr onto ours, the equivalent of the native path's `Stdio::inherit()`. `premature_exit_detail` returns early in foreground so the cause isn't printed twice, mirroring the native split; the follower is drained first (2&nbsp;s bound) so its output can't be outrun by the error explaining it.
- **Background** — can't work the same way: a native child keeps filling its log files after the CLI exits because its fds point at them, whereas here nothing is left to pump the daemon-owned stdio. Since the daemon already persists it, `network start -d` prints `docker logs -f <id>` — the counterpart of the native "stderr: `<path>`" message.
- **`--verbose`** — the native path adds it from the CLI's debug flag rather than from `launcher_settings_flags`, so an autocontainerized launcher stayed quiet under `-d`.

Fixes #677. Also closes out #597, whose remaining scope was this path.

## Tests

Two `#[tag(docker)]` tests using a manifest whose container prints a marker to stderr and exits 3. The real launcher can't be made to fail from outside the container (it tolerates unknown arguments, and its ports live in the container's namespace), and what's under test is the log plumbing, not the launcher. The foreground test asserts the `Container output` header is **absent** — that pins the marker as arriving over the live stream, and that the two paths don't both fire.

Successful-start streaming was verified by hand, not in CI; asserting on a healthy foreground network means matching launcher wording, which #676 deliberately avoided.

## Note

Streaming immediately surfaced a launcher bug — every containerized shutdown now ends with `failed to remove status directory / Device or resource busy`, because the launcher tries to `rmdir` its bind-mounted status dir. Pre-existing and previously invisible; icp-cli still exits 0. Filed as dfinity/icp-cli-network-launcher#78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
