### PR TITLE
fix(docs): emit absolute internal links and fix llms.txt encoding

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -7,16 +7,20 @@ import mermaid from 'astro-mermaid';
 
 const SITE = (process.env.PUBLIC_SITE || 'https://cli.internetcomputer.org').replace(/\/$/, '');
 
+// For versioned deployments: /0.1/, /0.2/, etc.
+// PUBLIC_BASE_PATH is set per-version in CI (e.g., /0.2/, /main/).
+// Single source of truth: used both as Astro's `base` and by rehypeRewriteLinks
+// so in-content links always carry the same version prefix as the deployment.
+const BASE_PATH = process.env.PUBLIC_BASE_PATH || '/';
+
 // https://astro.build/config
 export default defineConfig({
   site: SITE,
-  // For versioned deployments: /0.1/, /0.2/, etc.
-  // PUBLIC_BASE_PATH is set per-version in CI (e.g., /0.2/, /main/)
-  base: process.env.PUBLIC_BASE_PATH || '/',
+  base: BASE_PATH,
   markdown: {
     rehypePlugins: [
-      // Rewrite relative .md links for Astro's directory-based output
-      rehypeRewriteLinks,
+      // Rewrite relative .md links to absolute, base-prefixed URLs
+      [rehypeRewriteLinks, { base: BASE_PATH }],
       // Open external links in new tab
       [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
     ],

--- a/docs-site/plugins/astro-agent-docs.mjs
+++ b/docs-site/plugins/astro-agent-docs.mjs
@@ -377,8 +377,11 @@ export default function agentDocs() {
         }
 
         // 2. Generate llms.txt
+        // Prepend a UTF-8 BOM (as with the .md endpoints): llms.txt is served as
+        // text/plain without a charset, so without the BOM clients fall back to a
+        // legacy 8-bit encoding and mangle multibyte characters (e.g. — → â€").
         const llmsTxt = generateLlmsTxt(pages, siteUrl, basePath, cliSubPages);
-        fs.writeFileSync(path.join(outDir, "llms.txt"), llmsTxt);
+        fs.writeFileSync(path.join(outDir, "llms.txt"), BOM + llmsTxt);
         logger.info(
           `Generated llms.txt (${llmsTxt.length} chars, ${pages.length} pages)`
         );
@@ -389,7 +392,8 @@ export default function agentDocs() {
           const mdContent = fs.readFileSync(path.join(outDir, page.file), "utf-8").replace(/^\uFEFF/, "");
           fullParts.push("\n---\n", mdContent);
         }
-        fs.writeFileSync(path.join(outDir, "llms-full.txt"), fullParts.join("\n"));
+        // BOM for the same reason as llms.txt above (text/plain, no charset).
+        fs.writeFileSync(path.join(outDir, "llms-full.txt"), BOM + fullParts.join("\n"));
         logger.info(`Generated llms-full.txt (${pages.length} pages)`);
 
         // 4. Generate RSS feed

--- a/docs-site/plugins/rehype-rewrite-links.mjs
+++ b/docs-site/plugins/rehype-rewrite-links.mjs
@@ -1,45 +1,78 @@
 /**
- * Rehype plugin that rewrites relative .md links for Astro's directory-based output.
+ * Rehype plugin that rewrites relative .md/.mdx links to absolute, base-path-prefixed URLs.
  *
  * Authors write GitHub-friendly relative links with .md extensions:
  *   [Quickstart](quickstart.md)
  *   [Concepts](../concepts/canisters.md#lifecycle)
  *
- * Astro outputs each page as a directory (project-structure.md → project-structure/index.html),
- * so the browser resolves relative links one level deeper than the author expects.
- * This plugin strips .md extensions and prepends an extra ../ to compensate.
+ * Astro outputs each page as a directory (project-structure.md → project-structure/index.html).
+ * A relative link only resolves correctly when the page's URL carries a trailing slash (so the
+ * browser's base is the page's own directory). GitHub Pages used to enforce that by redirecting
+ * /x/foo → /x/foo/. Since hosting moved to the IC asset canister (#439) there is no such
+ * redirect: it serves both /x/foo and /x/foo/ with HTTP 200. A visitor landing on the
+ * no-trailing-slash URL (shared links, external links, typed URLs) then resolves relative links
+ * one directory too high, dropping the version segment (e.g. /1.2/) and 404ing.
  *
- * Exception: index.md files are output as <dir>/index.html (not <dir>/<dir>/index.html),
- * so the browser's base URL is already at the correct directory level — no extra ../
- * is needed for those pages.
+ * To be immune to that trailing-slash ambiguity, we resolve each link against the SOURCE file's
+ * location in the docs tree and emit an absolute URL that includes the deployment base path
+ * (e.g. /1.2/). Absolute URLs resolve identically regardless of the current page's trailing
+ * slash, and this matches how Starlight's own sidebar/nav links already work.
  *
- * Result (regular pages):
- *   quickstart.md                              → ../quickstart/
- *   ../concepts/canisters.md#lifecycle         → ../../concepts/canisters/#lifecycle
- *   ./sibling.md                               → ../sibling/
+ * The base path is passed in from astro.config.mjs (the single source of truth, set per-version
+ * in CI via PUBLIC_BASE_PATH — e.g. /1.2/, /main/); it defaults to / for local/root builds. This
+ * is what makes the fix release-proof: the link prefix always tracks the deployment base, so
+ * every future versioned build gets correct links with no code change.
  *
- * Result (index pages):
- *   backends/data-persistence.md               → backends/data-persistence/
- *   ../concepts/canisters.md                   → ../concepts/canisters/
+ * Result (base = /1.2/, page = migration/from-dfx.md):
+ *   ../tutorial.md                      → /1.2/tutorial/
+ *   ../concepts/index.md                → /1.2/concepts/
+ *   ../reference/configuration.md       → /1.2/reference/configuration/
+ *   ../concepts/canisters.md#lifecycle  → /1.2/concepts/canisters/#lifecycle
  *
- * Only relative links are affected — external URLs, anchors, and absolute paths are untouched.
+ * Only relative links are affected — external URLs, anchors, and already-absolute paths are
+ * untouched. A link that would escape the docs root is left as-is.
+ *
+ * This plugin replaced a fragile sed-based preprocessing step; see #423 for that history.
  *
  * Important: Astro caches rendered content in node_modules/.astro/data-store.json.
  * After changing this plugin, delete that file to force re-rendering.
  *
  * Note: This is a rehype (HTML-level) plugin, not a remark plugin. Starlight overrides
- * Astro's markdown.remarkPlugins, but rehypePlugins are correctly merged. See:
- * https://github.com/dfinity/icp-cli/issues/423
+ * Astro's markdown.remarkPlugins, but rehypePlugins are correctly merged. See #423.
  */
 import { visit } from "unist-util-visit";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-export default function rehypeRewriteLinks() {
+// Docs source lives at ../../docs relative to this plugin (docs-site/plugins/),
+// mirroring astro-agent-docs.mjs. Used to locate each page within the docs tree.
+const DOCS_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../docs",
+);
+
+/** Normalize a base path to always start and end with a single slash. */
+function normalizeBase(base) {
+  let b = base || "/";
+  if (!b.startsWith("/")) b = "/" + b;
+  if (!b.endsWith("/")) b += "/";
+  return b;
+}
+
+/**
+ * @param {{ base?: string }} [options] - `base` is the deployment base path
+ *   (e.g. "/1.2/"), passed from astro.config.mjs so it always matches Astro's own `base`.
+ */
+export default function rehypeRewriteLinks(options = {}) {
+  const basePath = normalizeBase(options.base);
+
   return (tree, file) => {
-    // Detect whether this file is an index page (e.g. guides/index.md).
-    // Index pages are output as <dir>/index.html, so the browser's base URL
-    // is already at the directory level — no extra ../ compensation needed.
     const filePath = file?.path || file?.history?.[0] || "";
-    const isIndexPage = /(?:^|[\\/])index\.(?:md|mdx)$/.test(filePath);
+    // Directory of the current page relative to the docs root, using forward
+    // slashes so link math is identical across platforms. "" for top-level pages.
+    const pageDir = filePath
+      ? path.relative(DOCS_ROOT, path.dirname(filePath)).split(path.sep).join("/")
+      : "";
 
     visit(tree, "element", (node) => {
       if (node.tagName !== "a") return;
@@ -53,45 +86,37 @@ export default function rehypeRewriteLinks() {
       // Skip anchor-only links
       if (href.startsWith("#")) return;
 
-      // Skip absolute paths
+      // Skip already-absolute paths
       if (href.startsWith("/")) return;
 
-      // Only process links that have .md extension (our internal doc links)
-      if (!href.includes(".md")) return;
+      // Split off anchor/query suffix (everything from the first # or ?).
+      const suffixIdx = href.search(/[#?]/);
+      const linkPath = suffixIdx === -1 ? href : href.slice(0, suffixIdx);
+      const suffix = suffixIdx === -1 ? "" : href.slice(suffixIdx);
 
-      let url = href;
+      // Only rewrite links that target an internal doc file (.md or .mdx).
+      if (!/\.mdx?$/.test(linkPath)) return;
 
-      // Strip .md extension, preserving anchors and query strings
-      url = url.replace(/\.md(#|$|\?)/, "$1");
+      // Resolve the author's relative link against the page's directory in the
+      // docs tree, yielding a path relative to the docs root.
+      const targetDoc = path.posix.normalize(path.posix.join(pageDir, linkPath));
 
-      // Rewrite index links to directory root (index → ./, foo/index → foo/)
-      url = url.replace(/(^|\/)index(#|$|\?)/, "$1$2");
+      // A link that climbs above the docs root can't be made absolute safely —
+      // leave it untouched rather than emit a bogus URL.
+      if (targetDoc.startsWith("..")) return;
 
-      // Split off anchor/query suffix
-      const splitMatch = url.match(/^([^#?]*)((?:#|\\?).*)?$/);
-      let path = splitMatch[1] || "";
-      const suffix = splitMatch[2] || "";
+      // Strip the .md/.mdx extension.
+      let out = targetDoc.replace(/\.mdx?$/, "");
 
-      // Add trailing slash if the path doesn't already end with one
-      if (path && !path.endsWith("/")) {
-        path += "/";
-      }
+      // index → directory root: "index" → "", "foo/index" → "foo/".
+      out = out.replace(/(^|\/)index$/, "$1");
 
-      // Strip leading ./ if present (normalize before prepending ../)
-      if (path.startsWith("./")) {
-        path = path.slice(2);
-      }
+      // Directory URLs get a trailing slash (skip the empty root case).
+      if (out && !out.endsWith("/")) out += "/";
 
-      // Prepend ../ to compensate for Astro's directory-based output.
-      // Regular pages (e.g. project-structure.md → project-structure/index.html)
-      // need the extra ../ because the browser base is one level deeper than
-      // the author expects. Index pages don't need this — they're already at
-      // the correct directory level.
-      if (!isIndexPage) {
-        path = "../" + path;
-      }
-
-      node.properties.href = path + suffix;
+      // Prefix the deployment base path (e.g. /1.2/) so the version segment can
+      // never be dropped by trailing-slash-sensitive relative resolution.
+      node.properties.href = basePath + out + suffix;
     });
   };
 }


### PR DESCRIPTION
## Problem

Internal doc links in page content (e.g. the **Getting Help** section of `migration/from-dfx`) 404 when the page is visited **without a trailing slash** — exactly the URL people share and link to externally (`.../1.2/migration/from-dfx`).

Root cause: `rehype-rewrite-links` rewrote author relative links (`../tutorial.md`) into `../`-relative URLs that only resolve correctly when the page URL carries a trailing slash (Astro's directory output). GitHub Pages used to enforce that with a `no-slash → slash` redirect, but since hosting moved to the IC asset canister (#439) **both** `/x/foo` and `/x/foo/` return `200` with no redirect. On a no-slash URL the browser resolves against the parent directory, so the extra `../` climbs one level too far — right past the version segment:

```
page: /1.2/migration/from-dfx        (no trailing slash)
link: ../../tutorial/   →  /tutorial/            → 404   (the /1.2/ is dropped)
page: /1.2/migration/from-dfx/       (trailing slash)
link: ../../tutorial/   →  /1.2/tutorial/        → 200
```

This affected **every in-content relative link on every page**; it only "worked" when navigating via the sidebar, which always lands on trailing-slash URLs.

Two smaller issues surfaced while investigating:
- **`llms.txt` mojibake** (`—` rendered as `â€"`): served as `text/plain` with no `charset`, and unlike the `.md` endpoints it had no UTF-8 BOM, so clients fell back to a legacy encoding.
- **Root `llms.txt` still on v1.1** (operational, *not* in this PR): the `publish-root-files` job copies `llms.txt` from the latest version's folder, which didn't exist on `docs-deployment` when it last ran (the versioned-docs job had been cascade-skipped, #671/#674). It self-corrects on the next `Documentation` run on `main` — e.g. `gh workflow run docs.yml --ref main`.

## Fix

- **Absolute, base-prefixed links.** `rehype-rewrite-links` now resolves each link against the source file's location in the docs tree and emits an absolute URL that includes the deployment base (`/1.2/tutorial/`). Absolute URLs resolve identically regardless of trailing slash, matching how Starlight's own nav links already work.
- **Single source of truth / release-proof.** The base path is computed once in `astro.config.mjs` and passed to both Astro's `base` and the plugin, so in-content links always carry the same version prefix as the deployment — no per-release change. Also broadened to `.mdx` and guards links that would escape the docs root.
- **UTF-8 BOM** on `llms.txt` / `llms-full.txt`, mirroring the `.md` endpoints.

## Verification

Built with three base paths and confirmed links track the base with **zero** relative links remaining:

| Build (`PUBLIC_BASE_PATH`) | Example link | Relative links left |
|---|---|---|
| `/1.3/` (future release) | `/1.3/tutorial/` | 0 |
| `/main/` | `/main/tutorial/` | 0 |
| `/` (PR validation) | `/tutorial/` | 0 |

Anchors preserved (`../concepts/sync-plugins.md#the-sandbox` → `/1.2/concepts/sync-plugins/#the-sandbox`); `index.md` links collapse to the directory root; BOM (`ef bb bf`) present on both `.txt` files. A full scan of the docs found all 225 internal links resolve to existing files.