### PR TITLE
docs: state the CLI access prerequisite for `identity link web --app`

### DIFF
--- a/docs/guides/managing-identities.md
+++ b/docs/guides/managing-identities.md
@@ -150,7 +150,7 @@ The simplest form gives icp-cli its own account with the auth provider (id.ai us
 icp identity link web my-cli-identity
 ```
 
-This opens your browser at the auth provider's sign-in page. Once you complete sign-in, the browser hands the delegation back to icp-cli and the identity is stored locally under the chosen name.
+This prints the sign-in URL and waits for you to press Enter, then opens your browser at the auth provider's sign-in page. Once you complete sign-in, the browser hands the delegation back to icp-cli and the identity is stored locally under the chosen name.
 
 ### Signing In As a Specific App
 
@@ -170,7 +170,7 @@ icp identity link web nns-identity --app nns.ic0.app
 icp identity link web oisy-identity --app oisy.com
 ```
 
-Note that apps may use `alternativeOrigin` with II - the correct domain is `nns.ic0.app`, not `nns.internetcomputer.org`, which would give you a different principal.
+Some apps use II's `alternativeOrigin` mechanism, so the domain Internet Identity knows them by is not the one in your address bar — passing the wrong one links a different principal. `--app` needs the II origin. NNS is the common case: its II origin is `nns.ic0.app`, and icp-cli maps `nns.internetcomputer.org` onto it for you, so either spelling links the same identity.
 
 ### Using a Different Auth Provider
 

--- a/docs/guides/managing-identities.md
+++ b/docs/guides/managing-identities.md
@@ -144,7 +144,23 @@ icp identity import my-identity --read-seed-phrase
 
 Sign in to a web-based authentication service and link the resulting identity into icp-cli. **Internet Identity** is one example; the icp-cli default points at [id.ai](https://id.ai), but any service that publishes a `/.well-known/cli-auth-config` for the icp-cli web-auth protocol works the same way.
 
-With Internet Identity, every app sees a *different* principal for the same user. Linking a web-based identity means picking which app you want to sign in *as*. Pass that app's domain with `--app`:
+The simplest form gives icp-cli its own account with the auth provider (id.ai uses `cli.id.ai`), and works without any further setup:
+
+```bash
+icp identity link web my-cli-identity
+```
+
+This opens your browser at the auth provider's sign-in page. Once you complete sign-in, the browser hands the delegation back to icp-cli and the identity is stored locally under the chosen name.
+
+### Signing In As a Specific App
+
+With Internet Identity, every app sees a *different* principal for the same user. To get the same principal an app sees in its own UI — your NNS neurons, your OISY wallet — pass that app's domain with `--app`.
+
+This requires one prerequisite: **you must enable CLI access for your Internet Identity first.** Internet Identity will not hand a command-line tool a delegation for another app's domain unless you have. Until you do, the sign-in page shows *"CLI access not enabled"* and the command never receives an identity.
+
+To enable it, sign in at [id.ai](https://id.ai) (Internet Identity), open your identity settings, and turn on **CLI access**. The setting is stored per browser and per identity, so enable it again on any other device or browser you sign in from.
+
+Then link the identity:
 
 ```bash
 # Sign in as your NNS identity
@@ -154,13 +170,7 @@ icp identity link web nns-identity --app nns.ic0.app
 icp identity link web oisy-identity --app oisy.com
 ```
 
-This opens your browser at the auth provider's sign-in page. Once you complete sign-in, the browser hands the delegation back to icp-cli and the identity is stored locally under the chosen name. The resulting principal matches the one the app would see in its own UI. Note that apps may use `alternativeOrigin` with II - the correct domain is `nns.ic0.app`, not `nns.internetcomputer.org`, which would give you a different principal.
-
-When `--app` is omitted, the auth provider picks its own default (id.ai uses `cli.id.ai`):
-
-```bash
-icp identity link web my-cli-identity
-```
+Note that apps may use `alternativeOrigin` with II - the correct domain is `nns.ic0.app`, not `nns.internetcomputer.org`, which would give you a different principal.
 
 ### Using a Different Auth Provider
 


### PR DESCRIPTION
## Context

We received this feedback on `icp identity link web`:

> Hello SDK team, I was very excited when I saw in the icp-cli docs the example of linking the nns.ic0.app identity with icp-cli. The excitement disappeared when I tried it out and II told me that the NNS dapp doesn't support it. The same happens for oisy.com. How about changing the example to something that is actually supported?

Both examples *are* supported. Internet Identity gates a delegation for another app's domain behind a per-identity **CLI access** setting, and without it the sign-in page shows "CLI access not enabled". Our guide never mentioned the prerequisite, so the screen reads as a capability limitation rather than a setting the user can flip.

The gate applies specifically to `--app`. Linking without it — where II hands icp-cli its own account at `cli.id.ai` — is not gated, which is why the plain example works and the two documented ones don't.

## Changes

Restructures **Linking a Web-Based Identity** in the identity guide so the working path leads:

- Opens with `icp identity link web <name>`, flagged as working without further setup.
- New **Signing In As a Specific App** subsection for `--app`, stating the CLI access prerequisite *before* the examples: what the failure looks like, how to fix it (sign in at id.ai → identity settings → CLI access), and that the setting is per browser and per identity.
- Keeps the `alternativeOrigin` / `nns.ic0.app` note, now attached to the `--app` section where it applies.

Docs only, no behavior change.

## For discussion: the CLI still hangs silently

Worth raising separately, because docs only help people who read them *before* running the command — the reporter was looking at a spinner.

When II reaches its `cli-disabled` state it renders that screen and stops there, **without posting anything back to our loopback callback** — the POST happens only on the path past the gate. `recv_delegation` has no timeout, so the CLI sits on `⠹ Linking web-based identity` indefinitely: no error, no exit, nothing to check. That silent hang is arguably the worse half of the reported experience.

I have a small change ready that prints an actionable hint after ~30s of waiting when `--app` is set, naming CLI access as the likely cause. Held back from this PR pending the II conversation below — happy to open it as a follow-up if people want it.

We asked the II team whether the `cli-disabled` screen could grant access inline and continue to the delegation in the same request. Answer: **no, independently granting access was a deliberate security decision** — requiring an out-of-band act is anti-social-engineering, since otherwise a malicious local CLI could present the enable prompt at exactly the moment a user is primed to approve it. Reasonable, and we're not pushing back on it.

Two asks that the security rationale does *not* cover, still open with them:

1. **Report terminal states back to the callback** — POST `error=cli-disabled` plus the nonce to the loopback URL. Grants nothing and reveals nothing new (the page already holds the nonce), but it would let us print a real error and exit non-zero instead of hanging. It also covers self-hosted `--auth` providers. This would need a small change on our side too: `delegation` is currently a required form field, so a delegation-less POST 422s.
2. **A deep link to the CLI access toggle** — the error screen already has a "Manage your identity" button, so a settings route exists. If it can land on that specific setting, the docs and any future CLI hint could point at an exact URL instead of "open your identity settings".

Neither changes what's in this PR. Flagging in case anyone has an opinion on the hint, or wants to weigh in on the asks before we follow up with II.
