### PR TITLE
fix: emit newline-delimited JSON from `icp canister logs --follow --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ bump. Currently experimental: project bundling, project dependencies
 
 # Unreleased
 
-* fix: `icp canister logs` no longer has its output formats swapped. `--json` emitted the human-readable lines and the default emitted JSON; now `--json` emits machine-readable JSON (terminated by a newline) and the default emits the human-readable lines. `--follow` already had the right orientation (see the next entry for a separate `--follow --json` fix). Scripts that relied on the inverted behavior — parsing the default output as JSON, or omitting `--json` to get JSON — must now pass `--json`.
-* fix: `icp canister logs --follow --json` now emits newline-delimited JSON (one record per line) and each record reaches stdout as it arrives. Previously the records were concatenated with no separator (`{...}{...}`) and, with no newline ever written, stayed in the line-buffered stdout buffer — so a live tail produced no output until the buffer filled or the process ended. Anything parsing the old concatenated output must now read one JSON object per line.
+* fix: `icp canister logs` output formats are corrected. `--json` now emits machine-readable JSON and the default emits the human-readable lines (the two were swapped), and `--follow --json` emits newline-delimited JSON, one record per line, streamed as each record arrives. This is breaking for scripts: parsing the default output as JSON now requires `--json`, and consumers of `--follow --json` must read one JSON object per line.
 
 # v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ bump. Currently experimental: project bundling, project dependencies
 # Unreleased
 
 * fix: `icp canister logs` no longer has its output formats swapped. `--json` emitted the human-readable lines and the default emitted JSON; now `--json` emits machine-readable JSON (terminated by a newline) and the default emits the human-readable lines. `--follow` was already correct and is unchanged. Scripts that relied on the inverted behavior — parsing the default output as JSON, or omitting `--json` to get JSON — must now pass `--json`.
+* fix: `icp canister logs --follow --json` now emits newline-delimited JSON (one record per line) and each record reaches stdout as it arrives. Previously the records were concatenated with no separator (`{...}{...}`) and, with no newline ever written, stayed in the line-buffered stdout buffer — so a live tail produced no output until the buffer filled or the process ended. Anything parsing the old concatenated output must now read one JSON object per line.
 
 # v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ bump. Currently experimental: project bundling, project dependencies
 
 # Unreleased
 
-* fix: `icp canister logs` no longer has its output formats swapped. `--json` emitted the human-readable lines and the default emitted JSON; now `--json` emits machine-readable JSON (terminated by a newline) and the default emits the human-readable lines. `--follow` was already correct and is unchanged. Scripts that relied on the inverted behavior — parsing the default output as JSON, or omitting `--json` to get JSON — must now pass `--json`.
+* fix: `icp canister logs` no longer has its output formats swapped. `--json` emitted the human-readable lines and the default emitted JSON; now `--json` emits machine-readable JSON (terminated by a newline) and the default emits the human-readable lines. `--follow` already had the right orientation (see the next entry for a separate `--follow --json` fix). Scripts that relied on the inverted behavior — parsing the default output as JSON, or omitting `--json` to get JSON — must now pass `--json`.
 * fix: `icp canister logs --follow --json` now emits newline-delimited JSON (one record per line) and each record reaches stdout as it arrives. Previously the records were concatenated with no separator (`{...}{...}`) and, with no newline ever written, stayed in the line-buffered stdout buffer — so a live tail produced no output until the buffer filled or the process ended. Anything parsing the old concatenated output must now read one JSON object per line.
 
 # v1.3.0

--- a/crates/icp-cli/src/commands/canister/logs.rs
+++ b/crates/icp-cli/src/commands/canister/logs.rs
@@ -194,9 +194,8 @@ async fn fetch_and_display_logs(
                     .collect(),
             },
         )?;
-        // Unlike the other `--json` sites in this module, terminate the document with a
-        // newline: it is the entirety of stdout, so without it the shell prompt lands
-        // mid-line. Covered by `canister_logs_single_fetch`.
+        // Terminate the document with a newline: it is the entirety of stdout, so without
+        // it the shell prompt lands mid-line. Covered by `canister_logs_single_fetch`.
         writeln!(out)?;
     } else {
         println!(
@@ -256,14 +255,20 @@ async fn follow_logs(
         if !new_logs.is_empty() {
             for log in &new_logs {
                 if args.json {
+                    let mut out = stdout().lock();
                     serde_json::to_writer(
-                        stdout(),
+                        &mut out,
                         &JsonFollowRecord {
                             timestamp: log.timestamp_nanos,
                             index: log.idx,
                             content: String::from_utf8_lossy(&log.content).into_owned(),
                         },
                     )?;
+                    // Emit newline-delimited JSON: the newline both separates records for
+                    // incremental consumers and, because Rust's stdout is a `LineWriter`
+                    // regardless of whether it is a terminal, flushes the record so that
+                    // `--follow` actually streams. Covered by `canister_logs_follow_mode_json`.
+                    writeln!(out)?;
                 } else {
                     println!("{}", format_log(log));
                 }

--- a/crates/icp-cli/src/commands/canister/logs.rs
+++ b/crates/icp-cli/src/commands/canister/logs.rs
@@ -1,4 +1,4 @@
-use std::io::{Write as _, stdout};
+use std::io::{ErrorKind, Write as _, stdout};
 
 use anyhow::{Context as _, anyhow};
 use candid::Principal;
@@ -223,7 +223,7 @@ async fn follow_logs(
     let mut last_idx: Option<u64> = None;
     let interval = std::time::Duration::from_secs(interval_seconds);
 
-    loop {
+    'follow: loop {
         let filter = match last_idx {
             Some(idx) => Some(CanisterLogFilter::ByIdx {
                 start: idx + 1, // Start from the next log index after the last one we displayed
@@ -254,23 +254,26 @@ async fn follow_logs(
 
         if !new_logs.is_empty() {
             for log in &new_logs {
-                if args.json {
-                    let mut out = stdout().lock();
-                    serde_json::to_writer(
-                        &mut out,
-                        &JsonFollowRecord {
-                            timestamp: log.timestamp_nanos,
-                            index: log.idx,
-                            content: String::from_utf8_lossy(&log.content).into_owned(),
-                        },
-                    )?;
-                    // Emit newline-delimited JSON: the newline both separates records for
-                    // incremental consumers and, because Rust's stdout is a `LineWriter`
-                    // regardless of whether it is a terminal, flushes the record so that
-                    // `--follow` actually streams. Covered by `canister_logs_follow_mode_json`.
-                    writeln!(out)?;
+                let line = if args.json {
+                    serde_json::to_string(&JsonFollowRecord {
+                        timestamp: log.timestamp_nanos,
+                        index: log.idx,
+                        content: String::from_utf8_lossy(&log.content).into_owned(),
+                    })?
                 } else {
-                    println!("{}", format_log(log));
+                    format_log(log)
+                };
+                // Under `--json` this makes the output newline-delimited: the newline both
+                // separates records for incremental consumers and, because Rust's stdout is a
+                // `LineWriter` regardless of whether it is a terminal, flushes the record so
+                // that `--follow` actually streams. Covered by `canister_logs_follow_mode_json`.
+                match writeln!(stdout().lock(), "{line}") {
+                    Ok(()) => {}
+                    // The consumer closed the pipe (`... --follow --json | head -1`). That is
+                    // an ordinary way to stop a tail, so stop quietly rather than reporting a
+                    // broken pipe. Covered by `canister_logs_follow_broken_pipe`.
+                    Err(e) if e.kind() == ErrorKind::BrokenPipe => break 'follow,
+                    Err(e) => return Err(e.into()),
                 }
             }
             // Update last_idx to the highest idx we've displayed

--- a/crates/icp-cli/tests/canister_logs_tests.rs
+++ b/crates/icp-cli/tests/canister_logs_tests.rs
@@ -5,6 +5,8 @@ use {
     indoc::formatdoc,
     predicates::prelude::PredicateBooleanExt,
     predicates::str::contains,
+    std::io::{BufRead as _, BufReader},
+    std::process::Stdio,
     std::time::Duration,
 };
 
@@ -299,6 +301,112 @@ async fn canister_logs_follow_mode_json() {
         assert!(
             contents.iter().any(|c| c.contains(&message)),
             "--follow --json output should contain {message:?}, got {contents:?}"
+        );
+    }
+}
+
+/// A consumer that stops reading — `icp canister logs --follow | head -1` — must not make
+/// the command report a broken pipe. Runs both output modes: `--json` writes far more often
+/// now that it streams, so it reaches the closed pipe first, but the human-readable path
+/// closes over exactly the same write.
+#[cfg(unix)] // moc
+#[tokio::test]
+async fn canister_logs_follow_broken_pipe() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("canister_logs");
+
+    // Copy the logger canister assets
+    ctx.copy_asset_dir("canister_logs", &project_dir);
+
+    // Project manifest
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: logger
+            recipe:
+              type: "@dfinity/motoko@v4.0.0"
+              configuration:
+                main: main.mo
+                args: ""
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    // Start network
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    // Deploy canister
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "logger", "--environment", "random-environment"])
+        .assert()
+        .success();
+
+    let log = |message: &str| {
+        ctx.icp()
+            .current_dir(&project_dir)
+            .args([
+                "canister",
+                "call",
+                "--environment",
+                "random-environment",
+                "logger",
+                "log",
+                &format!("(\"{message}\")"),
+            ])
+            .assert()
+            .success();
+    };
+
+    for json in [true, false] {
+        // One log exists before the follow starts, so the first poll has exactly one record
+        // to emit and we are not racing the canister for it.
+        log(&format!("Before follow {json}"));
+
+        let mut args = vec![
+            "canister",
+            "logs",
+            "logger",
+            "--follow",
+            "--interval",
+            "1",
+            "--environment",
+            "random-environment",
+        ];
+        if json {
+            args.push("--json");
+        }
+        let mut child = ctx
+            .icp_std()
+            .current_dir(&project_dir)
+            .args(&args)
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn icp canister logs --follow");
+
+        // Read one record, then close the read end of the pipe, exactly as `head -1` does.
+        let mut reader = BufReader::new(child.stdout.take().expect("stdout is piped"));
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .expect("failed to read the first record");
+        assert!(
+            !line.is_empty(),
+            "expected a first record before the pipe closed"
+        );
+        drop(reader);
+
+        // Produce another record so the next poll must write to the now-closed pipe. Without
+        // this the loop could idle forever and never notice the pipe is gone.
+        log(&format!("After close {json}"));
+
+        let status = child.wait().expect("failed to wait for icp canister logs");
+        assert!(
+            status.success(),
+            "a closed stdout pipe should end `--follow` quietly (json: {json}), got {status}"
         );
     }
 }

--- a/crates/icp-cli/tests/canister_logs_tests.rs
+++ b/crates/icp-cli/tests/canister_logs_tests.rs
@@ -130,6 +130,10 @@ async fn canister_logs_single_fetch() {
     }
 }
 
+/// Every `--follow` behaviour, in one network start and one `moc` deploy: each phase would
+/// otherwise pay for its own, which dominates the wall clock. Covers (1) polling for logs
+/// that do not exist yet, (2) `--json` streaming newline-delimited records as they arrive,
+/// and (3) a consumer that stops reading ending the command quietly.
 #[cfg(unix)] // moc
 #[tokio::test]
 async fn canister_logs_follow_mode() {
@@ -166,186 +170,7 @@ async fn canister_logs_follow_mode() {
         .assert()
         .success();
 
-    // Trigger repeated logging (will log 5 times over 5 seconds)
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args([
-            "canister",
-            "call",
-            "--environment",
-            "random-environment",
-            "logger",
-            "log_repeated",
-            "(\"Repeated\")",
-        ])
-        .assert()
-        .success();
-
-    // Start following logs with a timeout of 7 seconds (enough to see several logs)
-    // The logs are not present yet, so if e.g. "5 Repeated" is present in stdout after the timeout, then we correctly polled for new logs
-    ctx.icp()
-        .current_dir(&project_dir)
-        .timeout(Duration::from_secs(7))
-        .args([
-            "canister",
-            "logs",
-            "logger",
-            "--follow",
-            "--interval",
-            "1",
-            "--environment",
-            "random-environment",
-        ])
-        .assert()
-        .failure() // Will timeout/be interrupted
-        .stdout(contains("1 Repeated"))
-        .stdout(contains("2 Repeated"))
-        .stdout(contains("3 Repeated"))
-        .stdout(contains("4 Repeated"))
-        .stdout(contains("5 Repeated"));
-}
-
-#[cfg(unix)] // moc
-#[tokio::test]
-async fn canister_logs_follow_mode_json() {
-    let ctx = TestContext::new();
-    let project_dir = ctx.create_project_dir("canister_logs");
-
-    // Copy the logger canister assets
-    ctx.copy_asset_dir("canister_logs", &project_dir);
-
-    // Project manifest
-    let pm = formatdoc! {r#"
-        canisters:
-          - name: logger
-            recipe:
-              type: "@dfinity/motoko@v4.0.0"
-              configuration:
-                main: main.mo
-                args: ""
-
-        {NETWORK_RANDOM_PORT}
-        {ENVIRONMENT_RANDOM_PORT}
-    "#};
-
-    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
-
-    // Start network
-    let _g = ctx.start_network_in(&project_dir, "random-network").await;
-    ctx.ping_until_healthy(&project_dir, "random-network");
-
-    // Deploy canister
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args(["deploy", "logger", "--environment", "random-environment"])
-        .assert()
-        .success();
-
-    // Trigger repeated logging (will log 5 times over 5 seconds)
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args([
-            "canister",
-            "call",
-            "--environment",
-            "random-environment",
-            "logger",
-            "log_repeated",
-            "(\"Repeated\")",
-        ])
-        .assert()
-        .success();
-
-    // Follow with --json until the timeout kills the process. Because the process is
-    // killed rather than exiting normally, nothing buffered in stdout is flushed on the
-    // way out: any output we observe here must have been flushed as the records arrived.
-    let stdout = ctx
-        .icp()
-        .current_dir(&project_dir)
-        .timeout(Duration::from_secs(7))
-        .args([
-            "canister",
-            "logs",
-            "logger",
-            "--follow",
-            "--json",
-            "--interval",
-            "1",
-            "--environment",
-            "random-environment",
-        ])
-        .assert()
-        .failure() // Will timeout/be interrupted
-        .get_output()
-        .stdout
-        .clone();
-    let stdout = String::from_utf8(stdout).expect("stdout is not valid UTF-8");
-
-    // Newline-delimited JSON: every line is one complete, parseable record.
-    let mut contents = Vec::new();
-    for line in stdout.lines() {
-        let record: serde_json::Value = serde_json::from_str(line)
-            .unwrap_or_else(|e| panic!("--follow --json line {line:?} is not valid JSON: {e}"));
-        assert!(record["timestamp"].is_u64());
-        assert!(record["index"].is_u64());
-        contents.push(
-            record["content"]
-                .as_str()
-                .expect("--follow --json record should contain a content string")
-                .to_string(),
-        );
-    }
-
-    for i in 1..=5 {
-        let message = format!("{i} Repeated");
-        assert!(
-            contents.iter().any(|c| c.contains(&message)),
-            "--follow --json output should contain {message:?}, got {contents:?}"
-        );
-    }
-}
-
-/// A consumer that stops reading — `icp canister logs --follow | head -1` — must not make
-/// the command report a broken pipe. Runs both output modes: `--json` writes far more often
-/// now that it streams, so it reaches the closed pipe first, but the human-readable path
-/// closes over exactly the same write.
-#[cfg(unix)] // moc
-#[tokio::test]
-async fn canister_logs_follow_broken_pipe() {
-    let ctx = TestContext::new();
-    let project_dir = ctx.create_project_dir("canister_logs");
-
-    // Copy the logger canister assets
-    ctx.copy_asset_dir("canister_logs", &project_dir);
-
-    // Project manifest
-    let pm = formatdoc! {r#"
-        canisters:
-          - name: logger
-            recipe:
-              type: "@dfinity/motoko@v4.0.0"
-              configuration:
-                main: main.mo
-                args: ""
-
-        {NETWORK_RANDOM_PORT}
-        {ENVIRONMENT_RANDOM_PORT}
-    "#};
-
-    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
-
-    // Start network
-    let _g = ctx.start_network_in(&project_dir, "random-network").await;
-    ctx.ping_until_healthy(&project_dir, "random-network");
-
-    // Deploy canister
-    ctx.icp()
-        .current_dir(&project_dir)
-        .args(["deploy", "logger", "--environment", "random-environment"])
-        .assert()
-        .success();
-
-    let log = |message: &str| {
+    let call = |method: &str, message: &str| {
         ctx.icp()
             .current_dir(&project_dir)
             .args([
@@ -354,18 +179,13 @@ async fn canister_logs_follow_broken_pipe() {
                 "--environment",
                 "random-environment",
                 "logger",
-                "log",
+                method,
                 &format!("(\"{message}\")"),
             ])
             .assert()
             .success();
     };
-
-    for json in [true, false] {
-        // One log exists before the follow starts, so the first poll has exactly one record
-        // to emit and we are not racing the canister for it.
-        log(&format!("Before follow {json}"));
-
+    let follow_args = |json: bool| {
         let mut args = vec![
             "canister",
             "logs",
@@ -379,10 +199,72 @@ async fn canister_logs_follow_broken_pipe() {
         if json {
             args.push("--json");
         }
+        args
+    };
+
+    // Phase 1: the human-readable output polls for new logs. `log_repeated` returns
+    // immediately and logs 5 times over 5 seconds from a recurring timer, so none of these
+    // records exist when the follow starts — seeing "5 Repeated" within the 7s window means
+    // we really polled rather than replaying the 1-hour lookback.
+    call("log_repeated", "Repeated");
+    ctx.icp()
+        .current_dir(&project_dir)
+        .timeout(Duration::from_secs(7))
+        .args(follow_args(false))
+        .assert()
+        .failure() // Will timeout/be interrupted
+        .stdout(contains("1 Repeated"))
+        .stdout(contains("2 Repeated"))
+        .stdout(contains("3 Repeated"))
+        .stdout(contains("4 Repeated"))
+        .stdout(contains("5 Repeated"));
+
+    // Phase 2: `--json` streams newline-delimited records. Same fresh-logs setup, and
+    // because the timeout SIGKILLs the process rather than letting it exit, nothing buffered
+    // in stdout is flushed on the way out: any output we observe must have been flushed as
+    // the records arrived. Parsing each line on its own also pins the delimiting, since
+    // `serde_json::from_str` rejects the trailing content of a concatenated `{...}{...}`.
+    call("log_repeated", "Streamed");
+    let stdout = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .timeout(Duration::from_secs(7))
+        .args(follow_args(true))
+        .assert()
+        .failure() // Will timeout/be interrupted
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(stdout).expect("stdout is not valid UTF-8");
+    let mut contents = Vec::new();
+    for line in stdout.lines() {
+        let record: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("--follow --json line {line:?} is not valid JSON: {e}"));
+        assert!(record["timestamp"].is_u64());
+        assert!(record["index"].is_u64());
+        contents.push(
+            record["content"]
+                .as_str()
+                .expect("--follow --json record should contain a content string")
+                .to_string(),
+        );
+    }
+    for i in 1..=5 {
+        let message = format!("{i} Streamed");
+        assert!(
+            contents.iter().any(|c| c.contains(&message)),
+            "--follow --json output should contain {message:?}, got {contents:?}"
+        );
+    }
+
+    // Phase 3: a consumer that stops reading — `icp canister logs --follow | head -1` — must
+    // not make the command report a broken pipe. `--json` writes far more often now that it
+    // streams, so it reaches the closed pipe first, but both modes share the same write.
+    for json in [true, false] {
         let mut child = ctx
             .icp_std()
             .current_dir(&project_dir)
-            .args(&args)
+            .args(follow_args(json))
             .stdout(Stdio::piped())
             .spawn()
             .expect("failed to spawn icp canister logs --follow");
@@ -395,13 +277,14 @@ async fn canister_logs_follow_broken_pipe() {
             .expect("failed to read the first record");
         assert!(
             !line.is_empty(),
-            "expected a first record before the pipe closed"
+            "expected a first record before the pipe closed (json: {json})"
         );
         drop(reader);
 
-        // Produce another record so the next poll must write to the now-closed pipe. Without
-        // this the loop could idle forever and never notice the pipe is gone.
-        log(&format!("After close {json}"));
+        // Produce another record so the next poll must write to the now-closed pipe. The
+        // earlier phases left plenty for the first poll to emit, but this makes the write
+        // independent of how much the lookback happens to return.
+        call("log", &format!("After close {json}"));
 
         let status = child.wait().expect("failed to wait for icp canister logs");
         assert!(

--- a/crates/icp-cli/tests/canister_logs_tests.rs
+++ b/crates/icp-cli/tests/canister_logs_tests.rs
@@ -205,6 +205,106 @@ async fn canister_logs_follow_mode() {
 
 #[cfg(unix)] // moc
 #[tokio::test]
+async fn canister_logs_follow_mode_json() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("canister_logs");
+
+    // Copy the logger canister assets
+    ctx.copy_asset_dir("canister_logs", &project_dir);
+
+    // Project manifest
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: logger
+            recipe:
+              type: "@dfinity/motoko@v4.0.0"
+              configuration:
+                main: main.mo
+                args: ""
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    // Start network
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    // Deploy canister
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "logger", "--environment", "random-environment"])
+        .assert()
+        .success();
+
+    // Trigger repeated logging (will log 5 times over 5 seconds)
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "call",
+            "--environment",
+            "random-environment",
+            "logger",
+            "log_repeated",
+            "(\"Repeated\")",
+        ])
+        .assert()
+        .success();
+
+    // Follow with --json until the timeout kills the process. Because the process is
+    // killed rather than exiting normally, nothing buffered in stdout is flushed on the
+    // way out: any output we observe here must have been flushed as the records arrived.
+    let stdout = ctx
+        .icp()
+        .current_dir(&project_dir)
+        .timeout(Duration::from_secs(7))
+        .args([
+            "canister",
+            "logs",
+            "logger",
+            "--follow",
+            "--json",
+            "--interval",
+            "1",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .failure() // Will timeout/be interrupted
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(stdout).expect("stdout is not valid UTF-8");
+
+    // Newline-delimited JSON: every line is one complete, parseable record.
+    let mut contents = Vec::new();
+    for line in stdout.lines() {
+        let record: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("--follow --json line {line:?} is not valid JSON: {e}"));
+        assert!(record["timestamp"].is_u64());
+        assert!(record["index"].is_u64());
+        contents.push(
+            record["content"]
+                .as_str()
+                .expect("--follow --json record should contain a content string")
+                .to_string(),
+        );
+    }
+
+    for i in 1..=5 {
+        let message = format!("{i} Repeated");
+        assert!(
+            contents.iter().any(|c| c.contains(&message)),
+            "--follow --json output should contain {message:?}, got {contents:?}"
+        );
+    }
+}
+
+#[cfg(unix)] // moc
+#[tokio::test]
 async fn canister_logs_filter_by_index() {
     let ctx = TestContext::new();
     let project_dir = ctx.create_project_dir("canister_logs");

--- a/crates/icp-cli/tests/common/context.rs
+++ b/crates/icp-cli/tests/common/context.rs
@@ -99,7 +99,14 @@ impl TestContext {
     }
 
     pub(crate) fn icp(&self) -> Command {
-        let mut cmd = Command::new(icp_bin_path());
+        Command::from_std(self.icp_std())
+    }
+
+    /// The same isolated `icp` invocation as [`TestContext::icp`], as a raw
+    /// [`std::process::Command`] so a caller can wire up stdio itself — e.g. to spawn a
+    /// long-running command and close its stdout pipe part-way through.
+    pub(crate) fn icp_std(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new(icp_bin_path());
 
         // Isolate the command
         cmd.current_dir(self.home_path());


### PR DESCRIPTION
## What this fixes

Two bugs in `icp canister logs --follow`, both in `crates/icp-cli/src/commands/canister/logs.rs`.

**1. `--follow --json` was neither delimited nor streaming.** Each record was written with a bare `serde_json::to_writer(stdout(), ...)` and no newline, so:

- records ran together as `{...}{...}{...}` on one line, which line-oriented consumers (`head`, `while read`, per-line `json.loads`) cannot split into records — `jq` itself tolerates concatenated values, so it is the rest of the toolchain that breaks — and
- with no newline ever written, nothing left the line-buffered stdout buffer until it filled (~1KB) or the process exited — so a live tail showed *nothing*.

This was pre-existing and deliberately out of scope for the `--json` orientation fix in #704, which left follow mode untouched.

**2. A closed output pipe was reported as an error.** `... --follow | head -1` makes the next write fail with `EPIPE`. On the `--json` path that propagated out as `Error: Broken pipe (os error 32)` and a non-zero exit; on the human-readable path `println!` *panicked*. A consumer that stops reading is an ordinary way to stop a tail, not a failure. This one predates #704 as well, but piping NDJSON into `head`/`jq` is exactly the pattern fix 1 invites, so it became far more reachable.

## Approach

Each record is now serialized to a `String` and written with a single `writeln!`, and the follow loop is labelled so a broken pipe can break out of it:

```rust
match writeln!(stdout().lock(), "{line}") {
    Ok(()) => {}
    Err(e) if e.kind() == ErrorKind::BrokenPipe => break 'follow,
    Err(e) => return Err(e.into()),
}
```

Notes on the two judgement calls in there:

- **Newline, not an explicit `flush()`.** Rust's `std::io::stdout()` is a `LineWriter` unconditionally — unlike C stdio, it does not switch to block buffering when stdout is not a terminal — so writing the newline flushes the record. That is verified by the tests below rather than taken on trust, so no `flush()` call was added.
- **One write site for both output modes.** Collapsing the `--json` and human-readable branches means the broken-pipe handling covers both, which is what removes the pre-existing `println!` panic. The emitted text is byte-identical in both modes.

Also drops a comment in `fetch_and_display_logs` that claimed follow mode does *not* terminate its records — true when written, false as of this PR — while keeping the explanation of why the non-follow document needs its own trailing newline.

## Compatibility

`--follow --json` changes from concatenated JSON objects to newline-delimited JSON. Anything parsing the old output must now read one object per line. Called out in `CHANGELOG.md` under `# Unreleased`.

The non-follow paths are untouched: `--json` is still a single `JsonListRecord` document terminated by one newline, the default is still the human-readable `[idx. timestamp]: content` lines, and neither `JsonFollowRecord` nor `JsonListRecord` changed shape.

## Test coverage

All of it lives in `canister_logs_follow_mode` in `crates/icp-cli/tests/canister_logs_tests.rs`, as three phases sharing one network start and one `moc` deploy — the pattern `canister_logs_single_fetch` already uses. Each phase triggers its own fresh `log_repeated`, so nothing is replayed from the 1-hour lookback.

1. **Polling** (pre-existing) — the human-readable output picks up logs that did not exist when the follow started.
2. **NDJSON streaming** — covers delimiting *and* streaming, not just delimiting. `assert_cmd`'s `.timeout()` SIGKILLs the process, so anything still in the stdout buffer is lost; observing output at all therefore proves it was flushed as records arrived. Each line is parsed on its own, which also pins the delimiting, since `serde_json::from_str` rejects the trailing content of a concatenated `{...}{...}`.
3. **Closed pipe**, both output modes — spawn `--follow` with a piped stdout, read one record, drop the reader (what `head -1` does to the pipe), then emit one more log so the next poll *must* write to the now-closed pipe, and assert a clean exit. That last step is what makes it deterministic rather than racing the canister.

Both fixes were verified to **fail without them**, not just pass with them: `write!` in place of `writeln!` fails the run, as does dropping the `ErrorKind::BrokenPipe` arm.

Phase 3 needs a raw `std::process::Command` to control the child's stdio, so `TestContext::icp_std()` was added and `icp()` is now a thin `Command::from_std` wrapper over it — no duplicated env-isolation block.

`cargo test`, `cargo fmt`, and `cargo clippy --all-targets` are clean. (`canister_install_large_wasm_chunked` fails in my local environment for want of `wasm-tools`; unrelated, and it passes in CI.)

## Not addressed here

**Trailing newlines CLI-wide.** `canister logs` is now the only command whose `--json` output ends in a newline; `canister list`/`metadata`/`create`/`call`, `deploy`, all of `token`/`cycles`/`identity` and the `snapshot` commands write a bare document with no terminator. The justification in the comment this PR rewrites — it is the entirety of stdout, so the prompt lands mid-line — applies verbatim to all of them. Cosmetic rather than a parsing bug, so it belongs in a separate consistency sweep, pairing naturally with #493. Worth noting the sentence this PR deletes was that divergence's only in-code marker; deleting it is still correct, since within this module the contrast is now false.

**Schema documentation.** The `--json` output schema still has no owning documentation surface — `docs/reference/cli.md` is generated from clap help and describes flags only. Creating one is out of scope for a bug fix; #493 already tracks it, and the NDJSON contract for `--follow --json` should be written down when that happens.
