### PR TITLE
refactor: put script sync-step execution behind a ScriptRunner seam

### DIFF
--- a/crates/icp/src/canister/script.rs
+++ b/crates/icp/src/canister/script.rs
@@ -56,11 +56,27 @@ pub(super) async fn execute(
     stdio: Option<Sender<String>>,
 ) -> Result<(), ScriptError> {
     // Normalize `command` field based on whether it's a single command or multiple.
-    let cmds = adapter.command.as_vec();
+    execute_commands(&adapter.command.as_vec(), cwd, envs, stdio).await
+}
 
+/// Run each command in order under a shell, with `envs` set and `cwd` as the
+/// working directory, streaming stdout/stderr lines to `stdio`.
+///
+/// Takes already-resolved commands rather than an [`Adapter`], so the subprocess
+/// executor needs to know nothing about manifest types. The sync path resolves
+/// its commands and `ICP_CLI_*` environment into a
+/// [`ScriptInvocation`](super::sync::script::ScriptInvocation) before calling
+/// this; the build path calls [`execute`] with its adapter.
+pub(super) async fn execute_commands(
+    cmds: &[String],
+    cwd: &Path,
+    envs: &[(&str, &str)],
+    stdio: Option<Sender<String>>,
+) -> Result<(), ScriptError> {
     // Iterate over configured commands
     for input_cmd in cmds {
-        let mut cmd = shell_command(&input_cmd, cwd)?;
+        let input_cmd = input_cmd.as_str();
+        let mut cmd = shell_command(input_cmd, cwd)?;
 
         // Environment Variables
         for env in envs {

--- a/crates/icp/src/canister/sync/mod.rs
+++ b/crates/icp/src/canister/sync/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use candid::Principal;
@@ -11,7 +12,9 @@ use crate::package::PackageCache;
 use crate::prelude::*;
 
 mod plugin;
-mod script;
+pub mod script;
+
+use script::{HostScripts, ScriptInvocation, ScriptRunError, ScriptRunner};
 
 pub struct Params {
     pub path: PathBuf,
@@ -30,7 +33,7 @@ pub struct Params {
 #[derive(Debug, Snafu)]
 pub enum SynchronizeError {
     #[snafu(transparent)]
-    Script { source: super::script::ScriptError },
+    Script { source: ScriptRunError },
 
     #[snafu(transparent)]
     Plugin { source: plugin::PluginError },
@@ -48,7 +51,24 @@ pub trait Synchronize: Sync + Send {
     ) -> Result<Vec<String>, SynchronizeError>;
 }
 
-pub struct Syncer;
+/// Dispatches each sync step to the machinery that runs it. Plugin steps run in
+/// the wasmtime WASI sandbox, which this drives directly; script steps go through
+/// an injected [`ScriptRunner`], since spawning a subprocess is not available
+/// everywhere.
+pub struct Syncer {
+    scripts: Arc<dyn ScriptRunner>,
+}
+
+impl Syncer {
+    /// A syncer that runs script steps as host subprocesses.
+    pub fn host() -> Self {
+        Self::new(Arc::new(HostScripts))
+    }
+
+    pub fn new(scripts: Arc<dyn ScriptRunner>) -> Self {
+        Self { scripts }
+    }
+}
 
 #[async_trait]
 impl Synchronize for Syncer {
@@ -61,7 +81,10 @@ impl Synchronize for Syncer {
         pkg_cache: &PackageCache,
     ) -> Result<Vec<String>, SynchronizeError> {
         match step {
-            SyncStep::Script(adapter) => Ok(script::sync(adapter, params, stdio).await?),
+            SyncStep::Script(adapter) => Ok(self
+                .scripts
+                .run_script(ScriptInvocation::new(adapter, params), stdio)
+                .await?),
             SyncStep::Plugin(adapter) => Ok(plugin::sync(
                 adapter,
                 params,
@@ -93,5 +116,91 @@ impl Synchronize for UnimplementedMockSyncer {
         _pkg_cache: &PackageCache,
     ) -> Result<Vec<String>, SynchronizeError> {
         unimplemented!("UnimplementedMockSyncer::sync")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use crate::manifest::adapter::script::{Adapter, CommandField};
+
+    use super::*;
+
+    /// A [`ScriptRunner`] that records what it was asked to run instead of
+    /// running it, so step dispatch can be tested without spawning a shell.
+    #[derive(Default)]
+    struct RecordingScripts {
+        seen: Mutex<Vec<ScriptInvocation>>,
+    }
+
+    #[async_trait]
+    impl ScriptRunner for RecordingScripts {
+        async fn run_script(
+            &self,
+            invocation: ScriptInvocation,
+            _stdio: Option<Sender<String>>,
+        ) -> Result<Vec<String>, ScriptRunError> {
+            self.seen.lock().unwrap().push(invocation);
+            Ok(vec![])
+        }
+    }
+
+    fn dummy_agent() -> Agent {
+        Agent::builder()
+            .with_url("http://127.0.0.1:4943")
+            .build()
+            .expect("build test agent")
+    }
+
+    /// A script step reaches the injected runner fully resolved: the commands
+    /// from the manifest, the canister directory as cwd, and the `ICP_CLI_*`
+    /// environment assembled from the sync params. Nothing is spawned.
+    #[tokio::test]
+    async fn script_steps_are_dispatched_to_the_injected_runner() {
+        let scripts = Arc::new(RecordingScripts::default());
+        let syncer = Syncer::new(scripts.clone());
+
+        let cid = Principal::from_slice(&[7; 4]);
+        let params = Params {
+            path: "/work/backend".into(),
+            cid,
+            environment: "production".to_owned(),
+            network: "ic".to_owned(),
+            canister_ids: BTreeMap::from([(
+                "my-frontend".to_owned(),
+                Principal::from_slice(&[8; 4]),
+            )]),
+            proxy: None,
+        };
+        let step = SyncStep::Script(Adapter {
+            command: CommandField::Command("./deploy.sh".to_owned()),
+        });
+
+        let tmp = camino_tempfile::Utf8TempDir::new().unwrap();
+        let pkg_cache = PackageCache::new(tmp.path().to_owned()).unwrap();
+
+        let retained = syncer
+            .sync(&step, &params, &dummy_agent(), None, &pkg_cache)
+            .await
+            .expect("script step should dispatch");
+        assert!(retained.is_empty());
+
+        let seen = scripts.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].commands, vec!["./deploy.sh"]);
+        assert_eq!(seen[0].cwd, PathBuf::from("/work/backend"));
+        assert_eq!(
+            seen[0].env,
+            vec![
+                ("ICP_CLI_ENVIRONMENT".to_owned(), "production".to_owned()),
+                ("ICP_CLI_NETWORK".to_owned(), "ic".to_owned()),
+                ("ICP_CLI_CID".to_owned(), cid.to_text()),
+                (
+                    "ICP_CLI_CID_MY_FRONTEND".to_owned(),
+                    Principal::from_slice(&[8; 4]).to_text()
+                ),
+            ]
+        );
     }
 }

--- a/crates/icp/src/canister/sync/script.rs
+++ b/crates/icp/src/canister/sync/script.rs
@@ -1,17 +1,58 @@
+//! Script sync steps, split into resolution and execution.
+//!
+//! [`ScriptInvocation::new`] resolves a manifest script step against the sync
+//! [`Params`] — the command list, the working directory and the `ICP_CLI_*`
+//! environment — without running anything. [`ScriptRunner`] then executes a
+//! resolved invocation.
+//!
+//! Execution sits behind a trait because spawning a subprocess is the one part of
+//! sync that cannot be done everywhere: plugin steps run inside the wasmtime WASI
+//! sandbox, but a script step needs a shell. Keeping the split here means the
+//! resolution half is portable and unit-testable, and an environment without
+//! subprocesses can substitute a runner that refuses instead of losing the whole
+//! sync path.
+
+use async_trait::async_trait;
+use snafu::prelude::*;
 use tokio::sync::mpsc::Sender;
 
 use crate::manifest::adapter::script::Adapter;
+use crate::prelude::*;
 
 use super::Params;
 
-use super::super::script::{ScriptError, execute};
+use super::super::script::execute_commands;
 
-pub(super) async fn sync(
-    adapter: &Adapter,
-    params: &Params,
-    stdio: Option<Sender<String>>,
-) -> Result<Vec<String>, ScriptError> {
-    let mut envs: Vec<(String, String)> = vec![
+/// A fully-resolved script sync step: the command(s), the working directory, and
+/// the complete environment the subprocess runs with (see [`system_env_vars`]).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScriptInvocation {
+    /// Shell command(s) to run in order.
+    pub commands: Vec<String>,
+    /// Working directory (the canister directory).
+    pub cwd: PathBuf,
+    /// Environment variables the subprocess inherits, in insertion order.
+    pub env: Vec<(String, String)>,
+}
+
+impl ScriptInvocation {
+    /// Resolve a script step's adapter against the sync context, assembling the
+    /// `ICP_CLI_*` system environment variables the command runs with.
+    pub fn new(adapter: &Adapter, params: &Params) -> Self {
+        Self {
+            commands: adapter.command.as_vec(),
+            cwd: params.path.clone(),
+            env: system_env_vars(params),
+        }
+    }
+}
+
+/// The `ICP_CLI_*` system environment variables every script sync step runs
+/// with: the environment and network names, the target canister id, and one
+/// `ICP_CLI_CID_<NAME>` per known canister in the environment (name uppercased,
+/// non-alphanumerics replaced with `_`).
+pub fn system_env_vars(params: &Params) -> Vec<(String, String)> {
+    let mut envs = vec![
         ("ICP_CLI_ENVIRONMENT".to_owned(), params.environment.clone()),
         ("ICP_CLI_NETWORK".to_owned(), params.network.clone()),
         ("ICP_CLI_CID".to_owned(), params.cid.to_text()),
@@ -26,9 +67,161 @@ pub(super) async fn sync(
         );
         envs.push((key, id.to_text()));
     }
-    let env_refs: Vec<(&str, &str)> = envs.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
-    execute(adapter, params.path.as_ref(), &env_refs, stdio).await?;
-    // Persistent stderr is a sync-plugin feature only; script steps don't
-    // currently retain any output past the rolling step view.
-    Ok(vec![])
+    envs
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(display("script sync step failed"))]
+pub struct ScriptRunError {
+    /// Boxed because the error depends on how the runner executes: the host
+    /// runner fails with a [`ScriptError`](super::super::script::ScriptError), a
+    /// runner that refuses scripts fails with something else entirely.
+    pub source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
+
+/// Executes resolved script sync steps.
+#[async_trait]
+pub trait ScriptRunner: Sync + Send {
+    /// Run a resolved script step, streaming output to `stdio`, and return any
+    /// stderr lines to retain past the streamed view.
+    async fn run_script(
+        &self,
+        invocation: ScriptInvocation,
+        stdio: Option<Sender<String>>,
+    ) -> Result<Vec<String>, ScriptRunError>;
+}
+
+/// The [`ScriptRunner`] that spawns each command as a host subprocess.
+pub struct HostScripts;
+
+#[async_trait]
+impl ScriptRunner for HostScripts {
+    async fn run_script(
+        &self,
+        invocation: ScriptInvocation,
+        stdio: Option<Sender<String>>,
+    ) -> Result<Vec<String>, ScriptRunError> {
+        let env_refs: Vec<(&str, &str)> = invocation
+            .env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        execute_commands(&invocation.commands, &invocation.cwd, &env_refs, stdio)
+            .await
+            .map_err(|source| ScriptRunError {
+                source: Box::new(source),
+            })?;
+        // Persistent stderr is a sync-plugin feature only; script steps don't
+        // currently retain any output past the rolling step view.
+        Ok(vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use candid::Principal;
+
+    use super::*;
+    use crate::manifest::adapter::script::CommandField;
+
+    fn principal(byte: u8) -> Principal {
+        Principal::from_slice(&[byte; 4])
+    }
+
+    fn params(canister_ids: &[(&str, Principal)]) -> Params {
+        Params {
+            path: "/work/backend".into(),
+            cid: principal(1),
+            environment: "production".to_owned(),
+            network: "ic".to_owned(),
+            canister_ids: canister_ids
+                .iter()
+                .map(|(n, p)| ((*n).to_owned(), *p))
+                .collect::<BTreeMap<_, _>>(),
+            proxy: None,
+        }
+    }
+
+    /// The environment, network and target canister id are always present.
+    #[test]
+    fn base_env_vars_are_always_set() {
+        let p = params(&[]);
+        assert_eq!(
+            system_env_vars(&p),
+            vec![
+                ("ICP_CLI_ENVIRONMENT".to_owned(), "production".to_owned()),
+                ("ICP_CLI_NETWORK".to_owned(), "ic".to_owned()),
+                ("ICP_CLI_CID".to_owned(), principal(1).to_text()),
+            ]
+        );
+    }
+
+    /// Each known canister gets an `ICP_CLI_CID_<NAME>` variable, with the name
+    /// uppercased and every non-alphanumeric byte replaced by `_` so the result
+    /// is a legal shell identifier.
+    #[test]
+    fn canister_names_are_normalized_into_env_var_keys() {
+        let p = params(&[("my-frontend", principal(2)), ("dep:api", principal(3))]);
+        let keys: Vec<String> = system_env_vars(&p)
+            .into_iter()
+            .map(|(k, _)| k)
+            .filter(|k| k.starts_with("ICP_CLI_CID_"))
+            .collect();
+        // `canister_ids` is a BTreeMap, so ordering follows the canister names.
+        assert_eq!(keys, vec!["ICP_CLI_CID_DEP_API", "ICP_CLI_CID_MY_FRONTEND"]);
+    }
+
+    /// Resolution takes the commands and cwd from the step and its canister, and
+    /// runs nothing.
+    #[test]
+    fn invocation_resolves_commands_and_cwd() {
+        let adapter = Adapter {
+            command: CommandField::Commands(vec!["first".to_owned(), "second".to_owned()]),
+        };
+        let invocation = ScriptInvocation::new(&adapter, &params(&[]));
+
+        assert_eq!(invocation.commands, vec!["first", "second"]);
+        assert_eq!(invocation.cwd, PathBuf::from("/work/backend"));
+        assert_eq!(invocation.env, system_env_vars(&params(&[])));
+    }
+
+    /// The host runner passes the resolved environment through to the subprocess.
+    #[tokio::test]
+    async fn host_runner_applies_the_resolved_environment() {
+        let out = camino_tempfile::NamedUtf8TempFile::new().unwrap();
+        let invocation = ScriptInvocation {
+            commands: vec![format!("printenv ICP_CLI_NETWORK > '{}'", out.path())],
+            cwd: "/".into(),
+            env: system_env_vars(&params(&[])),
+        };
+
+        HostScripts.run_script(invocation, None).await.unwrap();
+
+        assert_eq!(std::fs::read_to_string(out.path()).unwrap(), "ic\n");
+    }
+
+    /// A command that exits non-zero surfaces as a `ScriptRunError` whose source
+    /// still names the command and its status, so the `caused by:` line the CLI
+    /// prints stays specific.
+    #[tokio::test]
+    async fn host_runner_reports_a_failing_command() {
+        let invocation = ScriptInvocation {
+            commands: vec!["exit 3".to_owned()],
+            cwd: "/".into(),
+            env: vec![],
+        };
+
+        let err = HostScripts
+            .run_script(invocation, None)
+            .await
+            .expect_err("a non-zero exit must fail the step");
+
+        assert_eq!(err.to_string(), "script sync step failed");
+        assert_eq!(
+            std::error::Error::source(&err).expect("cause").to_string(),
+            "command 'exit 3' failed with status code 3"
+        );
+    }
 }

--- a/crates/icp/src/canister/sync/script.rs
+++ b/crates/icp/src/canister/sync/script.rs
@@ -24,14 +24,18 @@ use super::Params;
 use super::super::script::execute_commands;
 
 /// A fully-resolved script sync step: the command(s), the working directory, and
-/// the complete environment the subprocess runs with (see [`system_env_vars`]).
+/// the environment variables to set for them (see [`system_env_vars`]).
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScriptInvocation {
     /// Shell command(s) to run in order.
     pub commands: Vec<String>,
     /// Working directory (the canister directory).
     pub cwd: PathBuf,
-    /// Environment variables the subprocess inherits, in insertion order.
+    /// Environment variables a runner **adds to** its execution environment, in
+    /// insertion order — not the complete environment. [`HostScripts`] overlays
+    /// them onto the inherited process environment, so the script still sees
+    /// ambient variables such as `PATH` and `HOME`; entries here win on a name
+    /// collision. A runner is not expected to clear what it inherits.
     pub env: Vec<(String, String)>,
 }
 
@@ -121,10 +125,17 @@ impl ScriptRunner for HostScripts {
 mod tests {
     use std::collections::BTreeMap;
 
+    use tokio::sync::Mutex;
+
     use candid::Principal;
 
     use super::*;
     use crate::manifest::adapter::script::CommandField;
+
+    /// Serializes the tests here that mutate the process environment, since
+    /// cargo runs tests in parallel threads. Async-aware because the variable
+    /// has to stay set across the subprocess `await` that reads it.
+    static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
 
     fn principal(byte: u8) -> Principal {
         Principal::from_slice(&[byte; 4])
@@ -200,6 +211,56 @@ mod tests {
         HostScripts.run_script(invocation, None).await.unwrap();
 
         assert_eq!(std::fs::read_to_string(out.path()).unwrap(), "ic\n");
+    }
+
+    /// `env` is an overlay, not the whole environment: the script still sees
+    /// variables the parent process had. Pins the contract documented on
+    /// [`ScriptInvocation::env`].
+    ///
+    /// Deliberately avoids two things that are not portable across the shells
+    /// this runs under. `printenv` accepts only one operand on BSD (macOS) and
+    /// so silently drops later names, hence one `echo` — a shell builtin
+    /// everywhere — per variable. And the inherited variable is one this test
+    /// sets rather than `PATH`, because Git-for-Windows bash rewrites `PATH`
+    /// into POSIX form, so its value there never equals the `PATH` the Rust side
+    /// reads.
+    #[tokio::test]
+    async fn host_runner_overlays_rather_than_replaces_the_environment() {
+        const AMBIENT: &str = "ICP_CLI_TEST_AMBIENT_VAR";
+        const AMBIENT_VALUE: &str = "inherited-from-parent";
+
+        let _guard = ENV_MUTEX.lock().await;
+        // SAFETY: ENV_MUTEX serializes the tests in this module that mutate the
+        // process environment, and the name is used by this test alone.
+        unsafe { std::env::set_var(AMBIENT, AMBIENT_VALUE) };
+
+        let overlaid = camino_tempfile::NamedUtf8TempFile::new().unwrap();
+        let inherited = camino_tempfile::NamedUtf8TempFile::new().unwrap();
+        let invocation = ScriptInvocation {
+            commands: vec![
+                format!("echo \"$ICP_CLI_NETWORK\" > '{}'", overlaid.path()),
+                format!("echo \"${AMBIENT}\" > '{}'", inherited.path()),
+            ],
+            cwd: "/".into(),
+            env: system_env_vars(&params(&[])),
+        };
+
+        let run = HostScripts.run_script(invocation, None).await;
+
+        // SAFETY: as above; the guard is still held.
+        unsafe { std::env::remove_var(AMBIENT) };
+        run.expect("script must run");
+
+        assert_eq!(
+            std::fs::read_to_string(overlaid.path()).unwrap().trim(),
+            "ic",
+            "the overlaid variable must be set"
+        );
+        assert_eq!(
+            std::fs::read_to_string(inherited.path()).unwrap().trim(),
+            AMBIENT_VALUE,
+            "a variable the parent process had must still reach the script"
+        );
     }
 
     /// A command that exits non-zero surfaces as a `ScriptRunError` whose source

--- a/crates/icp/src/context/init.rs
+++ b/crates/icp/src/context/init.rs
@@ -99,7 +99,7 @@ pub fn initialize(
     let builder = Arc::new(Builder);
 
     // Canister syncer
-    let syncer = Arc::new(Syncer);
+    let syncer = Arc::new(Syncer::host());
 
     // Project loader
     let pload = ProjectLoadImpl {


### PR DESCRIPTION
Salvaged from draft PR 660 (`spofford/deploylib`), **originally authored by Adam Spofford**.
That branch is being superseded for architectural reasons, but two of its splits stand on
their own. This is the second. It is re-executed on current `main` rather than cherry-picked,
since the branch is 33 commits behind; the branch's file layout and module docstrings were
used as the specification.

## What this changes

Sync has two kinds of step. Plugin steps already run inside the wasmtime WASI sandbox;
script steps must spawn a shell. Because script execution was reached directly, the whole
sync path inherited that requirement — and the part of a script step that is pure data
(which commands, in which directory, with which `ICP_CLI_*` variables) was inline,
untestable code in the middle of it.

- **`ScriptInvocation::new(adapter, params)`** resolves a manifest script step into commands,
  cwd and environment, running nothing. `system_env_vars` is now a named function, and the
  canister-name-to-env-key normalization it does (uppercase, non-alphanumerics to `_`) is
  tested rather than assumed.
- **`ScriptRunner`** executes a resolved invocation. `HostScripts` is the implementation that
  spawns subprocesses, injected into `Syncer` by `Syncer::host()` — what `icp sync` and
  `icp deploy` use. An environment without subprocesses can substitute a runner that refuses
  script steps instead of losing the sync path entirely.
- **`script::execute_commands`** takes resolved `&[String]` commands, so the subprocess
  executor no longer needs to know about manifest types. `script::execute` stays as the
  adapter-taking wrapper the build path uses.

The seam also makes step dispatch testable: a recording `ScriptRunner` now asserts that a
script step arrives fully resolved, with no shell involved.

## One user-visible change

A failing script step now reports `script sync step failed` with the specific failure on the
following `caused by:` line, matching how plugin step failures already read. There is a test
asserting exactly that chain, so the claim is verified rather than assumed.

`icp-cli` is untouched — the seam is internal to `icp`.

## Scope note

This carries only the seam. The branch's `NoScripts` refuse-everything implementation is not
included: nothing on `main` calls it, and adding unused surface is the specific thing that
made the superseded branch hard to justify. It is ~12 lines for whoever needs it.

## Validation

`cargo build`, `cargo fmt --check` and `cargo clippy --workspace --all-targets` are clean
with zero warnings. `cargo test --workspace`: 38 targets pass. The 7 failures
(`identity_link_hsm*`, `canister_snapshot_{download,upload}_resume`) are environmental —
they need SoftHSM2 and mitmproxy, and fail identically on unmodified `main`.

## Review notes

This is independent of the `Resolve` fetch/render salvage PR — different code, no shared
commits, both based on `main`. Either can be reviewed, merged or reverted without the other.
