### PR TITLE
refactor: give operations a task vocabulary of their own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,8 +3777,8 @@ dependencies = [
 name = "icp-events"
 version = "1.3.0"
 dependencies = [
- "candid",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/icp-cli/src/commands/canister/snapshot/download.rs
+++ b/crates/icp-cli/src/commands/canister/snapshot/download.rs
@@ -5,7 +5,7 @@ use icp::context::Context;
 use icp::prelude::*;
 use tracing::info;
 
-use icp_events::{TaskKind, TransferBlob, TransferDirection};
+use icp::operations::task::{Task, TransferBlob, TransferDirection};
 
 use super::SnapshotId;
 use crate::commands::args;
@@ -126,12 +126,12 @@ pub(crate) async fn exec(ctx: &Context, args: &DownloadArgs) -> Result<(), anyho
                 if !progress.wasm_module.is_complete(metadata.wasm_module_size) {
                     rendered_task(
                         ctx.debug,
-                        TaskKind::SnapshotTransfer {
-                            canister: name.to_string(),
-                            direction: TransferDirection::Download,
-                            blob: TransferBlob::WasmModule,
-                            total_bytes: metadata.wasm_module_size,
-                        },
+                        Task::snapshot_transfer(
+                            name.to_string(),
+                            TransferDirection::Download,
+                            TransferBlob::WasmModule,
+                            metadata.wasm_module_size,
+                        ),
                         async |task| {
                             download_blob_to_file(
                                 &agent,
@@ -158,12 +158,12 @@ pub(crate) async fn exec(ctx: &Context, args: &DownloadArgs) -> Result<(), anyho
                 if !progress.wasm_memory.is_complete(metadata.wasm_memory_size) {
                     rendered_task(
                         ctx.debug,
-                        TaskKind::SnapshotTransfer {
-                            canister: name.to_string(),
-                            direction: TransferDirection::Download,
-                            blob: TransferBlob::WasmMemory,
-                            total_bytes: metadata.wasm_memory_size,
-                        },
+                        Task::snapshot_transfer(
+                            name.to_string(),
+                            TransferDirection::Download,
+                            TransferBlob::WasmMemory,
+                            metadata.wasm_memory_size,
+                        ),
                         async |task| {
                             download_blob_to_file(
                                 &agent,
@@ -193,12 +193,12 @@ pub(crate) async fn exec(ctx: &Context, args: &DownloadArgs) -> Result<(), anyho
                 {
                     rendered_task(
                         ctx.debug,
-                        TaskKind::SnapshotTransfer {
-                            canister: name.to_string(),
-                            direction: TransferDirection::Download,
-                            blob: TransferBlob::StableMemory,
-                            total_bytes: metadata.stable_memory_size,
-                        },
+                        Task::snapshot_transfer(
+                            name.to_string(),
+                            TransferDirection::Download,
+                            TransferBlob::StableMemory,
+                            metadata.stable_memory_size,
+                        ),
                         async |task| {
                             download_blob_to_file(
                                 &agent,

--- a/crates/icp-cli/src/commands/canister/snapshot/upload.rs
+++ b/crates/icp-cli/src/commands/canister/snapshot/upload.rs
@@ -8,7 +8,7 @@ use icp::prelude::*;
 use serde::Serialize;
 use tracing::info;
 
-use icp_events::{TaskKind, TransferBlob, TransferDirection};
+use icp::operations::task::{Task, TransferBlob, TransferDirection};
 
 use super::SnapshotId;
 use crate::commands::args;
@@ -131,12 +131,12 @@ pub(crate) async fn exec(ctx: &Context, args: &UploadArgs) -> Result<(), anyhow:
                 if progress.wasm_module_offset < metadata.wasm_module_size {
                     rendered_task(
                         ctx.debug,
-                        TaskKind::SnapshotTransfer {
-                            canister: name.to_string(),
-                            direction: TransferDirection::Upload,
-                            blob: TransferBlob::WasmModule,
-                            total_bytes: metadata.wasm_module_size,
-                        },
+                        Task::snapshot_transfer(
+                            name.to_string(),
+                            TransferDirection::Upload,
+                            TransferBlob::WasmModule,
+                            metadata.wasm_module_size,
+                        ),
                         async |task| {
                             upload_blob_from_file(
                                 &agent,
@@ -162,12 +162,12 @@ pub(crate) async fn exec(ctx: &Context, args: &UploadArgs) -> Result<(), anyhow:
                 if progress.wasm_memory_offset < metadata.wasm_memory_size {
                     rendered_task(
                         ctx.debug,
-                        TaskKind::SnapshotTransfer {
-                            canister: name.to_string(),
-                            direction: TransferDirection::Upload,
-                            blob: TransferBlob::WasmMemory,
-                            total_bytes: metadata.wasm_memory_size,
-                        },
+                        Task::snapshot_transfer(
+                            name.to_string(),
+                            TransferDirection::Upload,
+                            TransferBlob::WasmMemory,
+                            metadata.wasm_memory_size,
+                        ),
                         async |task| {
                             upload_blob_from_file(
                                 &agent,
@@ -193,12 +193,12 @@ pub(crate) async fn exec(ctx: &Context, args: &UploadArgs) -> Result<(), anyhow:
                 if progress.stable_memory_offset < metadata.stable_memory_size {
                     rendered_task(
                         ctx.debug,
-                        TaskKind::SnapshotTransfer {
-                            canister: name.to_string(),
-                            direction: TransferDirection::Upload,
-                            blob: TransferBlob::StableMemory,
-                            total_bytes: metadata.stable_memory_size,
-                        },
+                        Task::snapshot_transfer(
+                            name.to_string(),
+                            TransferDirection::Upload,
+                            TransferBlob::StableMemory,
+                            metadata.stable_memory_size,
+                        ),
                         async |task| {
                             upload_blob_from_file(
                                 &agent,

--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -5,6 +5,7 @@ use clap_complete::ArgValueCandidates;
 use futures::{StreamExt, future::try_join_all, stream::FuturesOrdered};
 use ic_agent::{Agent, AgentError};
 use ic_management_canister_types::{CanisterId, CanisterIdRecord};
+use icp::operations::task::Task;
 use icp::parsers::CyclesAmount;
 use icp::{
     context::{CanisterSelection, Context, EnvironmentSelection},
@@ -12,7 +13,7 @@ use icp::{
     network::Configuration as NetworkConfiguration,
 };
 use icp_canister_interfaces::candid_ui::MAINNET_CANDID_UI_CID;
-use icp_events::{TaskKind, TaskOutcome};
+use icp_events::TaskOutcome;
 use itertools::Itertools;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -239,9 +240,7 @@ pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), anyhow:
         rendered(ctx.debug, async |reporter| {
             let mut futs = FuturesOrdered::new();
             for name in canisters_to_create.iter() {
-                let task = reporter.task(TaskKind::Create {
-                    canister: (*name).clone(),
-                });
+                let task = reporter.task(Task::create((*name).clone()));
                 let create_op = create_operation.clone();
                 let (_, canister_info) = env.get_canister_info(name).map_err(|e| anyhow!(e))?;
                 futs.push_back(async move {

--- a/crates/icp-cli/src/render/interactive.rs
+++ b/crates/icp-cli/src/render/interactive.rs
@@ -1,10 +1,10 @@
-//! Live progress-bar renderer: one indicatif spinner per task, a rolling
+//! Live progress-bar renderer: one indicatif widget per task, a rolling
 //! window of the current step's output beneath it, and a ✔/✘ finish state.
 //! Failed tasks replay their captured output once the stream ends.
 
 use std::{collections::BTreeMap, time::Duration};
 
-use icp_events::{Event, EventKind, TaskId, TaskKind, TaskOutcome};
+use icp_events::{EventKind, TaskId, TaskOutcome};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use tracing::debug;
@@ -12,10 +12,9 @@ use tracing::debug;
 use super::style::{
     COLOR_FAILURE, COLOR_REGULAR, COLOR_SUCCESS, TICK_EMPTY, TICK_FAILURE, TICK_SUCCESS, make_style,
 };
-use super::{
-    RollingLines, TaskLog, dump_failures, failure_message, step_header, success_message,
-    transfer_label,
-};
+use icp::operations::task::{Event, Widget};
+
+use super::{RollingLines, TaskLog, dump_failures};
 
 /// Number of output lines shown live under a task's progress bar.
 const LIVE_WINDOW_LINES: usize = 4;
@@ -50,24 +49,26 @@ impl InteractiveRenderer {
     pub(crate) fn handle(&mut self, event: Event) {
         match event.kind {
             EventKind::TaskStarted { task } => {
+                let presentation = task.presentation();
                 // Bars are configured fully before insertion: adding to the
-                // MultiProgress can draw the initial frame, and it must not
-                // appear unstyled or unlabeled.
-                let bar = match &task {
-                    // Quantifiable transfers get a byte bar instead of a
-                    // spinner, labeled by the blob rather than the canister.
-                    TaskKind::SnapshotTransfer {
-                        blob, total_bytes, ..
-                    } => self.multi_progress.add(
-                        ProgressBar::new(*total_bytes)
+                // MultiProgress switches the draw target, and `set_style`
+                // adapts a style to stderr only while the bar is still
+                // detached.
+                let bar = match presentation.widget() {
+                    // Quantifiable work gets a determinate byte bar, labeled
+                    // by the blob rather than the canister.
+                    Widget::Bytes { label, total } => self.multi_progress.add(
+                        ProgressBar::new(total)
                             .with_style(transfer_style())
-                            .with_prefix(transfer_label(blob)),
+                            .with_prefix(label),
                     ),
-                    _ => {
+                    // The bracket decoration is this renderer's convention,
+                    // matching the captured-output and failure-dump prefixes.
+                    Widget::Indeterminate { label } => {
                         let mut bar = ProgressBar::new_spinner()
                             .with_style(make_style(TICK_EMPTY, COLOR_REGULAR))
-                            .with_prefix(format!("[{}]", task.canister()));
-                        if let Some(message) = super::running_message(&task) {
+                            .with_prefix(format!("[{label}]"));
+                        if let Some(message) = presentation.running_message() {
                             bar = bar.with_message(message);
                         }
                         let bar = self.multi_progress.add(bar);
@@ -102,7 +103,7 @@ impl InteractiveRenderer {
                 let Some(view) = self.tasks.get_mut(&event.task_id) else {
                     return;
                 };
-                view.header = step_header(view.log.kind(), number, total, &label);
+                view.header = view.log.presentation().step_header(number, total, &label);
                 view.headline = view
                     .header
                     .lines()
@@ -133,7 +134,7 @@ impl InteractiveRenderer {
                     return;
                 };
 
-                debug!("[{}] {line}", view.log.kind().canister());
+                debug!("[{}] {line}", view.log.presentation().canister());
 
                 view.window.push(line.clone());
                 view.log.push_line(line);
@@ -158,27 +159,22 @@ impl InteractiveRenderer {
                     return;
                 };
 
-                // A transfer's byte bar has no message or tick slot; it just
-                // freezes at its final position.
-                if matches!(view.log.kind(), TaskKind::SnapshotTransfer { .. }) {
-                    view.bar.finish();
-                    if let TaskOutcome::Failed { message, causes } = outcome {
-                        view.log.fail(message, causes);
-                    }
-                    return;
-                }
-
                 match outcome {
                     TaskOutcome::Succeeded { retained_output } => {
-                        view.bar.set_style(make_style(TICK_SUCCESS, COLOR_SUCCESS));
-                        view.bar.set_message(success_message(view.log.kind()));
+                        // A byte bar has no message or tick slot, so it just
+                        // freezes at its final position.
+                        if let Some(message) = view.log.presentation().success_message() {
+                            view.bar.set_style(make_style(TICK_SUCCESS, COLOR_SUCCESS));
+                            view.bar.set_message(message);
+                        }
                         view.bar.finish();
-                        super::print_retained(view.log.kind(), &retained_output);
+                        super::print_retained(view.log.task(), &retained_output);
                     }
                     TaskOutcome::Failed { message, causes } => {
-                        view.bar.set_style(make_style(TICK_FAILURE, COLOR_FAILURE));
-                        view.bar
-                            .set_message(failure_message(view.log.kind(), &message));
+                        if let Some(rendered) = view.log.presentation().failure_message(&message) {
+                            view.bar.set_style(make_style(TICK_FAILURE, COLOR_FAILURE));
+                            view.bar.set_message(rendered);
+                        }
                         view.bar.finish();
                         view.log.fail(message, causes);
                     }

--- a/crates/icp-cli/src/render/mod.rs
+++ b/crates/icp-cli/src/render/mod.rs
@@ -1,14 +1,20 @@
 //! Presentation layer for [`icp_events`] streams.
 //!
-//! Operations emit typed events through a [`icp_events::Reporter`]; a
-//! [`Renderer`] consumes the stream and owns everything user-facing: wording,
-//! progress bars, and the deferred failure dumps. Commands pick a renderer
-//! with [`Renderer::for_ctx`] and drive it with [`Renderer::run`] alongside
-//! the operation.
+//! Operations emit typed events through a [`Reporter`]; a [`Renderer`]
+//! consumes the stream and owns everything user-facing: wording, progress
+//! bars, and the deferred failure dumps. Commands pick a renderer with
+//! [`Renderer::for_ctx`] and drive it with [`Renderer::run`] alongside the
+//! operation.
+//!
+//! `icp_events` is generic over the task payload and knows nothing about what
+//! is being run; the vocabulary comes from [`icp::operations::task`], where
+//! each kind of work describes itself. What lives here is only how those
+//! descriptions are drawn on a terminal.
 
 use std::collections::{BTreeMap, VecDeque};
 
-use icp_events::{Event, Reporter, TaskId, TaskKind, TaskOutcome, TaskReporter, TransferBlob};
+use icp::operations::task::{Failure, Presentation, Task};
+use icp_events::{TaskId, TaskOutcome};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::error;
 
@@ -20,6 +26,8 @@ mod style;
 pub(crate) use interactive::InteractiveRenderer;
 pub(crate) use plain::PlainRenderer;
 pub(crate) use spinner::{ProgressManager, ProgressManagerSettings};
+
+use icp::operations::task::{Event, Reporter, TaskReporter};
 
 /// The maximum number of lines to display for a step output
 const MAX_LINES_PER_STEP: usize = 10_000;
@@ -77,16 +85,16 @@ pub(crate) async fn rendered<T>(debug: bool, op: impl AsyncFnOnce(&Reporter) -> 
     result
 }
 
-/// Run a single task under its own renderer: starts a task of `kind`, hands
-/// its reporter to `op`, and finishes the task from the result before the
+/// Run a single task under its own renderer: starts `task`, hands its
+/// reporter to `op`, and finishes the task from the result before the
 /// renderer flushes.
 pub(crate) async fn rendered_task<T, E: std::fmt::Display>(
     debug: bool,
-    kind: TaskKind,
+    task: Task,
     op: impl AsyncFnOnce(&TaskReporter) -> Result<T, E>,
 ) -> Result<T, E> {
     rendered(debug, async |reporter| {
-        let task = reporter.task(kind);
+        let task = reporter.task(task);
         let result = op(&task).await;
 
         match &result {
@@ -99,143 +107,18 @@ pub(crate) async fn rendered_task<T, E: std::fmt::Display>(
     .await
 }
 
-// Wording for each task kind. Events carry data; these helpers own the words.
-
-/// Message shown while a task runs, before any step reports in. Multi-step
-/// tasks (build, sync) have none — their step headers take over.
-fn running_message(kind: &TaskKind) -> Option<&'static str> {
-    match kind {
-        // Build and sync step headers take over; a transfer's byte bar has no
-        // message slot at all.
-        TaskKind::Build { .. } | TaskKind::Sync { .. } | TaskKind::SnapshotTransfer { .. } => None,
-        TaskKind::Create { .. } => Some("Creating..."),
-        TaskKind::Install { .. } => Some("Installing..."),
-        TaskKind::UpdateSettings { .. } => Some("Updating canister settings..."),
-        TaskKind::UpdateEnvironmentVariables { .. } => Some("Updating environment variables..."),
-        TaskKind::CandidCheck { .. } => Some("Checking compatibility..."),
-    }
-}
-
-/// Prefix label for a snapshot-transfer byte bar.
-fn transfer_label(blob: &TransferBlob) -> &'static str {
-    match blob {
-        TransferBlob::WasmModule => "WASM module",
-        TransferBlob::WasmMemory => "WASM memory",
-        TransferBlob::StableMemory => "Stable memory",
-    }
-}
-
-/// Live header shown while a step runs, e.g. "Building: step 1 of 3 (script)…".
-/// `label` may span multiple lines.
-fn step_header(kind: &TaskKind, number: usize, total: usize, label: &str) -> String {
-    match kind {
-        TaskKind::Sync { .. } => format!("\nSyncing: {label} {number} of {total}"),
-        // Only build and sync report steps; a generic header for the rest.
-        _ => format!("Building: step {number} of {total} {label}"),
-    }
-}
-
-/// Label for the captured-output header, e.g. "[name] Build output:".
-fn output_label(kind: &TaskKind) -> &'static str {
-    match kind {
-        TaskKind::Sync { .. } => "Sync",
-        // Only build and sync capture step output; a generic label for the rest.
-        _ => "Build",
-    }
-}
-
-/// Final progress-bar message for a task that succeeded.
-fn success_message(kind: &TaskKind) -> String {
-    match kind {
-        TaskKind::Build { .. } => "Built successfully".to_owned(),
-        TaskKind::Sync { canister_id, .. } => format!("Synced successfully: {canister_id}"),
-        TaskKind::Create { .. } => "Created successfully".to_owned(),
-        TaskKind::Install { .. } => "Installed successfully".to_owned(),
-        TaskKind::UpdateSettings { .. } => "Canister settings updated successfully".to_owned(),
-        TaskKind::UpdateEnvironmentVariables { .. } => {
-            "Environment variables updated successfully".to_owned()
-        }
-        TaskKind::CandidCheck { .. } => "Compatible".to_owned(),
-        // A transfer's byte bar has no message slot; nothing to show.
-        TaskKind::SnapshotTransfer { .. } => "done".to_owned(),
-    }
-}
-
-/// Final progress-bar message for a task that failed.
-fn failure_message(kind: &TaskKind, message: &str) -> String {
-    match kind {
-        TaskKind::Build { .. } => format!("Failed to build canister: {message}"),
-        TaskKind::Sync { .. } => format!("Failed to sync canister: {message}"),
-        // Create failures surface through the command's returned error; the
-        // bar shows the bare message.
-        TaskKind::Create { .. } => message.to_owned(),
-        TaskKind::Install { .. } => format!("Failed to install canister: {message}"),
-        TaskKind::UpdateSettings { .. } => {
-            format!("Failed to update canister settings: {message}")
-        }
-        TaskKind::UpdateEnvironmentVariables { .. } => {
-            format!("Failed to update environment variables: {message}")
-        }
-        TaskKind::CandidCheck { .. } => "Incompatible".to_owned(),
-        // Transfer failures surface through the command's returned error.
-        TaskKind::SnapshotTransfer { .. } => message.to_owned(),
-    }
-}
-
-/// First line of a task's failure dump, or `None` for kinds that don't get a
-/// deferred dump (their failure travels on the command's returned error).
-fn failure_header(kind: &TaskKind) -> Option<String> {
-    match kind {
-        TaskKind::Build { canister } => {
-            Some(format!("----- Failed to build canister '{canister}' -----"))
-        }
-        TaskKind::Sync {
-            canister,
-            canister_id,
-        } => Some(format!(
-            "----- Failed to sync canister '{canister}': {canister_id} -----"
-        )),
-        TaskKind::Create { .. } => None,
-        TaskKind::Install {
-            canister,
-            canister_id,
-        } => Some(format!(
-            "----- Failed to install canister '{canister}': {canister_id} -----"
-        )),
-        TaskKind::UpdateSettings {
-            canister,
-            canister_id,
-        } => Some(format!(
-            "----- Failed to update settings for canister '{canister}': {canister_id} -----"
-        )),
-        TaskKind::UpdateEnvironmentVariables {
-            canister,
-            canister_id,
-        } => Some(format!(
-            "----- Failed to update environment variables for canister '{canister}': {canister_id} -----"
-        )),
-        TaskKind::CandidCheck {
-            canister,
-            canister_id,
-        } => Some(format!(
-            " ----- Candid interface compatibility check failed: '{canister}' ({canister_id}) -----"
-        )),
-        TaskKind::SnapshotTransfer { .. } => None,
-    }
-}
-
 /// Print output lines a task retained past its rolling step view (e.g.
 /// sync-plugin stderr), prefixed with the canister name.
-fn print_retained(kind: &TaskKind, lines: &[String]) {
+fn print_retained(task: &Task, lines: &[String]) {
     for line in lines {
-        eprintln!("[{}] {line}", kind.canister());
+        eprintln!("[{}] {line}", task.presentation().canister());
     }
 }
 
 /// Captured output of one task, kept so a failure can be replayed after the
 /// live view is gone.
 pub(super) struct TaskLog {
-    kind: TaskKind,
+    task: Task,
     finished_steps: Vec<StepLog>,
     current_step: Option<StepLog>,
     failure: Option<Failure>,
@@ -244,11 +127,6 @@ pub(super) struct TaskLog {
 struct StepLog {
     title: String,
     lines: RollingLines,
-}
-
-struct Failure {
-    message: String,
-    causes: Vec<String>,
 }
 
 /// A fixed-capacity rolling buffer that always holds the last `capacity` items.
@@ -286,17 +164,21 @@ impl RollingLines {
 }
 
 impl TaskLog {
-    fn new(kind: TaskKind) -> Self {
+    fn new(task: Task) -> Self {
         Self {
-            kind,
+            task,
             finished_steps: Vec::new(),
             current_step: None,
             failure: None,
         }
     }
 
-    fn kind(&self) -> &TaskKind {
-        &self.kind
+    fn task(&self) -> &Task {
+        &self.task
+    }
+
+    fn presentation(&self) -> &dyn Presentation {
+        self.task.presentation()
     }
 
     fn start_step(&mut self, title: String) {
@@ -333,10 +215,13 @@ impl TaskLog {
             return Vec::new();
         }
 
-        let name = self.kind.canister();
+        let name = self.presentation().canister();
         let mut lines = Vec::new();
 
-        lines.push(format!("[{name}] {} output:", output_label(&self.kind)));
+        lines.push(format!(
+            "[{name}] {} output:",
+            self.presentation().output_label()
+        ));
 
         let steps: &[StepLog] = if all_steps {
             &self.finished_steps
@@ -366,40 +251,31 @@ impl TaskLog {
 }
 
 /// Print the failure dump for every failed task, in task-creation order.
+/// A task whose failure the caller could have proceeded past gets the CLI's
+/// wording for how to do that, once, at the end.
 fn dump_failures(logs: &BTreeMap<TaskId, TaskLog>, all_steps: bool) {
-    let mut candid_failures = false;
+    let mut bypassable = false;
 
     for log in logs.values() {
         let Some(failure) = &log.failure else {
             continue;
         };
-        let Some(header) = failure_header(&log.kind) else {
+        let presentation = log.presentation();
+        let Some(dump) = presentation.failure_dump(failure) else {
             continue;
         };
 
-        error!("{header}");
-        match &log.kind {
-            TaskKind::CandidCheck { .. } => {
-                candid_failures = true;
-                error!(
-                    "You are making a BREAKING change. Other canisters or frontend clients \
-                     relying on your canister may stop working.\n\n{}",
-                    failure.message,
-                );
-            }
-            _ => {
-                error!("'{}'", failure.message);
-                for cause in &failure.causes {
-                    error!("  caused by: {cause}");
-                }
-            }
+        for line in dump {
+            error!("{line}");
         }
         for line in log.dump(all_steps) {
             error!("{line}");
         }
+
+        bypassable |= presentation.failure_is_bypassable();
     }
 
-    if candid_failures {
+    if bypassable {
         error!("Use --yes to bypass this check.");
     }
 }

--- a/crates/icp-cli/src/render/plain.rs
+++ b/crates/icp-cli/src/render/plain.rs
@@ -4,10 +4,12 @@
 
 use std::collections::BTreeMap;
 
-use icp_events::{Event, EventKind, TaskId, TaskOutcome};
+use icp_events::{EventKind, TaskId, TaskOutcome};
 use tracing::debug;
 
-use super::{TaskLog, dump_failures, step_header};
+use icp::operations::task::Event;
+
+use super::{TaskLog, dump_failures};
 
 pub(crate) struct PlainRenderer {
     tasks: BTreeMap<TaskId, TaskLog>,
@@ -34,7 +36,7 @@ impl PlainRenderer {
                 let Some(log) = self.tasks.get_mut(&event.task_id) else {
                     return;
                 };
-                let header = step_header(log.kind(), number, total, &label);
+                let header = log.presentation().step_header(number, total, &label);
                 log.start_step(header);
             }
 
@@ -44,7 +46,7 @@ impl PlainRenderer {
                 };
                 // Mark command boundaries so interleaved output stays
                 // attributable to the command producing it.
-                debug!("[{}] $ {command}", log.kind().canister());
+                debug!("[{}] $ {command}", log.presentation().canister());
             }
 
             EventKind::Output { line, .. } => {
@@ -53,7 +55,7 @@ impl PlainRenderer {
                 };
                 // Prefix with the canister so interleaved concurrent tasks
                 // stay attributable.
-                debug!("[{}] {line}", log.kind().canister());
+                debug!("[{}] {line}", log.presentation().canister());
                 log.push_line(line);
             }
 
@@ -72,7 +74,7 @@ impl PlainRenderer {
                 };
                 match outcome {
                     TaskOutcome::Succeeded { retained_output } => {
-                        super::print_retained(log.kind(), &retained_output);
+                        super::print_retained(log.task(), &retained_output);
                     }
                     TaskOutcome::Failed { message, causes } => {
                         log.fail(message, causes);

--- a/crates/icp-events/Cargo.toml
+++ b/crates/icp-events/Cargo.toml
@@ -6,6 +6,9 @@ license = { workspace = true }
 publish.workspace = true
 
 [dependencies]
-candid = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/icp-events/src/lib.rs
+++ b/crates/icp-events/src/lib.rs
@@ -1,45 +1,56 @@
 //! Typed progress events passed from operations to the presentation layer.
 //!
-//! Operations (and the core library underneath them) emit [`Event`]s through
-//! cheap-to-clone reporter handles ([`Reporter`] → [`TaskReporter`] →
-//! [`StepReporter`]); the CLI's renderers consume the event stream and decide
-//! how to display it. Events carry data, not prose — wording, layout, and
-//! color are the renderer's job.
+//! Operations emit [`Event`]s through cheap-to-clone reporter handles
+//! ([`Reporter`] → [`TaskReporter`] → [`StepReporter`]); a consumer reads the
+//! event stream and decides how to display it. Events carry data, not prose —
+//! wording, layout, and color belong to the consumer.
+//!
+//! The crate is deliberately ignorant of *what* a task is. [`Event`] is
+//! generic over a task payload `T` supplied by the caller, so the vocabulary
+//! of operations (build, sync, install, …) lives with the code that renders
+//! it rather than here. [`StepReporter`], by contrast, is **not** generic: it
+//! erases `T` behind [`StepSink`] so that ports in the core library — which
+//! are stored as `Arc<dyn Build>` / `Arc<dyn Synchronize>` — can accept one
+//! without naming the consumer's task type.
 //!
 //! Sends never block and never fail: the channel is unbounded, and with no
 //! receiver events are simply dropped, so tests and headless callers get
 //! silence for free. Errors do not travel on this stream — an operation's
 //! `Result` remains the source of truth; [`TaskOutcome::Failed`] exists only
-//! so a renderer can paint the failure state.
+//! so a consumer can paint the failure state.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
-use candid::Principal;
 use serde::Serialize;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
-/// Identifies one task (one canister-level unit of work) within an event
-/// stream. Ids are assigned in task-creation order, so renderers can use them
-/// to present tasks in a stable order regardless of completion order.
+/// Identifies one task (one unit of work) within an event stream. Ids are
+/// assigned in task-creation order, so consumers can use them to present
+/// tasks in a stable order regardless of completion order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct TaskId(u64);
 
 #[derive(Debug, Clone, Serialize)]
-pub struct Event {
+pub struct Event<T> {
     pub task_id: TaskId,
     #[serde(flatten)]
-    pub kind: EventKind,
+    pub kind: EventKind<T>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
-pub enum EventKind {
-    /// The task began. Emitted once per task, before any of its steps.
-    TaskStarted { task: TaskKind },
+pub enum EventKind<T> {
+    /// The task began. Emitted once per task, before any of its steps. `task`
+    /// is the caller's own description of the work — this crate never
+    /// inspects it.
+    TaskStarted { task: T },
 
     /// A step of the task began. Steps within a task are sequential;
     /// `number` is 1-based. `label` describes the step (it may span
@@ -51,16 +62,15 @@ pub enum EventKind {
     },
 
     /// A shell command within the task's current step began executing.
-    /// Script steps run their commands in order; renderers can use this to
+    /// Script steps run their commands in order; consumers can use this to
     /// attribute the output that follows to the command producing it.
     CommandStarted { command: String },
 
     /// One line of output produced while the task's current step runs.
     Output { stream: OutputStream, line: String },
 
-    /// How far a quantifiable task has come, in the unit its [`TaskKind`]
-    /// declares (e.g. bytes out of [`TaskKind::SnapshotTransfer`]'s
-    /// `total_bytes`).
+    /// How far a quantifiable task has come, in whatever unit its task
+    /// payload declares (e.g. bytes).
     Progress { position: u64 },
 
     /// The task's current step finished.
@@ -70,79 +80,8 @@ pub enum EventKind {
     TaskCompleted { outcome: TaskOutcome },
 }
 
-/// What a task is doing, and to which canister.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum TaskKind {
-    Build {
-        canister: String,
-    },
-    Sync {
-        canister: String,
-        canister_id: Principal,
-    },
-    Create {
-        canister: String,
-    },
-    Install {
-        canister: String,
-        canister_id: Principal,
-    },
-    UpdateSettings {
-        canister: String,
-        canister_id: Principal,
-    },
-    UpdateEnvironmentVariables {
-        canister: String,
-        canister_id: Principal,
-    },
-    CandidCheck {
-        canister: String,
-        canister_id: Principal,
-    },
-    SnapshotTransfer {
-        canister: String,
-        direction: TransferDirection,
-        blob: TransferBlob,
-        total_bytes: u64,
-    },
-}
-
-impl TaskKind {
-    /// The canister this task operates on.
-    pub fn canister(&self) -> &str {
-        match self {
-            TaskKind::Build { canister }
-            | TaskKind::Sync { canister, .. }
-            | TaskKind::Create { canister }
-            | TaskKind::Install { canister, .. }
-            | TaskKind::UpdateSettings { canister, .. }
-            | TaskKind::UpdateEnvironmentVariables { canister, .. }
-            | TaskKind::CandidCheck { canister, .. }
-            | TaskKind::SnapshotTransfer { canister, .. } => canister,
-        }
-    }
-}
-
-/// Which way a snapshot blob is moving relative to the local machine.
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TransferDirection {
-    Upload,
-    Download,
-}
-
-/// The snapshot blob being transferred.
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TransferBlob {
-    WasmModule,
-    WasmMemory,
-    StableMemory,
-}
-
 /// Where an output line came from.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputStream {
     Stdout,
@@ -151,7 +90,7 @@ pub enum OutputStream {
     Info,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StepOutcome {
     Succeeded,
@@ -163,8 +102,8 @@ pub enum StepOutcome {
 pub enum TaskOutcome {
     Succeeded {
         /// Output lines that belong on the persistent output channel after
-        /// success — e.g. sync-plugin stderr, which the rolling step view
-        /// would otherwise discard. Most tasks retain nothing.
+        /// success — e.g. sync-plugin stderr, which a rolling step view would
+        /// otherwise discard. Most tasks retain nothing.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         retained_output: Vec<String>,
     },
@@ -198,23 +137,9 @@ impl TaskOutcome {
     }
 }
 
-/// Create a lone [`StepReporter`] wired to its own receiver, for callers that
-/// need to observe a single step's output without the task/step ceremony —
-/// primarily tests.
-pub fn step_channel() -> (StepReporter, UnboundedReceiver<Event>) {
-    let (tx, rx) = unbounded_channel();
-    (
-        StepReporter {
-            tx: Some(tx),
-            task_id: TaskId(0),
-        },
-        rx,
-    )
-}
-
 /// Create a connected reporter/receiver pair. The receiver yields `None` once
 /// the reporter and every handle derived from it have been dropped.
-pub fn channel() -> (Reporter, UnboundedReceiver<Event>) {
+pub fn channel<T: Send + 'static>() -> (Reporter<T>, UnboundedReceiver<Event<T>>) {
     let (tx, rx) = unbounded_channel();
     let reporter = Reporter {
         inner: Some(ReporterInner {
@@ -225,26 +150,63 @@ pub fn channel() -> (Reporter, UnboundedReceiver<Event>) {
     (reporter, rx)
 }
 
-/// Entry point handed to an operation; spawns [`TaskReporter`]s.
-#[derive(Debug, Clone)]
-pub struct Reporter {
-    inner: Option<ReporterInner>,
+/// Create a lone [`StepReporter`] wired to its own receiver, for callers that
+/// need to observe a single step's output without the task/step ceremony —
+/// primarily tests. The task payload type is never constructed, so it is
+/// usually left as `()`.
+pub fn step_channel<T: Send + 'static>() -> (StepReporter, UnboundedReceiver<Event<T>>) {
+    let (tx, rx) = unbounded_channel();
+    let sink = TaskSink {
+        tx,
+        task_id: TaskId(0),
+    };
+    (
+        StepReporter {
+            sink: Some(Arc::new(sink)),
+        },
+        rx,
+    )
 }
 
-#[derive(Debug, Clone)]
-struct ReporterInner {
-    tx: UnboundedSender<Event>,
+/// Entry point handed to an operation; spawns [`TaskReporter`]s.
+pub struct Reporter<T> {
+    inner: Option<ReporterInner<T>>,
+}
+
+struct ReporterInner<T> {
+    tx: UnboundedSender<Event<T>>,
     next_task_id: Arc<AtomicU64>,
 }
 
-impl Reporter {
+// Hand-written so cloning a reporter does not require the task payload to be
+// `Clone` — only the channel handle is duplicated.
+impl<T> Clone for ReporterInner<T> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            next_task_id: self.next_task_id.clone(),
+        }
+    }
+}
+
+impl<T> Clone for Reporter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> Reporter<T> {
     /// A reporter whose events go nowhere.
     pub fn null() -> Self {
         Self { inner: None }
     }
+}
 
+impl<T: Send + 'static> Reporter<T> {
     /// Begin a task, emitting [`EventKind::TaskStarted`].
-    pub fn task(&self, task: TaskKind) -> TaskReporter {
+    pub fn task(&self, task: T) -> TaskReporter<T> {
         let Some(inner) = &self.inner else {
             return TaskReporter::null();
         };
@@ -261,13 +223,21 @@ impl Reporter {
 }
 
 /// Reports the lifecycle of one task.
-#[derive(Debug, Clone)]
-pub struct TaskReporter {
-    tx: Option<UnboundedSender<Event>>,
+pub struct TaskReporter<T> {
+    tx: Option<UnboundedSender<Event<T>>>,
     task_id: TaskId,
 }
 
-impl TaskReporter {
+impl<T> Clone for TaskReporter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            task_id: self.task_id,
+        }
+    }
+}
+
+impl<T> TaskReporter<T> {
     /// A task reporter whose events go nowhere.
     pub fn null() -> Self {
         Self {
@@ -276,7 +246,7 @@ impl TaskReporter {
         }
     }
 
-    fn send(&self, kind: EventKind) {
+    fn send(&self, kind: EventKind<T>) {
         if let Some(tx) = &self.tx {
             let _ = tx.send(Event {
                 task_id: self.task_id,
@@ -285,22 +255,8 @@ impl TaskReporter {
         }
     }
 
-    /// Begin the task's next step, emitting [`EventKind::StepStarted`].
-    /// `number` is 1-based.
-    pub fn step(&self, number: usize, total: usize, label: impl Into<String>) -> StepReporter {
-        self.send(EventKind::StepStarted {
-            number,
-            total,
-            label: label.into(),
-        });
-        StepReporter {
-            tx: self.tx.clone(),
-            task_id: self.task_id,
-        }
-    }
-
     /// Report how far the task has come, emitting [`EventKind::Progress`].
-    /// The unit is whatever the task's [`TaskKind`] declares.
+    /// The unit is whatever the task payload declares.
     pub fn progress(&self, position: u64) {
         self.send(EventKind::Progress { position });
     }
@@ -312,45 +268,102 @@ impl TaskReporter {
     }
 }
 
-/// Reports output produced during one step of a task.
-#[derive(Debug, Clone)]
-pub struct StepReporter {
-    tx: Option<UnboundedSender<Event>>,
+impl<T: Send + 'static> TaskReporter<T> {
+    /// Begin the task's next step, emitting [`EventKind::StepStarted`].
+    /// `number` is 1-based.
+    ///
+    /// The returned handle has the task payload type erased, so it can be
+    /// passed to code that must not know the task vocabulary.
+    pub fn step(&self, number: usize, total: usize, label: impl Into<String>) -> StepReporter {
+        self.send(EventKind::StepStarted {
+            number,
+            total,
+            label: label.into(),
+        });
+        StepReporter {
+            sink: self.tx.clone().map(|tx| {
+                Arc::new(TaskSink {
+                    tx,
+                    task_id: self.task_id,
+                }) as Arc<dyn StepSink>
+            }),
+        }
+    }
+}
+
+/// The step-scoped half of an event sink, with the task payload type erased.
+///
+/// This is the whole reason [`StepReporter`] is not generic: the core
+/// library's ports take a step reporter but must not name the task
+/// vocabulary, and they are held as trait objects (`Arc<dyn Build>`), which
+/// rules out threading a type parameter through them.
+trait StepSink: Send + Sync {
+    fn command_started(&self, command: String);
+    fn output(&self, stream: OutputStream, line: String);
+    fn step_completed(&self, outcome: StepOutcome);
+}
+
+struct TaskSink<T> {
+    tx: UnboundedSender<Event<T>>,
     task_id: TaskId,
+}
+
+impl<T: Send + 'static> StepSink for TaskSink<T> {
+    fn command_started(&self, command: String) {
+        let _ = self.tx.send(Event {
+            task_id: self.task_id,
+            kind: EventKind::CommandStarted { command },
+        });
+    }
+
+    fn output(&self, stream: OutputStream, line: String) {
+        let _ = self.tx.send(Event {
+            task_id: self.task_id,
+            kind: EventKind::Output { stream, line },
+        });
+    }
+
+    fn step_completed(&self, outcome: StepOutcome) {
+        let _ = self.tx.send(Event {
+            task_id: self.task_id,
+            kind: EventKind::StepCompleted { outcome },
+        });
+    }
+}
+
+/// Reports output produced during one step of a task.
+#[derive(Clone)]
+pub struct StepReporter {
+    sink: Option<Arc<dyn StepSink>>,
+}
+
+impl fmt::Debug for StepReporter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StepReporter")
+            .field("connected", &self.sink.is_some())
+            .finish()
+    }
 }
 
 impl StepReporter {
     /// A step reporter whose events go nowhere.
     pub fn null() -> Self {
-        Self {
-            tx: None,
-            task_id: TaskId(0),
-        }
-    }
-
-    fn send(&self, kind: EventKind) {
-        if let Some(tx) = &self.tx {
-            let _ = tx.send(Event {
-                task_id: self.task_id,
-                kind,
-            });
-        }
+        Self { sink: None }
     }
 
     /// Report that a shell command within the step began executing, emitting
     /// [`EventKind::CommandStarted`].
     pub fn command(&self, command: impl Into<String>) {
-        self.send(EventKind::CommandStarted {
-            command: command.into(),
-        });
+        if let Some(sink) = &self.sink {
+            sink.command_started(command.into());
+        }
     }
 
     /// Emit one line of output.
     pub fn output(&self, stream: OutputStream, line: impl Into<String>) {
-        self.send(EventKind::Output {
-            stream,
-            line: line.into(),
-        });
+        if let Some(sink) = &self.sink {
+            sink.output(stream, line.into());
+        }
     }
 
     /// Emit one line of tool stdout.
@@ -370,6 +383,268 @@ impl StepReporter {
 
     /// Finish the step, emitting [`EventKind::StepCompleted`].
     pub fn done(&self, outcome: StepOutcome) {
-        self.send(EventKind::StepCompleted { outcome });
+        if let Some(sink) = &self.sink {
+            sink.step_completed(outcome);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stand-in task payload. Real callers use their own vocabulary; this
+    /// crate only ever moves it across the channel.
+    #[derive(Debug, Clone, Serialize)]
+    #[serde(tag = "kind", rename = "demo")]
+    struct DemoTask {
+        name: String,
+    }
+
+    fn demo(name: &str) -> DemoTask {
+        DemoTask {
+            name: name.to_owned(),
+        }
+    }
+
+    fn drain<T>(rx: &mut UnboundedReceiver<Event<T>>) -> Vec<Event<T>> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn null_reporters_emit_nothing_and_never_panic() {
+        let reporter: Reporter<DemoTask> = Reporter::null();
+        let task = reporter.task(demo("a"));
+        let step = task.step(1, 1, "only");
+
+        // Every method must be safe to call with no receiver attached.
+        step.command("echo hi");
+        step.stdout("out");
+        step.stderr("err");
+        step.info("note");
+        step.done(StepOutcome::Succeeded);
+        task.progress(42);
+        task.finish(TaskOutcome::succeeded());
+
+        // Handles derived from a null reporter are themselves null.
+        assert!(TaskReporter::<DemoTask>::null().tx.is_none());
+        assert!(StepReporter::null().sink.is_none());
+    }
+
+    #[tokio::test]
+    async fn task_ids_follow_creation_order() {
+        let (reporter, mut rx) = channel::<DemoTask>();
+        let first = reporter.task(demo("a"));
+        let second = reporter.task(demo("b"));
+        let third = reporter.task(demo("c"));
+
+        // Finishing out of order must not disturb the ids.
+        third.finish(TaskOutcome::succeeded());
+        first.finish(TaskOutcome::succeeded());
+        second.finish(TaskOutcome::succeeded());
+
+        let started: Vec<TaskId> = drain(&mut rx)
+            .into_iter()
+            .filter(|e| matches!(e.kind, EventKind::TaskStarted { .. }))
+            .map(|e| e.task_id)
+            .collect();
+        assert_eq!(started, vec![TaskId(0), TaskId(1), TaskId(2)]);
+    }
+
+    #[tokio::test]
+    async fn events_arrive_in_emission_order_and_carry_their_task_id() {
+        let (reporter, mut rx) = channel::<DemoTask>();
+        let task = reporter.task(demo("a"));
+        let step = task.step(1, 2, "compile");
+        step.command("make");
+        step.stdout("line one");
+        step.stderr("line two");
+        step.done(StepOutcome::Succeeded);
+        task.finish(TaskOutcome::succeeded());
+
+        let events = drain(&mut rx);
+        assert!(events.iter().all(|e| e.task_id == TaskId(0)));
+
+        let shape: Vec<String> = events
+            .iter()
+            .map(|e| match &e.kind {
+                EventKind::TaskStarted { .. } => "started".to_owned(),
+                EventKind::StepStarted {
+                    number,
+                    total,
+                    label,
+                } => {
+                    format!("step {number}/{total} {label}")
+                }
+                EventKind::CommandStarted { command } => format!("$ {command}"),
+                EventKind::Output { stream, line } => format!("{stream:?} {line}"),
+                EventKind::Progress { position } => format!("progress {position}"),
+                EventKind::StepCompleted { .. } => "step done".to_owned(),
+                EventKind::TaskCompleted { .. } => "task done".to_owned(),
+            })
+            .collect();
+        assert_eq!(
+            shape,
+            vec![
+                "started",
+                "step 1/2 compile",
+                "$ make",
+                "Stdout line one",
+                "Stderr line two",
+                "step done",
+                "task done",
+            ]
+        );
+    }
+
+    /// A step reporter keeps its own channel handle, so output emitted after
+    /// the task reporter is gone still arrives. This is what makes the
+    /// spawned stdout/stderr readers in the core library safe.
+    #[tokio::test]
+    async fn step_reporter_outlives_its_task_reporter() {
+        let (reporter, mut rx) = channel::<DemoTask>();
+        let step = {
+            let task = reporter.task(demo("a"));
+            task.step(1, 1, "run")
+        };
+        step.stdout("after the task handle dropped");
+
+        let lines: Vec<String> = drain(&mut rx)
+            .into_iter()
+            .filter_map(|e| match e.kind {
+                EventKind::Output { line, .. } => Some(line),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(lines, vec!["after the task handle dropped".to_owned()]);
+    }
+
+    /// The receiver must close once every handle is gone, otherwise a
+    /// consumer driving the stream to completion would hang.
+    #[tokio::test]
+    async fn stream_closes_when_all_handles_drop() {
+        let (reporter, mut rx) = channel::<DemoTask>();
+        let task = reporter.task(demo("a"));
+        let step = task.step(1, 1, "run");
+
+        drop(reporter);
+        drop(task);
+        assert!(rx.recv().await.is_some(), "buffered events still deliver");
+
+        drop(step);
+        while rx.recv().await.is_some() {}
+        // Reaching here means recv() returned None rather than hanging.
+    }
+
+    /// The `--json` renderer planned in #493 depends on this wire format, so
+    /// the tags and field names are pinned here rather than left to chance.
+    /// The task payload's own shape is the caller's business and is asserted
+    /// where that payload is defined.
+    #[test]
+    fn event_wire_format_is_stable() {
+        let event = |kind| {
+            serde_json::to_value(Event {
+                task_id: TaskId(7),
+                kind,
+            })
+            .expect("event should serialize")
+        };
+
+        assert_eq!(
+            event(EventKind::TaskStarted { task: demo("a") }),
+            serde_json::json!({
+                "task_id": 7, "event": "task_started",
+                // The payload nests under `task`; its inner shape is the
+                // caller's to define.
+                "task": { "kind": "demo", "name": "a" },
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::StepStarted {
+                number: 1,
+                total: 3,
+                label: "compile".to_owned(),
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "step_started",
+                "number": 1, "total": 3, "label": "compile",
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::CommandStarted {
+                command: "make build".to_owned(),
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "command_started", "command": "make build",
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::Output {
+                stream: OutputStream::Stderr,
+                line: "boom".to_owned(),
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "output", "stream": "stderr", "line": "boom",
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::Progress { position: 1024 }),
+            serde_json::json!({ "task_id": 7, "event": "progress", "position": 1024 })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::StepCompleted {
+                outcome: StepOutcome::Failed,
+            }),
+            serde_json::json!({ "task_id": 7, "event": "step_completed", "outcome": "failed" })
+        );
+
+        // Task outcomes nest under `outcome`, internally tagged by `result`.
+        assert_eq!(
+            event(EventKind::<DemoTask>::TaskCompleted {
+                outcome: TaskOutcome::succeeded(),
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "task_completed",
+                "outcome": { "result": "succeeded" },
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::TaskCompleted {
+                outcome: TaskOutcome::Succeeded {
+                    retained_output: vec!["kept".to_owned()],
+                },
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "task_completed",
+                "outcome": { "result": "succeeded", "retained_output": ["kept"] },
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::TaskCompleted {
+                outcome: TaskOutcome::Failed {
+                    message: "no".to_owned(),
+                    causes: vec!["because".to_owned()],
+                },
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "task_completed",
+                "outcome": { "result": "failed", "message": "no", "causes": ["because"] },
+            })
+        );
+        assert_eq!(
+            event(EventKind::<DemoTask>::TaskCompleted {
+                outcome: TaskOutcome::Skipped {
+                    reason: "not an upgrade".to_owned(),
+                },
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "task_completed",
+                "outcome": { "result": "skipped", "reason": "not an upgrade" },
+            })
+        );
     }
 }

--- a/crates/icp-sync-plugin/src/runtime.rs
+++ b/crates/icp-sync-plugin/src/runtime.rs
@@ -765,7 +765,7 @@ mod tests {
 
     /// Drain the emitted output events into (stream, line) pairs.
     fn output_lines(
-        rx: &mut tokio::sync::mpsc::UnboundedReceiver<icp_events::Event>,
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<icp_events::Event<()>>,
     ) -> Vec<(EventStream, String)> {
         let mut lines = Vec::new();
         while let Ok(event) = rx.try_recv() {
@@ -781,7 +781,8 @@ mod tests {
         let Some(wasm_path) = option_env!("TEST_PLUGIN_WASM") else {
             return;
         };
-        let (reporter, mut rx) = icp_events::step_channel();
+        // The task payload type is irrelevant here: only step output is observed.
+        let (reporter, mut rx) = icp_events::step_channel::<()>();
         let result = tokio::task::block_in_place(|| {
             run_plugin(
                 wasm_path.into(),
@@ -813,7 +814,8 @@ mod tests {
         let Some(wasm_path) = option_env!("TEST_PLUGIN_WASM") else {
             return;
         };
-        let (reporter, mut rx) = icp_events::step_channel();
+        // The task payload type is irrelevant here: only step output is observed.
+        let (reporter, mut rx) = icp_events::step_channel::<()>();
         let result = tokio::task::block_in_place(|| {
             run_plugin(
                 wasm_path.into(),

--- a/crates/icp/src/operations/binding_env_vars.rs
+++ b/crates/icp/src/operations/binding_env_vars.rs
@@ -4,7 +4,9 @@ use crate::Canister;
 use futures::{StreamExt, stream::FuturesOrdered};
 use ic_agent::{Agent, export::Principal};
 use ic_management_canister_types::{CanisterSettings, EnvironmentVariable, UpdateSettingsArgs};
-use icp_events::{Reporter, TaskKind, TaskOutcome};
+use icp_events::TaskOutcome;
+
+use crate::operations::task::{Reporter, Task};
 use snafu::Snafu;
 use tracing::error;
 
@@ -111,10 +113,7 @@ pub async fn set_binding_env_vars_many(
     let mut futs = FuturesOrdered::new();
 
     for (cid, info) in target_canisters {
-        let task = reporter.task(TaskKind::UpdateEnvironmentVariables {
-            canister: info.name.clone(),
-            canister_id: cid,
-        });
+        let task = reporter.task(Task::update_environment_variables(info.name.clone(), cid));
 
         // Each canister receives only the ids it is wired to (its own project's
         // canisters by their local names, plus any declared dependencies under

--- a/crates/icp/src/operations/build.rs
+++ b/crates/icp/src/operations/build.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 use camino_tempfile::tempdir;
 use futures::{StreamExt, stream::FuturesOrdered};
-use icp_events::{Reporter, StepOutcome, TaskKind, TaskOutcome, TaskReporter};
+use icp_events::{StepOutcome, TaskOutcome};
+
+use crate::operations::task::{Reporter, Task, TaskReporter};
 use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Snafu)]
@@ -99,9 +101,7 @@ pub async fn build_many(
     let mut futs = FuturesOrdered::new();
 
     for (canister_path, canister) in canisters {
-        let task = reporter.task(TaskKind::Build {
-            canister: canister.name.clone(),
-        });
+        let task = reporter.task(Task::build(canister.name.clone()));
         let builder = builder.clone();
         let artifacts = artifacts.clone();
 

--- a/crates/icp/src/operations/bundle.rs
+++ b/crates/icp/src/operations/bundle.rs
@@ -28,7 +28,9 @@ use flate2::{Compression, write::GzEncoder};
 use snafu::{OptionExt, ResultExt, Snafu};
 use tar::Builder;
 
-use icp_events::{Reporter, StepReporter};
+use icp_events::StepReporter;
+
+use crate::operations::task::Reporter;
 
 use crate::operations::build::{BuildManyError, build_many};
 

--- a/crates/icp/src/operations/candid_compat.rs
+++ b/crates/icp/src/operations/candid_compat.rs
@@ -8,7 +8,9 @@ use candid_parser::utils::CandidSource;
 use futures::{StreamExt, stream::FuturesOrdered};
 use ic_agent::Agent;
 use ic_management_canister_types::CanisterInstallMode;
-use icp_events::{Reporter, TaskKind, TaskOutcome};
+use icp_events::TaskOutcome;
+
+use crate::operations::task::{Reporter, Task};
 use snafu::Snafu;
 use tracing::debug;
 
@@ -25,10 +27,7 @@ pub async fn check_candid_compatibility_many(
     let mut check_futs = FuturesOrdered::new();
 
     for (name, cid, mode) in canisters {
-        let task = reporter.task(TaskKind::CandidCheck {
-            canister: name.to_owned(),
-            canister_id: cid,
-        });
+        let task = reporter.task(Task::candid_check(name, cid));
         let is_upgrade = matches!(mode, CanisterInstallMode::Upgrade(_));
         let agent = agent.clone();
         let artifacts = artifacts.clone();

--- a/crates/icp/src/operations/install.rs
+++ b/crates/icp/src/operations/install.rs
@@ -6,7 +6,9 @@ use ic_management_canister_types::{
     ClearChunkStoreArgs, InstallChunkedCodeArgs, InstallCodeArgs, UpgradeFlags, UploadChunkArgs,
     WasmMemoryPersistence,
 };
-use icp_events::{Reporter, TaskKind, TaskOutcome};
+use icp_events::TaskOutcome;
+
+use crate::operations::task::{Reporter, Task};
 use sha2::{Digest, Sha256};
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
@@ -361,10 +363,7 @@ pub async fn install_many(
     let mut futs = FuturesOrdered::new();
 
     for (name, cid, mode, status, init_args) in canisters {
-        let task = reporter.task(TaskKind::Install {
-            canister: name.clone(),
-            canister_id: cid,
-        });
+        let task = reporter.task(Task::install(name.clone(), cid));
         let agent = agent.clone();
         let artifacts = artifacts.clone();
 

--- a/crates/icp/src/operations/mod.rs
+++ b/crates/icp/src/operations/mod.rs
@@ -11,6 +11,7 @@ pub mod recover_cycles;
 pub mod settings;
 pub mod snapshot_transfer;
 pub mod sync;
+pub mod task;
 pub mod token;
 
 pub mod misc;

--- a/crates/icp/src/operations/settings.rs
+++ b/crates/icp/src/operations/settings.rs
@@ -15,7 +15,9 @@ use ic_agent::Agent;
 use ic_management_canister_types::{
     CanisterIdRecord, CanisterSettings, EnvironmentVariable, LogVisibility, UpdateSettingsArgs,
 };
-use icp_events::{Reporter, TaskKind, TaskOutcome};
+use icp_events::TaskOutcome;
+
+use crate::operations::task::{Reporter, Task};
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use snafu::{ResultExt, Snafu};
@@ -224,10 +226,7 @@ pub async fn sync_settings_many(
     let ids = Arc::new(ids);
 
     for (cid, info) in target_canisters {
-        let task = reporter.task(TaskKind::UpdateSettings {
-            canister: info.name.clone(),
-            canister_id: cid,
-        });
+        let task = reporter.task(Task::update_settings(info.name.clone(), cid));
         let agent = agent.clone();
         let ids = ids.clone();
 

--- a/crates/icp/src/operations/snapshot_transfer.rs
+++ b/crates/icp/src/operations/snapshot_transfer.rs
@@ -15,11 +15,11 @@ use ic_management_canister_types::{
 
 use super::proxy::UpdateOrProxyError;
 use super::proxy_management;
+use crate::operations::task::TaskReporter;
 use crate::{
     fs::lock::{DirectoryStructureLock, LWrite, LockError, PathsAccess},
     prelude::*,
 };
-use icp_events::TaskReporter;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tokio::{

--- a/crates/icp/src/operations/sync.rs
+++ b/crates/icp/src/operations/sync.rs
@@ -7,7 +7,9 @@ use crate::{
 use candid::Principal;
 use futures::{StreamExt, stream::FuturesOrdered};
 use ic_agent::Agent;
-use icp_events::{Reporter, StepOutcome, TaskKind, TaskOutcome, TaskReporter};
+use icp_events::{StepOutcome, TaskOutcome};
+
+use crate::operations::task::{Reporter, Task, TaskReporter};
 use snafu::prelude::*;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -93,10 +95,7 @@ pub async fn sync_many(
     let mut futs = FuturesOrdered::new();
 
     for (cid, canister_path, canister_info) in canisters {
-        let task = reporter.task(TaskKind::Sync {
-            canister: canister_info.name.clone(),
-            canister_id: cid,
-        });
+        let task = reporter.task(Task::sync(canister_info.name.clone(), cid));
 
         let fut = {
             let agent = agent.clone();

--- a/crates/icp/src/operations/task.rs
+++ b/crates/icp/src/operations/task.rs
@@ -1,0 +1,740 @@
+//! What a running operation is doing, and how it describes itself.
+//!
+//! Every kind of work the operations layer reports on is its own type
+//! implementing [`Presentation`], so everything a frontend needs to know about
+//! (say) a Candid check — its label while running, its success and failure
+//! lines, the shape of its failure report — lives in one impl block instead of
+//! being spread across one arm in each of half a dozen wording functions.
+//!
+//! This lives here rather than in a frontend because the operations construct
+//! it and every frontend needs it: a terminal renderer, a `--json` stream, and
+//! an in-browser caller would otherwise each re-invent the same descriptions.
+//! What stays with the frontend is how these are drawn — colors, bar
+//! templates, log decoration — and any wording naming a frontend's own
+//! affordances (see [`Presentation::failure_is_bypassable`]).
+//!
+//! [`Task`] is the serializable envelope that travels on the event stream.
+//! [`Task::presentation`] is the single dispatch point from envelope to
+//! behavior, and it is exhaustive, so a new task cannot be added without
+//! being wired up.
+
+use candid::Principal;
+use serde::Serialize;
+
+/// The event types instantiated for this crate's task vocabulary.
+/// Operations and frontends name these rather than repeating the
+/// task parameter.
+pub type Reporter = icp_events::Reporter<Task>;
+pub type TaskReporter = icp_events::TaskReporter<Task>;
+pub type Event = icp_events::Event<Task>;
+
+/// The shape of live progress a task can report. How this is drawn — and
+/// how the label is decorated — is the frontend's business.
+pub enum Widget {
+    /// Work of unknown duration, labeled by the canister it acts on.
+    Indeterminate { label: String },
+    /// Quantifiable work: `total` bytes, labeled by what is being moved.
+    Bytes { label: String, total: u64 },
+}
+
+/// Display data for a failed task, as carried by
+/// [`icp_events::TaskOutcome::Failed`]. The typed error stays on the
+/// operation's return path; this is only ever printed.
+pub struct Failure {
+    pub message: String,
+    pub causes: Vec<String>,
+}
+
+/// How one kind of task presents itself. Defaults cover the common case — a
+/// spinner-driven task that reports no steps — so most implementations only
+/// state what makes them different.
+pub trait Presentation {
+    /// The canister this task operates on. Used to prefix captured output.
+    fn canister(&self) -> &str;
+
+    /// The live widget this task drives.
+    fn widget(&self) -> Widget {
+        Widget::Indeterminate {
+            label: self.canister().to_owned(),
+        }
+    }
+
+    /// Message shown while the task runs, before any step reports in.
+    /// Step-reporting tasks return `None`: their step headers take over.
+    fn running_message(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Live header shown while a step runs. `label` may span multiple lines.
+    ///
+    /// Only tasks that actually report steps need to override this; the
+    /// default passes the label through rather than inventing a header for a
+    /// task that was never meant to have one.
+    fn step_header(&self, _number: usize, _total: usize, label: &str) -> String {
+        label.to_owned()
+    }
+
+    /// Label for the captured-output header, e.g. the "Build" in
+    /// `[name] Build output:`. Only reachable for tasks that report steps.
+    fn output_label(&self) -> &'static str {
+        "Output"
+    }
+
+    /// Final widget message on success, or `None` for a widget with no
+    /// message slot (a byte bar has none).
+    fn success_message(&self) -> Option<String>;
+
+    /// Final widget message on failure, or `None` as above.
+    fn failure_message(&self, message: &str) -> Option<String>;
+
+    /// First line of this task's deferred failure dump, or `None` for tasks
+    /// whose failure travels on the command's returned error instead.
+    fn failure_header(&self) -> Option<String> {
+        None
+    }
+
+    /// The deferred failure dump for this task, ahead of any captured step
+    /// output. `None` suppresses the dump entirely.
+    fn failure_dump(&self, failure: &Failure) -> Option<Vec<String>> {
+        let mut lines = vec![self.failure_header()?, format!("'{}'", failure.message)];
+        lines.extend(
+            failure
+                .causes
+                .iter()
+                .map(|cause| format!("  caused by: {cause}")),
+        );
+        Some(lines)
+    }
+
+    /// Whether this failure is one the caller could have chosen to proceed
+    /// through. Frontends use it to offer their own affordance for doing so
+    /// — a CLI flag, a confirmation dialog — which is why the wording for
+    /// that stays with the frontend rather than living here.
+    fn failure_is_bypassable(&self) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-step tasks
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "build")]
+pub struct BuildTask {
+    pub canister: String,
+}
+
+impl Presentation for BuildTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn step_header(&self, number: usize, total: usize, label: &str) -> String {
+        format!("Building: step {number} of {total} {label}")
+    }
+
+    fn output_label(&self) -> &'static str {
+        "Build"
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some("Built successfully".to_owned())
+    }
+
+    fn failure_message(&self, message: &str) -> Option<String> {
+        Some(format!("Failed to build canister: {message}"))
+    }
+
+    fn failure_header(&self) -> Option<String> {
+        Some(format!(
+            "----- Failed to build canister '{}' -----",
+            self.canister
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "sync")]
+pub struct SyncTask {
+    pub canister: String,
+    pub canister_id: Principal,
+}
+
+impl Presentation for SyncTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn step_header(&self, number: usize, total: usize, label: &str) -> String {
+        format!("\nSyncing: {label} {number} of {total}")
+    }
+
+    fn output_label(&self) -> &'static str {
+        "Sync"
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some(format!("Synced successfully: {}", self.canister_id))
+    }
+
+    fn failure_message(&self, message: &str) -> Option<String> {
+        Some(format!("Failed to sync canister: {message}"))
+    }
+
+    fn failure_header(&self) -> Option<String> {
+        Some(format!(
+            "----- Failed to sync canister '{}': {} -----",
+            self.canister, self.canister_id
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Single-action tasks
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "create")]
+pub struct CreateTask {
+    pub canister: String,
+}
+
+impl Presentation for CreateTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn running_message(&self) -> Option<&'static str> {
+        Some("Creating...")
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some("Created successfully".to_owned())
+    }
+
+    /// Create failures surface through the command's returned error, so the
+    /// bar shows the bare message and there is no deferred dump.
+    fn failure_message(&self, message: &str) -> Option<String> {
+        Some(message.to_owned())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "install")]
+pub struct InstallTask {
+    pub canister: String,
+    pub canister_id: Principal,
+}
+
+impl Presentation for InstallTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn running_message(&self) -> Option<&'static str> {
+        Some("Installing...")
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some("Installed successfully".to_owned())
+    }
+
+    fn failure_message(&self, message: &str) -> Option<String> {
+        Some(format!("Failed to install canister: {message}"))
+    }
+
+    fn failure_header(&self) -> Option<String> {
+        Some(format!(
+            "----- Failed to install canister '{}': {} -----",
+            self.canister, self.canister_id
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "update_settings")]
+pub struct UpdateSettingsTask {
+    pub canister: String,
+    pub canister_id: Principal,
+}
+
+impl Presentation for UpdateSettingsTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn running_message(&self) -> Option<&'static str> {
+        Some("Updating canister settings...")
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some("Canister settings updated successfully".to_owned())
+    }
+
+    fn failure_message(&self, message: &str) -> Option<String> {
+        Some(format!("Failed to update canister settings: {message}"))
+    }
+
+    fn failure_header(&self) -> Option<String> {
+        Some(format!(
+            "----- Failed to update settings for canister '{}': {} -----",
+            self.canister, self.canister_id
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "update_environment_variables")]
+pub struct UpdateEnvironmentVariablesTask {
+    pub canister: String,
+    pub canister_id: Principal,
+}
+
+impl Presentation for UpdateEnvironmentVariablesTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn running_message(&self) -> Option<&'static str> {
+        Some("Updating environment variables...")
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some("Environment variables updated successfully".to_owned())
+    }
+
+    fn failure_message(&self, message: &str) -> Option<String> {
+        Some(format!("Failed to update environment variables: {message}"))
+    }
+
+    fn failure_header(&self) -> Option<String> {
+        Some(format!(
+            "----- Failed to update environment variables for canister '{}': {} -----",
+            self.canister, self.canister_id
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "candid_check")]
+pub struct CandidCheckTask {
+    pub canister: String,
+    pub canister_id: Principal,
+}
+
+impl Presentation for CandidCheckTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn running_message(&self) -> Option<&'static str> {
+        Some("Checking compatibility...")
+    }
+
+    fn success_message(&self) -> Option<String> {
+        Some("Compatible".to_owned())
+    }
+
+    /// The incompatibility details ride on the failure message but are far
+    /// too long for a progress bar; the dump below prints them instead.
+    fn failure_message(&self, _message: &str) -> Option<String> {
+        Some("Incompatible".to_owned())
+    }
+
+    fn failure_header(&self) -> Option<String> {
+        Some(format!(
+            " ----- Candid interface compatibility check failed: '{}' ({}) -----",
+            self.canister, self.canister_id
+        ))
+    }
+
+    /// A breaking change gets its own wording, and no cause chain: the
+    /// message is the rendered incompatibility report.
+    fn failure_dump(&self, failure: &Failure) -> Option<Vec<String>> {
+        Some(vec![
+            self.failure_header()?,
+            format!(
+                "You are making a BREAKING change. Other canisters or frontend clients \
+                 relying on your canister may stop working.\n\n{}",
+                failure.message,
+            ),
+        ])
+    }
+
+    fn failure_is_bypassable(&self) -> bool {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Byte transfers
+// ---------------------------------------------------------------------------
+
+/// Which way a snapshot blob is moving relative to the local machine.
+/// Carried for the benefit of the event stream; the terminal renderers label
+/// transfers by blob alone.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirection {
+    Upload,
+    Download,
+}
+
+/// The snapshot blob being transferred.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferBlob {
+    WasmModule,
+    WasmMemory,
+    StableMemory,
+}
+
+impl TransferBlob {
+    fn label(self) -> &'static str {
+        match self {
+            TransferBlob::WasmModule => "WASM module",
+            TransferBlob::WasmMemory => "WASM memory",
+            TransferBlob::StableMemory => "Stable memory",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "snapshot_transfer")]
+pub struct SnapshotTransferTask {
+    pub canister: String,
+    pub direction: TransferDirection,
+    pub blob: TransferBlob,
+    pub total_bytes: u64,
+}
+
+impl Presentation for SnapshotTransferTask {
+    fn canister(&self) -> &str {
+        &self.canister
+    }
+
+    fn widget(&self) -> Widget {
+        Widget::Bytes {
+            label: self.blob.label().to_owned(),
+            total: self.total_bytes,
+        }
+    }
+
+    /// A byte bar's template has no message slot, so there is nothing to say
+    /// on either outcome — it simply freezes at its final position. Transfer
+    /// failures surface through the command's returned error.
+    fn success_message(&self) -> Option<String> {
+        None
+    }
+
+    fn failure_message(&self, _message: &str) -> Option<String> {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+/// One unit of work the CLI reports on. This is the payload carried by
+/// `icp_events::EventKind::TaskStarted`.
+///
+/// `untagged` defers to each task's own internally-tagged representation, so
+/// a build serializes as `{"kind":"build","canister":"..."}`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum Task {
+    Build(BuildTask),
+    Sync(SyncTask),
+    Create(CreateTask),
+    Install(InstallTask),
+    UpdateSettings(UpdateSettingsTask),
+    UpdateEnvironmentVariables(UpdateEnvironmentVariablesTask),
+    CandidCheck(CandidCheckTask),
+    SnapshotTransfer(SnapshotTransferTask),
+}
+
+impl Task {
+    /// The one dispatch point from the serializable envelope to the
+    /// per-task presentation rules.
+    pub fn presentation(&self) -> &dyn Presentation {
+        match self {
+            Task::Build(task) => task,
+            Task::Sync(task) => task,
+            Task::Create(task) => task,
+            Task::Install(task) => task,
+            Task::UpdateSettings(task) => task,
+            Task::UpdateEnvironmentVariables(task) => task,
+            Task::CandidCheck(task) => task,
+            Task::SnapshotTransfer(task) => task,
+        }
+    }
+
+    pub fn build(canister: impl Into<String>) -> Self {
+        Task::Build(BuildTask {
+            canister: canister.into(),
+        })
+    }
+
+    pub fn sync(canister: impl Into<String>, canister_id: Principal) -> Self {
+        Task::Sync(SyncTask {
+            canister: canister.into(),
+            canister_id,
+        })
+    }
+
+    pub fn create(canister: impl Into<String>) -> Self {
+        Task::Create(CreateTask {
+            canister: canister.into(),
+        })
+    }
+
+    pub fn install(canister: impl Into<String>, canister_id: Principal) -> Self {
+        Task::Install(InstallTask {
+            canister: canister.into(),
+            canister_id,
+        })
+    }
+
+    pub fn update_settings(canister: impl Into<String>, canister_id: Principal) -> Self {
+        Task::UpdateSettings(UpdateSettingsTask {
+            canister: canister.into(),
+            canister_id,
+        })
+    }
+
+    pub fn update_environment_variables(
+        canister: impl Into<String>,
+        canister_id: Principal,
+    ) -> Self {
+        Task::UpdateEnvironmentVariables(UpdateEnvironmentVariablesTask {
+            canister: canister.into(),
+            canister_id,
+        })
+    }
+
+    pub fn candid_check(canister: impl Into<String>, canister_id: Principal) -> Self {
+        Task::CandidCheck(CandidCheckTask {
+            canister: canister.into(),
+            canister_id,
+        })
+    }
+
+    pub fn snapshot_transfer(
+        canister: impl Into<String>,
+        direction: TransferDirection,
+        blob: TransferBlob,
+        total_bytes: u64,
+    ) -> Self {
+        Task::SnapshotTransfer(SnapshotTransferTask {
+            canister: canister.into(),
+            direction,
+            blob,
+            total_bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cid() -> Principal {
+        Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap()
+    }
+
+    /// The task payload is the one part of the event stream whose shape this
+    /// crate owns, and the `--json` renderer planned in #493 will publish it.
+    /// Each variant serializes as its own internally-tagged object, so the
+    /// envelope adds no nesting of its own.
+    #[test]
+    fn task_wire_format_is_stable() {
+        let json = |task: Task| serde_json::to_value(task).expect("task should serialize");
+
+        assert_eq!(
+            json(Task::build("frontend")),
+            serde_json::json!({ "kind": "build", "canister": "frontend" })
+        );
+        assert_eq!(
+            json(Task::sync("frontend", cid())),
+            serde_json::json!({
+                "kind": "sync", "canister": "frontend",
+                "canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+            })
+        );
+        assert_eq!(
+            json(Task::create("frontend")),
+            serde_json::json!({ "kind": "create", "canister": "frontend" })
+        );
+        assert_eq!(
+            json(Task::install("frontend", cid())),
+            serde_json::json!({
+                "kind": "install", "canister": "frontend",
+                "canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+            })
+        );
+        assert_eq!(
+            json(Task::update_settings("frontend", cid())),
+            serde_json::json!({
+                "kind": "update_settings", "canister": "frontend",
+                "canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+            })
+        );
+        assert_eq!(
+            json(Task::update_environment_variables("frontend", cid())),
+            serde_json::json!({
+                "kind": "update_environment_variables", "canister": "frontend",
+                "canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+            })
+        );
+        assert_eq!(
+            json(Task::candid_check("frontend", cid())),
+            serde_json::json!({
+                "kind": "candid_check", "canister": "frontend",
+                "canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+            })
+        );
+        assert_eq!(
+            json(Task::snapshot_transfer(
+                "frontend",
+                TransferDirection::Download,
+                TransferBlob::StableMemory,
+                4096,
+            )),
+            serde_json::json!({
+                "kind": "snapshot_transfer", "canister": "frontend",
+                "direction": "download", "blob": "stable_memory", "total_bytes": 4096,
+            })
+        );
+    }
+
+    /// Every task must be reachable through the envelope's dispatch, and must
+    /// agree with it on which canister it is about.
+    #[test]
+    fn every_task_dispatches_to_its_own_presentation() {
+        let tasks = [
+            Task::build("c"),
+            Task::sync("c", cid()),
+            Task::create("c"),
+            Task::install("c", cid()),
+            Task::update_settings("c", cid()),
+            Task::update_environment_variables("c", cid()),
+            Task::candid_check("c", cid()),
+            Task::snapshot_transfer("c", TransferDirection::Upload, TransferBlob::WasmModule, 1),
+        ];
+
+        for task in &tasks {
+            assert_eq!(task.presentation().canister(), "c");
+        }
+    }
+
+    /// Only the two multi-step kinds render step headers and captured-output
+    /// labels; the rest never report steps, so they keep the neutral default
+    /// rather than borrowing the build wording.
+    #[test]
+    fn step_wording_belongs_to_the_multi_step_kinds() {
+        let build = Task::build("c");
+        assert_eq!(
+            build.presentation().step_header(1, 3, "script"),
+            "Building: step 1 of 3 script"
+        );
+        assert_eq!(build.presentation().output_label(), "Build");
+
+        let sync = Task::sync("c", cid());
+        assert_eq!(
+            sync.presentation().step_header(2, 4, "asset"),
+            "\nSyncing: asset 2 of 4"
+        );
+        assert_eq!(sync.presentation().output_label(), "Sync");
+
+        let install = Task::install("c", cid());
+        assert_eq!(install.presentation().step_header(1, 1, "unused"), "unused");
+        assert_eq!(install.presentation().output_label(), "Output");
+    }
+
+    /// A byte bar has no message slot, which is how the renderer knows to
+    /// leave the bar alone on completion instead of stamping a tick on it.
+    #[test]
+    fn byte_transfers_have_no_completion_message() {
+        let transfer =
+            Task::snapshot_transfer("c", TransferDirection::Upload, TransferBlob::WasmMemory, 8);
+        assert!(transfer.presentation().success_message().is_none());
+        assert!(transfer.presentation().failure_message("boom").is_none());
+        assert!(transfer.presentation().failure_header().is_none());
+
+        match transfer.presentation().widget() {
+            Widget::Bytes { label, total } => {
+                assert_eq!(label, "WASM memory");
+                assert_eq!(total, 8);
+            }
+            Widget::Indeterminate { .. } => panic!("a transfer must use a byte bar"),
+        }
+    }
+
+    /// Create and transfer failures travel on the command's returned error,
+    /// so they must not also produce a deferred dump.
+    #[test]
+    fn kinds_without_a_header_produce_no_dump() {
+        let failure = Failure {
+            message: "boom".to_owned(),
+            causes: vec!["inner".to_owned()],
+        };
+
+        for task in [
+            Task::create("c"),
+            Task::snapshot_transfer("c", TransferDirection::Upload, TransferBlob::WasmModule, 1),
+        ] {
+            assert!(task.presentation().failure_dump(&failure).is_none());
+        }
+    }
+
+    #[test]
+    fn failure_dump_carries_the_message_then_its_cause_chain() {
+        let failure = Failure {
+            message: "outer".to_owned(),
+            causes: vec!["middle".to_owned(), "inner".to_owned()],
+        };
+
+        assert_eq!(
+            Task::sync("c", cid())
+                .presentation()
+                .failure_dump(&failure)
+                .expect("sync failures dump"),
+            vec![
+                "----- Failed to sync canister 'c': rrkah-fqaaa-aaaaa-aaaaq-cai -----".to_owned(),
+                "'outer'".to_owned(),
+                "  caused by: middle".to_owned(),
+                "  caused by: inner".to_owned(),
+            ]
+        );
+    }
+
+    /// A Candid failure replaces the generic dump with the breaking-change
+    /// warning, and is the only kind the caller may choose to proceed past.
+    #[test]
+    fn candid_failures_get_their_own_wording_and_are_bypassable() {
+        let failure = Failure {
+            message: "method foo removed".to_owned(),
+            causes: vec!["ignored".to_owned()],
+        };
+        let task = Task::candid_check("c", cid());
+
+        let dump = task
+            .presentation()
+            .failure_dump(&failure)
+            .expect("candid failures dump");
+        assert_eq!(dump.len(), 2, "header plus the breaking-change warning");
+        assert!(dump[0].contains("Candid interface compatibility check failed: 'c'"));
+        assert!(dump[1].starts_with("You are making a BREAKING change."));
+        assert!(dump[1].ends_with("method foo removed"));
+        // The cause chain is deliberately dropped: the message is the report.
+        assert!(!dump[1].contains("ignored"));
+
+        assert!(task.presentation().failure_is_bypassable());
+        assert!(
+            !Task::build("c").presentation().failure_is_bypassable(),
+            "a build failure is not something the caller can proceed past"
+        );
+    }
+}


### PR DESCRIPTION
An idea that came out of reviewing #725. Filed against `rk/ops-in-icp` so it can be folded into #729 if it looks right, or land on its own afterwards.

**Why.** Two costs sit in the current shape:

- `icp-events` owns `TaskKind`, an enum of the operations the CLI runs. With the operations layer moving into `icp`, that vocabulary sits one crate too low: `icp-events` is transport, and it enumerates what its callers do.
- A task kind's wording is spread across six `match` blocks in `icp-cli`'s renderer, plus a special case in `dump_failures`. Two of them end in `_ =>`, so a new kind compiles happily and silently renders as `Building: step N of M` under a `Build output:` header. Two other arms are already unreachable: `SnapshotTransfer` returns success and failure strings that a byte bar has no `{msg}` slot to display.

**What.** `icp-events` becomes generic in the task payload, describing only the shape of a progress stream. The vocabulary moves up to `icp::operations::task`, beside the operations that construct it, where each kind of work is one type implementing `Presentation` that describes itself in one impl block.

It goes in `icp` rather than the CLI so that a frontend which is not a terminal — a `--json` stream, an in-browser caller — gets the same descriptions instead of re-deriving them. What stays with the frontend is how they are drawn: `Widget` reports `Indeterminate` or `Bytes` with a bare label and the terminal renderer applies the `[canister]` brackets, and `failure_is_bypassable()` says only that the caller could have proceeded, leaving `Use --yes to bypass this check.` — which names a CLI flag — in `icp-cli`.

|                           | before                            | after                         |
| ------------------------- | --------------------------------- | ----------------------------- |
| add or change a task kind | 6 `match` blocks, 2 crates        | 1 impl block, 1 file          |
| forget to wire one up     | compiles, renders as a build step | does not compile              |
| `icp-events` dependencies | `candid`, `serde`, `tokio`        | `serde`, `tokio`              |
| `icp-events` tests        | 0                                 | 6, incl. a pinned wire format |

**How.** `Event`, `EventKind`, `Reporter`, and `TaskReporter` take a task type parameter. `StepReporter` stays non-generic — it erases the payload behind a `StepSink` trait, which is what keeps `Build` and `Synchronize` usable as `Arc<dyn _>` in `icp::Context`. `Task` is the serializable envelope, dispatched through a single exhaustive match. `success_message`/`failure_message` return `Option`, where `None` means "this widget has no message slot", so the byte-bar special-casing in the interactive renderer drops out instead of being restated.

No behaviour change: `build_tests`, `sync_tests`, and `canister_snapshot_tests` pass unmodified, and the event and task wire formats are preserved so the `--json` renderer in #493 stays purely additive. 13 new tests. Full rationale is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
