### PR TITLE
fix: emit JSON from `icp canister logs --json` instead of human-readable text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bump. Currently experimental: project bundling, project dependencies
 
 # Unreleased
 
+* fix: `icp canister logs` no longer has its output formats swapped. `--json` emitted the human-readable lines and the default emitted JSON; now `--json` emits machine-readable JSON (terminated by a newline) and the default emits the human-readable lines. `--follow` was already correct and is unchanged. Scripts that relied on the inverted behavior — parsing the default output as JSON, or omitting `--json` to get JSON — must now pass `--json`.
+
 # v1.3.0
 
 * feat: a canister environment variable's value can now be read from a file, by writing `var: { path: <file> }` in place of `var: value`. The path resolves against the canister's directory — including in an environment override, matching `init_args` — and surrounding whitespace is trimmed off the file's contents. The file is read when the project is loaded, so a missing file fails before anything is deployed. `icp project bundle` writes the value into the bundled manifest inline, rejecting a file outside the project as it does for other manifest file references.

--- a/crates/icp-cli/src/commands/canister/logs.rs
+++ b/crates/icp-cli/src/commands/canister/logs.rs
@@ -194,6 +194,9 @@ async fn fetch_and_display_logs(
                     .collect(),
             },
         )?;
+        // Unlike the other `--json` sites in this module, terminate the document with a
+        // newline: it is the entirety of stdout, so without it the shell prompt lands
+        // mid-line. Covered by `canister_logs_single_fetch`.
         writeln!(out)?;
     } else {
         println!(

--- a/crates/icp-cli/src/commands/canister/logs.rs
+++ b/crates/icp-cli/src/commands/canister/logs.rs
@@ -1,4 +1,4 @@
-use std::io::stdout;
+use std::io::{Write as _, stdout};
 
 use anyhow::{Context as _, anyhow};
 use candid::Principal;
@@ -179,17 +179,9 @@ async fn fetch_and_display_logs(
         .context("Failed to fetch canister logs")?;
 
     if args.json {
-        println!(
-            "{}",
-            result
-                .canister_log_records
-                .iter()
-                .map(format_log)
-                .format("\n")
-        );
-    } else {
+        let mut out = stdout();
         serde_json::to_writer(
-            stdout(),
+            &mut out,
             &JsonListRecord {
                 log_records: result
                     .canister_log_records
@@ -202,6 +194,16 @@ async fn fetch_and_display_logs(
                     .collect(),
             },
         )?;
+        writeln!(out)?;
+    } else {
+        println!(
+            "{}",
+            result
+                .canister_log_records
+                .iter()
+                .map(format_log)
+                .format("\n")
+        );
     }
 
     Ok(())

--- a/crates/icp-cli/tests/canister_logs_tests.rs
+++ b/crates/icp-cli/tests/canister_logs_tests.rs
@@ -90,6 +90,104 @@ async fn canister_logs_single_fetch() {
         .stdout(contains("Test message 2"));
 }
 
+/// Regression test: `--json` must emit machine-readable JSON and the default must emit the
+/// human-readable formatted lines. These were once swapped.
+#[cfg(unix)] // moc
+#[tokio::test]
+async fn canister_logs_single_fetch_json_orientation() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("canister_logs");
+
+    ctx.copy_asset_dir("canister_logs", &project_dir);
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: logger
+            recipe:
+              type: "@dfinity/motoko@v4.0.0"
+              configuration:
+                main: main.mo
+                args: ""
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "logger", "--environment", "random-environment"])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "logger",
+            "log",
+            "(\"Orientation message\")",
+        ])
+        .assert()
+        .success();
+
+    // With --json: parseable JSON in the JsonListRecord shape, terminated by a newline.
+    let json_stdout = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "logs",
+            "logger",
+            "--json",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json_stdout = String::from_utf8(json_stdout).expect("stdout is not valid UTF-8");
+    assert!(
+        json_stdout.ends_with('\n'),
+        "--json output should end with a newline, got {json_stdout:?}"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(json_stdout.trim()).expect("--json output should be valid JSON");
+    let records = parsed["log_records"]
+        .as_array()
+        .expect("--json output should contain a log_records array");
+    let record = records
+        .iter()
+        .find(|r| r["content"].as_str() == Some("Orientation message"))
+        .expect("--json output should contain the logged message");
+    assert!(record["timestamp"].is_u64());
+    assert!(record["index"].is_u64());
+
+    // Without --json: human-readable "[idx. timestamp]: content" lines, not JSON.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "logs",
+            "logger",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("]: Orientation message"))
+        .stdout(contains("log_records").not());
+}
+
 #[cfg(unix)] // moc
 #[tokio::test]
 async fn canister_logs_follow_mode() {

--- a/crates/icp-cli/tests/canister_logs_tests.rs
+++ b/crates/icp-cli/tests/canister_logs_tests.rs
@@ -74,7 +74,8 @@ async fn canister_logs_single_fetch() {
         .assert()
         .success();
 
-    // Fetch logs
+    // Fetch logs: the default emits the human-readable "[idx. timestamp]: content" lines,
+    // not JSON. (Regression: this orientation was once swapped with `--json`.)
     ctx.icp()
         .current_dir(&project_dir)
         .args([
@@ -86,57 +87,9 @@ async fn canister_logs_single_fetch() {
         ])
         .assert()
         .success()
-        .stdout(contains("Test message 1"))
-        .stdout(contains("Test message 2"));
-}
-
-/// Regression test: `--json` must emit machine-readable JSON and the default must emit the
-/// human-readable formatted lines. These were once swapped.
-#[cfg(unix)] // moc
-#[tokio::test]
-async fn canister_logs_single_fetch_json_orientation() {
-    let ctx = TestContext::new();
-    let project_dir = ctx.create_project_dir("canister_logs");
-
-    ctx.copy_asset_dir("canister_logs", &project_dir);
-
-    let pm = formatdoc! {r#"
-        canisters:
-          - name: logger
-            recipe:
-              type: "@dfinity/motoko@v4.0.0"
-              configuration:
-                main: main.mo
-                args: ""
-
-        {NETWORK_RANDOM_PORT}
-        {ENVIRONMENT_RANDOM_PORT}
-    "#};
-
-    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
-
-    let _g = ctx.start_network_in(&project_dir, "random-network").await;
-    ctx.ping_until_healthy(&project_dir, "random-network");
-
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args(["deploy", "logger", "--environment", "random-environment"])
-        .assert()
-        .success();
-
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args([
-            "canister",
-            "call",
-            "--environment",
-            "random-environment",
-            "logger",
-            "log",
-            "(\"Orientation message\")",
-        ])
-        .assert()
-        .success();
+        .stdout(contains("]: Test message 1"))
+        .stdout(contains("]: Test message 2"))
+        .stdout(contains("log_records").not());
 
     // With --json: parseable JSON in the JsonListRecord shape, terminated by a newline.
     let json_stdout = ctx
@@ -165,27 +118,14 @@ async fn canister_logs_single_fetch_json_orientation() {
     let records = parsed["log_records"]
         .as_array()
         .expect("--json output should contain a log_records array");
-    let record = records
-        .iter()
-        .find(|r| r["content"].as_str() == Some("Orientation message"))
-        .expect("--json output should contain the logged message");
-    assert!(record["timestamp"].is_u64());
-    assert!(record["index"].is_u64());
-
-    // Without --json: human-readable "[idx. timestamp]: content" lines, not JSON.
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args([
-            "canister",
-            "logs",
-            "logger",
-            "--environment",
-            "random-environment",
-        ])
-        .assert()
-        .success()
-        .stdout(contains("]: Orientation message"))
-        .stdout(contains("log_records").not());
+    for message in ["Test message 1", "Test message 2"] {
+        let record = records
+            .iter()
+            .find(|r| r["content"].as_str() == Some(message))
+            .unwrap_or_else(|| panic!("--json output should contain {message:?}"));
+        assert!(record["timestamp"].is_u64());
+        assert!(record["index"].is_u64());
+    }
 }
 
 #[cfg(unix)] // moc


### PR DESCRIPTION
## Intent

Fix an inverted condition that makes `icp canister logs --json` behave backwards.

The bug: in crates/icp-cli/src/commands/canister/logs.rs, function fetch_and_display_logs (the non-follow path), the two branches of `if args.json { ... } else { ... }` were swapped. The `if args.json` branch printed the human-readable formatted lines (.map(format_log).format("\n")) and the `else` branch serialized JsonListRecord with serde_json::to_writer. So --json emitted human text and the default emitted JSON. The follow path (follow_logs) already has the correct orientation - if args.json writes JSON, else prints format_log - and was used as the reference for intended behavior.

What was asked:
1. Swap the two branch bodies in fetch_and_display_logs so --json produces the JSON output and the default produces the human-readable output.
2. Check whether the JSON branch terminates its output with a newline the way the human branch does (human uses println!, JSON uses serde_json::to_writer on stdout()). If the fixed --json output would leave the shell prompt mid-line or be awkward to pipe, add the trailing newline. Do not restructure the output shape or field names beyond that.
3. Confirm this is the only place the condition is inverted - grep the file and the command module for other args.json uses and verify each one against its intended orientation, and report whether others were found.

Acceptance criteria: --json prints machine-readable JSON and the default prints the existing human-readable formatted lines; follow mode (--follow) behavior unchanged; a regression test covers both orientations of the non-follow path, extending the existing crates/icp-cli/tests/canister_logs_tests.rs rather than creating a new test file and following the conventions there and in .claude/testing.md; cargo test, cargo fmt and cargo clippy clean.

Constraints: keep the change minimal and surgical - this is a bug fix, not a refactor of the logs command. Do not change the JSON schema (JsonListRecord / JsonFollowRecord field names or structure) or the human-readable format. Follow the repo conventions in .claude/CLAUDE.md, .claude/architecture.md and .claude/testing.md for paths (camino), error handling (Snafu) and tests. Regenerate CLI docs with ./scripts/generate-cli-docs.sh only if the change actually alters generated content.

Decisions and findings while doing the work:
- Added the trailing newline deliberately: the fixed --json output would otherwise leave the shell prompt mid-line. Implemented as `let mut out = stdout(); serde_json::to_writer(&mut out, ...)?; writeln!(out)?;` with `use std::io::{Write as _, stdout}`. Note this intentionally differs from the surrounding house pattern - the other --json sites in the canister command module (list.rs, metadata.rs, snapshot/list.rs, snapshot/create.rs, snapshot/upload.rs, create.rs) all use bare serde_json::to_writer(stdout(), ..) with no trailing newline. Only the touched branch was changed, per the minimal-change constraint; the other sites were deliberately left alone rather than made consistent.
- Audited every args.json / json_format use in crates/icp-cli/src/commands/canister/ (list.rs, metadata.rs, call.rs, create.rs x2, snapshot/{list,create,upload}.rs, settings/show.rs, and logs.rs:253 in the follow path). All were correctly oriented; logs.rs was the only inversion. The follow path was left untouched.
- Regression test: added canister_logs_single_fetch_json_orientation to crates/icp-cli/tests/canister_logs_tests.rs, following the existing PocketIC / assert_cmd conventions in that file. It runs the real CLI against a live local network and asserts observable output: with --json, stdout parses as JSON with the log_records/timestamp/index/content shape and ends with a newline; without --json, stdout contains the human-readable "]: <message>" line and does not contain log_records. Verified it fails against the unfixed source (reverted only the src file, kept the test) and passes with the fix.
- Validation: cargo fmt --check, cargo clippy --all-targets, and all 5 canister_logs tests are clean. Full cargo test --workspace passes except canister_install_large_wasm_chunked, which fails on a missing tests/assets/large.wasm - a fixture generated by tests/assets/generate_large_wasm.sh that is absent in this fresh worktree. That failure is pre-existing and unrelated to this change.
- ./scripts/generate-cli-docs.sh produced no diff (no help-text change), so no docs regeneration was committed.

## What Changed

- Swapped the two branch bodies of `if args.json` in `fetch_and_display_logs` (`crates/icp-cli/src/commands/canister/logs.rs`), so `--json` now serializes `JsonListRecord` and the default prints the `format_log` lines; the `--follow` path was already correct and is untouched.
- Terminated the `--json` document with a trailing newline (`writeln!` on the same `stdout` handle) so the output does not leave the shell prompt mid-line, with a comment noting this deliberately differs from the other `--json` sites in the module.
- Extended the existing `canister_logs_single_fetch` test to assert both orientations — the default output contains the `]: <message>` lines and no `log_records`, and `--json` output ends with a newline and parses into a `log_records` array whose entries carry `content`, `timestamp`, and `index` — plus a CHANGELOG entry flagging that scripts relying on the inverted behavior must now pass `--json`.

## Risk Assessment

✅ Low: A two-branch swap plus a trailing newline in a single non-follow output path, backed by a regression test that provably fails against the unfixed code in both orientations and a CHANGELOG entry documenting the script-visible behavior change; the JSON schema, human format, and follow path are untouched.

## Testing

Ran the targeted logs integration tests and the logs module unit tests, all clean. Proved the added assertions are a true regression test by reverting only `logs.rs` to the base commit — the test fails there because the default invocation emits JSON — and passes once the fix is restored. Beyond the automated tests, I exercised the real `icp` binary against a live local PocketIC network with a deployed Motoko logger canister and captured before/after CLI transcripts: post-fix, `--json` emits newline-terminated machine-readable JSON that pipes cleanly into `jq`, while the default emits the human-readable `[idx. timestamp]: content` lines; pre-fix the same jq pipe failed and the JSON ran into the shell prompt mid-line. Follow mode was exercised in both orientations and is unchanged. I also independently audited all ten `args.json`/`json_format` sites in the canister command module and confirmed `logs.rs:181` was the only inverted one, matching the author's reported finding. This is a CLI change with no rendered UI surface, so terminal transcripts (including an `xxd` byte-level check of the trailing newline) are the appropriate end-user evidence rather than screenshots. Cleaned up the throwaway project and its network launcher; the worktree is clean.

<details>
<summary>Evidence: Before/after CLI transcript: --json orientation fix</summary>

<code>--- BEFORE (base 8fce05b, inverted) ---&#10;$ icp canister logs logger --environment random-environment&#10;{&#34;log_records&#34;:[{&#34;timestamp&#34;:1786511823727360895,&#34;index&#34;:0,&#34;content&#34;:&#34;Hello from the logger canister&#34;},{&#34;timestamp&#34;:1786511824076708234,&#34;index&#34;:1,&#34;content&#34;:&#34;Second message&#34;}]}$ icp canister logs logger --json --environment random-environment&#10;[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister&#10;[1. 2026-08-12T05:17:04.076708234Z]: Second message&#10;$ icp canister logs logger --json --environment random-environment | jq -r &#34;.log_records[].content&#34;&#10;jq: parse error: Invalid numeric literal at line 1, column 18&#10;&#10;--- AFTER (192f932, fixed) ---&#10;$ icp canister logs logger --environment random-environment # default: human-readable&#10;[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister&#10;[1. 2026-08-12T05:17:04.076708234Z]: Second message&#10;&#10;$ icp canister logs logger --json --environment random-environment # --json: machine-readable&#10;{&#34;log_records&#34;:[{&#34;timestamp&#34;:1786511823727360895,&#34;index&#34;:0,&#34;content&#34;:&#34;Hello from the logger canister&#34;},{&#34;timestamp&#34;:1786511824076708234,&#34;index&#34;:1,&#34;content&#34;:&#34;Second message&#34;}]}&#10;$ icp canister logs logger --json --environment random-environment | jq -r &#34;.log_records[].content&#34;&#10;Hello from the logger canister&#10;Second message&#10;&#10;$ icp canister logs logger --json --environment random-environment | xxd | tail -1 # last byte 0x0a = trailing newline&#10;000000a0: 6f6e 6420 6d65 7373 6167 6522 7d5d 7d0a ond message&#34;}]}.&#10;&#10;$ icp canister logs logger --since-index 1 --json --environment random-environment # --json honours filters&#10;{&#34;log_records&#34;:[{&#34;timestamp&#34;:1786511824076708234,&#34;index&#34;:1,&#34;content&#34;:&#34;Second message&#34;}]}</code>

```text
icp canister logs --json orientation: before vs after
=====================================================

--- BEFORE (base 8fce05b, inverted) ---
$ icp canister logs logger --environment random-environment
{"log_records":[{"timestamp":1786511823727360895,"index":0,"content":"Hello from the logger canister"},{"timestamp":1786511824076708234,"index":1,"content":"Second message"}]}$ icp canister logs logger --json --environment random-environment
[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister
[1. 2026-08-12T05:17:04.076708234Z]: Second message
$ icp canister logs logger --json --environment random-environment | jq -r ".log_records[].content"
jq: parse error: Invalid numeric literal at line 1, column 18
$ icp canister logs logger --json --environment random-environment | xxd | tail -1   # last byte is 0x0a (newline)
00000070: 6d65 7373 6167 650a                      message.


--- AFTER (192f932, fixed) ---
$ icp canister logs logger --environment random-environment          # default: human-readable
[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister
[1. 2026-08-12T05:17:04.076708234Z]: Second message

$ icp canister logs logger --json --environment random-environment    # --json: machine-readable
{"log_records":[{"timestamp":1786511823727360895,"index":0,"content":"Hello from the logger canister"},{"timestamp":1786511824076708234,"index":1,"content":"Second message"}]}
$ icp canister logs logger --json --environment random-environment | jq -r ".log_records[].content"
Hello from the logger canister
Second message

$ icp canister logs logger --json --environment random-environment | xxd | tail -1   # last byte 0x0a = trailing newline
000000a0: 6f6e 6420 6d65 7373 6167 6522 7d5d 7d0a  ond message"}]}.

$ icp canister logs logger --since-index 1 --json --environment random-environment    # --json honours filters
{"log_records":[{"timestamp":1786511824076708234,"index":1,"content":"Second message"}]}
```
</details>
<details>
<summary>Evidence: Post-fix CLI transcript (live local network)</summary>

```text
$ icp canister logs logger --environment random-environment          # default: human-readable
[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister
[1. 2026-08-12T05:17:04.076708234Z]: Second message

$ icp canister logs logger --json --environment random-environment    # --json: machine-readable
{"log_records":[{"timestamp":1786511823727360895,"index":0,"content":"Hello from the logger canister"},{"timestamp":1786511824076708234,"index":1,"content":"Second message"}]}
$ icp canister logs logger --json --environment random-environment | jq -r ".log_records[].content"
Hello from the logger canister
Second message

$ icp canister logs logger --json --environment random-environment | xxd | tail -1   # last byte 0x0a = trailing newline
000000a0: 6f6e 6420 6d65 7373 6167 6522 7d5d 7d0a  ond message"}]}.

$ icp canister logs logger --since-index 1 --json --environment random-environment    # --json honours filters
{"log_records":[{"timestamp":1786511824076708234,"index":1,"content":"Second message"}]}
```
</details>
<details>
<summary>Evidence: Pre-fix CLI transcript (inverted behavior, base commit binary)</summary>

```text
$ icp canister logs logger --environment random-environment
{"log_records":[{"timestamp":1786511823727360895,"index":0,"content":"Hello from the logger canister"},{"timestamp":1786511824076708234,"index":1,"content":"Second message"}]}$ icp canister logs logger --json --environment random-environment
[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister
[1. 2026-08-12T05:17:04.076708234Z]: Second message
$ icp canister logs logger --json --environment random-environment | jq -r ".log_records[].content"
jq: parse error: Invalid numeric literal at line 1, column 18
$ icp canister logs logger --json --environment random-environment | xxd | tail -1   # last byte is 0x0a (newline)
00000070: 6d65 7373 6167 650a                      message.
```
</details>
<details>
<summary>Evidence: Follow mode unchanged (both orientations, live logs)</summary>

<code>$ timeout 7 icp canister logs logger --follow --interval 1 --environment random-environment # follow, human-readable (unchanged)&#10;[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister&#10;[1. 2026-08-12T05:17:04.076708234Z]: Second message&#10;[2. 2026-08-12T05:17:49.725315913Z]: 1 Tick&#10;[3. 2026-08-12T05:17:50.677686626Z]: 2 Tick&#10;[4. 2026-08-12T05:17:51.757141821Z]: 3 Tick&#10;[5. 2026-08-12T05:17:52.741121094Z]: 4 Tick&#10;[6. 2026-08-12T05:17:53.712770572Z]: 5 Tick&#10;&#10;$ timeout 7 icp canister logs logger --follow --json --interval 1 --environment random-environment | tail -c 400 # follow --json (unchanged)&#10;dex&#34;:5,&#34;content&#34;:&#34;4 Tick&#34;}{&#34;timestamp&#34;:1786511873712770572,&#34;index&#34;:6,&#34;content&#34;:&#34;5 Tick&#34;}{&#34;timestamp&#34;:1786511877147032872,&#34;index&#34;:7,&#34;content&#34;:&#34;1 Tock&#34;}{&#34;timestamp&#34;:1786511878112360361,&#34;index&#34;:8,&#34;content&#34;:&#34;2 Tock&#34;}</code>

```text
$ icp canister call ... logger log_repeated ("Tick")   # emits 5 logs, 1/second
()

$ timeout 7 icp canister logs logger --follow --interval 1 --environment random-environment    # follow, human-readable (unchanged)
[0. 2026-08-12T05:17:03.727360895Z]: Hello from the logger canister
[1. 2026-08-12T05:17:04.076708234Z]: Second message
[2. 2026-08-12T05:17:49.725315913Z]: 1 Tick
[3. 2026-08-12T05:17:50.677686626Z]: 2 Tick
[4. 2026-08-12T05:17:51.757141821Z]: 3 Tick
[5. 2026-08-12T05:17:52.741121094Z]: 4 Tick
[6. 2026-08-12T05:17:53.712770572Z]: 5 Tick

$ icp canister call ... logger log_repeated ("Tock")
()
$ timeout 7 icp canister logs logger --follow --json --interval 1 --environment random-environment | tail -c 400   # follow --json (unchanged)
dex":5,"content":"4 Tick"}{"timestamp":1786511873712770572,"index":6,"content":"5 Tick"}{"timestamp":1786511877147032872,"index":7,"content":"1 Tock"}{"timestamp":1786511878112360361,"index":8,"content":"2 Tock"}{"timestamp":1786511879160461332,"index":9,"content":"3 Tock"}{"timestamp":1786511880114864129,"index":10,"content":"4 Tock"}{"timestamp":1786511881180303692,"index":11,"content":"5 Tock"}
```
</details>
<details>
<summary>Evidence: Regression test fails against pre-fix source</summary>

```text
$ git checkout 8fce05b -- crates/icp-cli/src/commands/canister/logs.rs
$ cargo test -p icp-cli --test canister_logs_tests -- canister_logs_single_fetch

thread 'canister_logs_single_fetch' panicked at crates/icp-cli/tests/canister_logs_tests.rs:90:10:
Unexpected stdout, failed var.contains(]: Test message 1)
├── var: {"log_records":[{"timestamp":1786511761844881385,"index":0,"content":"Test message 1"},{"timestamp":1786511762203854429,"index":1,"content":"Test message 2"}]}

command=`... icp canister logs logger --environment random-environment`
code=0

test result: FAILED. 0 passed; 1 failed; 0 ignored; 4 filtered out

--- after restoring the fix ---
test result: ok. 4 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 99.44s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b4c32d172c1b1e02ac9ac9467f20ba2fd1d05dc0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `CHANGELOG.md:8` - No `# Unreleased` CHANGELOG entry for this user-visible behavior change. CHANGELOG.md:8 (`# Unreleased`) is empty, and .github/workflows/release-pr.yml promotes exactly that section into the release notes, so this fix would ship undocumented. It matters more than a typical fix note because the *default* (no-flag) output changes from JSON to human-readable text: any script that worked around the inverted condition by omitting `--json` and parsing stdout as JSON breaks silently on upgrade. Comparable user-facing fixes in v1.3.0 (e.g. the `icp network start` error-reporting fix) do carry entries. Suggested line: &#34;fix: `icp canister logs --json` now emits JSON and the default emits human-readable lines; the two were swapped. Scripts that parsed the default output as JSON must pass `--json`.&#34;
- ℹ️ `crates/icp-cli/src/commands/canister/logs.rs:256` - Pre-existing, and explicitly out of the stated minimal scope, but now asymmetric with the fixed branch: in the follow path each record is written with bare `serde_json::to_writer(stdout(), ..)` and no newline. Rust&#39;s `Stdout` is a `LineWriter`, so with `--follow --json` nothing reaches the terminal/pipe until ~1KB of buffer fills or the process exits — the live-tail property that `--follow` exists for is lost, and records arrive concatenated (`{..}{..}`) rather than newline-delimited (NDJSON), which a consumer of a streaming log feed would expect. The one-line `writeln!(out)` pattern just adopted at logs.rs:197 would fix both. Flagging for follow-up triage only; not a blocker, since the intent states follow-mode behavior is unchanged.
- ℹ️ `crates/icp-cli/tests/canister_logs_tests.rs:97` - The new test re-runs the entire expensive fixture of `canister_logs_single_fetch` (PocketIC network start + `ping_until_healthy` + a Motoko `deploy`) to assert output shape, adding a fifth full network/compile cycle to this file. The existing `canister_logs_single_fetch` at line 15 already deploys the same logger and writes log records, so both orientations could be asserted there (it already covers the human-readable orientation), keeping regression coverage identical at roughly half the wall-clock cost. Deliberate author choice per the stated intent, so raising it rather than changing it.

🔧 Fix: add changelog entry, fold logs JSON test into existing test
1 info still open:
- ℹ️ `crates/icp-cli/src/commands/canister/logs.rs:181` - Independently confirmed the intent&#39;s audit claim (item 3): every other `args.json` / `json_format` site in crates/icp-cli/src/commands/canister/ is correctly oriented — list.rs:26, metadata.rs:50, call.rs:244, create.rs:305 and :394, snapshot/list.rs:58, snapshot/create.rs:86, snapshot/upload.rs:219, settings/show.rs:53, and logs.rs:255 (follow path). Also checked status.rs:239, :262 and :292, which the author&#39;s audit list omitted; those use `match args.options.json_format { true =&gt; serde_json::to_string(..), false =&gt; build_output(..) }` and are correct. logs.rs:181 was the only inversion. No action needed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cargo test -p icp-cli --test canister_logs_tests -- --test-threads=1` (4 passed, 1 pre-existing `#[ignore]`)</code>
- <code>`cargo test -p icp-cli --bin icp commands::canister::logs` (22 unit tests, incl. format_log/format_content/build_filter)</code>
- <code>Regression proof: `git checkout 8fce05b -- crates/icp-cli/src/commands/canister/logs.rs` then `cargo test -p icp-cli --test canister_logs_tests -- canister_logs_single_fetch` — FAILED with `var: {&#34;log_records&#34;:[...]}` on the default (non-`--json`) invocation; restored the fix and it passes</code>
- <code>Manual end-to-end: deployed the `logger` Motoko canister to a live local network (`icp network start random-network`, `icp deploy logger`), emitted logs via `icp canister call logger log`, then captured real stdout for `icp canister logs logger` vs `icp canister logs logger --json`</code>
- <code>Pipe check: `icp canister logs logger --json ... | jq -r &#39;.log_records[].content&#39;` (succeeds post-fix; `jq: parse error` pre-fix)</code>
- <code>Trailing-newline check: `icp canister logs logger --json ... | xxd | tail -1` confirms final byte `0x0a`</code>
- <code>Filter interaction: `icp canister logs logger --since-index 1 --json ...` returns only the filtered record in JSON</code>
- <code>Follow mode unchanged: `timeout 7 icp canister logs logger --follow --interval 1 ...` and `timeout 7 icp canister logs logger --follow --json --interval 1 ...` against live `log_repeated` output</code>
- <code>Inversion audit: `grep -rn &#39;\.json\b|json_format&#39; crates/icp-cli/src/commands/canister/` and inspected each branch body in list.rs, metadata.rs, call.rs, create.rs (x2), snapshot/{list,create,upload}.rs, settings/show.rs, status.rs, and logs.rs:255 (follow path)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
