### PR TITLE
refactor: make deploy an operation in icp::operations

### DIFF
--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -3,7 +3,7 @@ use candid::Principal;
 use clap::Args;
 use clap_complete::ArgValueCandidates;
 use ic_agent::{Agent, AgentError};
-use icp::operations::deploy::{DeployParams, deploy, resolve_targets};
+use icp::operations::deploy::{DeployParams, DeployReport, deploy, resolve_targets};
 use icp::parsers::CyclesAmount;
 use icp::{
     context::{CanisterSelection, Context, EnvironmentSelection},
@@ -122,18 +122,22 @@ pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), anyhow:
     // One reporter for the whole deploy: every phase and every canister lands
     // on the same stream, so the renderer can order the run without the
     // command having to await it phase by phase.
-    let report = rendered(ctx.debug, async |reporter| {
-        deploy(ctx, &params, reporter).await
+    let mut report = DeployReport::default();
+    let result = rendered(ctx.debug, async |reporter| {
+        deploy(ctx, &params, reporter, &mut report).await
     })
-    .await?;
+    .await;
 
     // Terminal output is the command's job. The operation reports what it did;
-    // this decides how to say it.
+    // this decides how to say it. Printed before the result is unwrapped: a
+    // canister created before a later phase failed still exists, and the user
+    // needs its id either way.
     if !args.json {
         for (name, id) in &report.created {
             println!("Created canister {name} with ID {id}");
         }
     }
+    result?;
 
     let agent = ctx
         .get_agent_for_env(&identity_selection, &environment_selection)

--- a/crates/icp-cli/src/commands/deploy.rs
+++ b/crates/icp-cli/src/commands/deploy.rs
@@ -1,11 +1,9 @@
-use anyhow::{anyhow, bail};
+use anyhow::bail;
 use candid::Principal;
 use clap::Args;
 use clap_complete::ArgValueCandidates;
-use futures::{StreamExt, future::try_join_all, stream::FuturesOrdered};
 use ic_agent::{Agent, AgentError};
-use ic_management_canister_types::{CanisterId, CanisterIdRecord};
-use icp::operations::task::Task;
+use icp::operations::deploy::{DeployParams, deploy, resolve_targets};
 use icp::parsers::CyclesAmount;
 use icp::{
     context::{CanisterSelection, Context, EnvironmentSelection},
@@ -13,25 +11,9 @@ use icp::{
     network::Configuration as NetworkConfiguration,
 };
 use icp_canister_interfaces::candid_ui::MAINNET_CANDID_UI_CID;
-use icp_events::TaskOutcome;
-use itertools::Itertools;
 use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::time::Duration;
-use tracing::info;
 
 use crate::options::EnvironmentOpt;
-use icp::operations::{
-    binding_env_vars::set_binding_env_vars_many,
-    build::build_many,
-    candid_compat::check_candid_compatibility_many,
-    create::{CreateFunding, CreateOperation, CreateTarget},
-    install::{install_many, resolve_install_mode_and_status},
-    proxy_management,
-    settings::{sync_controller_dependents, sync_settings_many},
-    sync::sync_many,
-};
-
 use crate::{
     commands::{args::ArgsOpt, canister::create},
     options::{IdentityOpt, arg_struct_change_help},
@@ -113,531 +95,52 @@ pub(crate) async fn exec(ctx: &Context, args: &DeployArgs) -> Result<(), anyhow:
     let environment_selection: EnvironmentSelection = args.environment.0.clone().into();
     let identity_selection: IdentitySelection = args.identity.clone().into();
 
-    let env = ctx.get_environment(&environment_selection).await?;
-
-    let mut member_scoped = false;
-    let cnames: Vec<String> = if args.names.is_empty() {
-        // No canisters specified: default to the whole environment, unless the
-        // command is run inside a vendored member — then scope to that member's
-        // own canisters. (The resolved-root notice is emitted centrally during
-        // project load.)
-        let project = ctx.project.load().await?;
-        let member_dir = ctx.project.member_dir();
-        match icp::project::member_scoped_canisters(&project.dir, member_dir.as_deref(), &env) {
-            Some(scoped) => {
-                member_scoped = true;
-                scoped
-            }
-            None => env.canisters.keys().cloned().collect(),
-        }
-    } else {
-        // Individual canisters specified.
-        args.names.clone()
-    };
+    let canisters = resolve_targets(ctx, &environment_selection, &args.names).await?;
 
     // Skip doing any work if no canisters are targeted
-    if cnames.is_empty() {
+    if canisters.is_empty() {
         return Ok(());
     }
 
-    if args.args_opt.is_some() && cnames.len() != 1 {
-        anyhow::bail!("--args and --args-file can only be used when deploying a single canister");
+    if args.args_opt.is_some() && canisters.len() != 1 {
+        bail!("--args and --args-file can only be used when deploying a single canister");
     }
 
-    // A member-scoped deploy targets only the sub-project's own canisters, but
-    // those canisters are wired to their dependencies' ids — and the dependency
-    // canisters are outside the scope, so they are not (re)deployed here. If any
-    // are missing from the workspace store, fail fast rather than silently
-    // deploying an unwired canister.
-    if member_scoped {
-        let scoped: HashSet<&str> = cnames.iter().map(String::as_str).collect();
-        let deployed: BTreeMap<String, Principal> = ctx
-            .ids_by_environment(&environment_selection)
-            .await?
-            .into_iter()
-            .collect();
-        let mut missing: BTreeSet<String> = BTreeSet::new();
-        for name in &cnames {
-            if let Some((_, canister)) = env.canisters.get(name) {
-                for target in canister.bindings.values() {
-                    if !scoped.contains(target.as_str()) && !deployed.contains_key(target) {
-                        missing.insert(target.clone());
-                    }
-                }
-            }
-        }
-        if !missing.is_empty() {
-            anyhow::bail!(
-                "this sub-project depends on canister(s) not yet deployed in the workspace: {}. \
-                 Run `icp deploy` from the workspace root first (or deploy them explicitly by name).",
-                missing.into_iter().collect::<Vec<_>>().join(", ")
-            );
-        }
-    }
+    let params = DeployParams {
+        environment: environment_selection.clone(),
+        identity: identity_selection.clone(),
+        canisters: canisters.clone(),
+        mode: args.mode.clone(),
+        subnet: args.subnet,
+        proxy: args.proxy,
+        cycles: args.cycles.get(),
+        no_create: args.no_create,
+        yes: args.yes,
+        init_args: args.args_opt.resolve_bytes()?,
+    };
 
-    let canisters_to_build = try_join_all(
-        cnames
-            .iter()
-            .map(|name| ctx.get_canister_and_path_for_env(name, &environment_selection)),
-    )
-    .await?;
-
-    // Build the selected canisters
-    info!("Building canisters:");
-
-    let pkg_cache = ctx.dirs.package_cache()?;
-    rendered(ctx.debug, async |reporter| {
-        build_many(
-            canisters_to_build,
-            environment_selection.name(),
-            ctx.builder.clone(),
-            ctx.artifacts.clone(),
-            &pkg_cache,
-            reporter,
-        )
-        .await
+    // One reporter for the whole deploy: every phase and every canister lands
+    // on the same stream, so the renderer can order the run without the
+    // command having to await it phase by phase.
+    let report = rendered(ctx.debug, async |reporter| {
+        deploy(ctx, &params, reporter).await
     })
     .await?;
 
-    // Ensure the selected canisters exist, creating any that are missing.
-    let env = ctx
-        .get_environment(&environment_selection)
-        .await
-        .map_err(|e| anyhow!(e))?;
+    // Terminal output is the command's job. The operation reports what it did;
+    // this decides how to say it.
+    if !args.json {
+        for (name, id) in &report.created {
+            println!("Created canister {name} with ID {id}");
+        }
+    }
+
     let agent = ctx
         .get_agent_for_env(&identity_selection, &environment_selection)
-        .await
-        .map_err(|e| anyhow!(e))?;
-    let existing_canisters = ctx
-        .ids_by_environment(&environment_selection)
-        .await
-        .map_err(|e| anyhow!(e))?;
-    let canisters_to_create = cnames
-        .iter()
-        .filter(|name| !existing_canisters.contains_key(*name))
-        .collect::<Vec<_>>();
-
-    if canisters_to_create.is_empty() {
-        info!("All canisters already exist");
-    } else if args.no_create {
-        bail!(
-            "`--no-create` was specified but the following canisters do not exist: {}",
-            canisters_to_create.iter().format(", ")
-        );
-    } else {
-        info!("Creating canisters:");
-        let target = match (args.subnet, args.proxy) {
-            (Some(subnet), _) => CreateTarget::Subnet(subnet),
-            (_, Some(proxy)) => CreateTarget::Proxy(proxy),
-            _ => CreateTarget::None,
-        };
-        let create_operation = CreateOperation::new(
-            agent.clone(),
-            target,
-            CreateFunding::Cycles(args.cycles.get()),
-            existing_canisters.into_values().collect(),
-        );
-        rendered(ctx.debug, async |reporter| {
-            let mut futs = FuturesOrdered::new();
-            for name in canisters_to_create.iter() {
-                let task = reporter.task(Task::create((*name).clone()));
-                let create_op = create_operation.clone();
-                let (_, canister_info) = env.get_canister_info(name).map_err(|e| anyhow!(e))?;
-                futs.push_back(async move {
-                    let result = create_op.create(&canister_info.settings.into()).await;
-
-                    match &result {
-                        Ok(_) => task.finish(TaskOutcome::succeeded()),
-                        Err(err) => task.finish(TaskOutcome::failed(err.to_string())),
-                    }
-
-                    result
-                });
-            }
-
-            // Cache errors until all futures are processed. Otherwise we risk dropping a canister id.
-            let mut error: Option<anyhow::Error> = None;
-            let mut idx = 0;
-            while let Some(res) = futs.next().await {
-                match res {
-                    Ok(id) => {
-                        let canister_name = canisters_to_create
-                            .get(idx)
-                            .expect("should have tried to create every canister");
-                        if !args.json {
-                            println!("Created canister {canister_name} with ID {id}");
-                        }
-                        ctx.set_canister_id_for_env(canister_name, id, &environment_selection)
-                            .await
-                            .map_err(|e| anyhow!(e))?;
-                        // Apply controller settings for any already-created canister that was
-                        // waiting for this one to exist (e.g. created via `icp canister create`).
-                        sync_controller_dependents(
-                            ctx,
-                            &agent,
-                            args.proxy,
-                            canister_name,
-                            &environment_selection,
-                        )
-                        .await
-                        .map_err(|e| anyhow!(e))?;
-                    }
-                    Err(err) => {
-                        error = Some(err.into());
-                    }
-                }
-                idx += 1;
-            }
-            if let Some(err) = error {
-                return Err(err);
-            }
-            Ok(())
-        })
         .await?;
-    }
-
-    ctx.update_custom_domains(&environment_selection).await;
-
-    info!("Setting environment variables:");
-    let env = ctx
-        .get_environment(&environment_selection)
-        .await
-        .map_err(|e| anyhow!(e))?;
-
-    let env_canisters = &env.canisters;
-    let target_canisters = try_join_all(cnames.iter().map(|name| {
-        let environment_selection = environment_selection.clone();
-        async move {
-            let cid = ctx
-                .get_canister_id_for_env(
-                    &CanisterSelection::Named(name.clone()),
-                    &environment_selection,
-                )
-                .await
-                .map_err(|e| anyhow!(e))?;
-            let (_, info) = env_canisters
-                .get(name)
-                .ok_or_else(|| anyhow!("Canister id exists but no canister info"))?;
-            Ok::<_, anyhow::Error>((cid, info.clone()))
-        }
-    }))
-    .await?;
-
-    let canister_list = ctx
-        .ids_by_environment(&environment_selection)
-        .await
-        .map_err(|e| anyhow!(e))?;
-
-    rendered(ctx.debug, async |reporter| {
-        set_binding_env_vars_many(
-            agent.clone(),
-            args.proxy,
-            &env.name,
-            target_canisters.clone(),
-            canister_list.clone(),
-            reporter,
-        )
-        .await
-    })
-    .await
-    .map_err(|e| anyhow!(e))?;
-
-    rendered(ctx.debug, async |reporter| {
-        sync_settings_many(
-            agent.clone(),
-            args.proxy,
-            target_canisters,
-            canister_list,
-            reporter,
-        )
-        .await
-    })
-    .await
-    .map_err(|e| anyhow!(e))?;
-
-    // Install the selected canisters
-
-    let canisters = try_join_all(cnames.iter().map(|name| {
-        let environment_selection = environment_selection.clone();
-        let agent = agent.clone();
-        async move {
-            let cid = ctx
-                .get_canister_id_for_env(
-                    &CanisterSelection::Named(name.clone()),
-                    &environment_selection,
-                )
-                .await
-                .map_err(|e| anyhow!(e))?;
-
-            let (mode, status) =
-                resolve_install_mode_and_status(&agent, args.proxy, name, &cid, &args.mode).await?;
-
-            let env = ctx.get_environment(&environment_selection).await?;
-            let (_canister_path, canister_info) =
-                env.get_canister_info(name).map_err(|e| anyhow!(e))?;
-
-            // CLI --args/--args-file take priority over manifest init_args
-            let init_args_bytes = if args.args_opt.is_some() {
-                args.args_opt.resolve_bytes()?
-            } else {
-                canister_info
-                    .init_args
-                    .as_ref()
-                    .map(|ia| ia.to_bytes())
-                    .transpose()?
-            };
-
-            Ok::<_, anyhow::Error>((name.clone(), cid, mode, status, init_args_bytes))
-        }
-    }))
-    .await?;
-
-    if !args.yes {
-        info!("Checking compatibility:");
-        rendered(ctx.debug, async |reporter| {
-            check_candid_compatibility_many(
-                agent.clone(),
-                canisters
-                    .iter()
-                    .map(|(name, cid, mode, _, _)| (&**name, *cid, *mode)),
-                ctx.artifacts.clone(),
-                reporter,
-            )
-            .await
-        })
-        .await
-        .map_err(|e| anyhow!(e))?;
-    }
-
-    info!("Installing canisters:");
-
-    rendered(ctx.debug, async |reporter| {
-        install_many(
-            agent.clone(),
-            args.proxy,
-            canisters,
-            ctx.artifacts.clone(),
-            reporter,
-        )
-        .await
-    })
-    .await?;
-
-    // Sync the selected canisters
-
-    // Prepare list of canisters with their info for syncing
-    let env = ctx
-        .get_environment(&environment_selection)
-        .await
-        .map_err(|e| anyhow!(e))?;
-
-    let env_canisters = &env.canisters;
-    let sync_canisters = try_join_all(cnames.iter().map(|name| {
-        let environment_selection = environment_selection.clone();
-        async move {
-            let cid = ctx
-                .get_canister_id_for_env(
-                    &CanisterSelection::Named(name.clone()),
-                    &environment_selection,
-                )
-                .await
-                .map_err(|e| anyhow!(e))?;
-            let (canister_path, info) = env_canisters
-                .get(name)
-                .ok_or_else(|| anyhow!("Canister id exists but no canister info"))?;
-            Ok::<_, anyhow::Error>((cid, canister_path.clone(), info.clone()))
-        }
-    }))
-    .await?;
-
-    // Filter out canisters with no sync steps
-    let sync_canisters: Vec<_> = sync_canisters
-        .into_iter()
-        .filter(|(_, _, info)| !info.sync.steps.is_empty())
-        .collect();
-
-    if sync_canisters.is_empty() {
-        info!("No canisters have sync steps configured");
-    } else {
-        // Asset sync requires the canister to be Running. install_code is status-
-        // preserving, so a canister that entered deploy Stopped/Stopping (handed out
-        // Stopped from a pool, or left so by an earlier interrupted deploy) is still
-        // not Running here. Start each canister we're about to sync. Per the IC spec
-        // start_canister is synchronous — its Ok reply means the canister is already
-        // Running, so no status poll is needed — and idempotent (no-op if Running).
-        let proxy = args.proxy;
-        try_join_all(sync_canisters.iter().map(|(cid, _, _)| {
-            let agent = agent.clone();
-            let cid = *cid;
-            async move {
-                proxy_management::start_canister(
-                    &agent,
-                    proxy,
-                    CanisterIdRecord {
-                        canister_id: CanisterId::from(cid),
-                    },
-                )
-                .await
-                .map_err(|e| anyhow!(e))
-            }
-        }))
-        .await?;
-
-        // start_canister is synchronous, so each canister is now Running in the
-        // subnet's *certified* state — but IC query calls are eventually-consistent
-        // reads, answered by a single replica that may still lag the height at which
-        // the restart committed and would then observe the just-vacated Stopped state.
-        // The sync plugin's first calls are queries, so without this wait sync can fail
-        // with a transient IC0508 right after a restart. Wait until the query path
-        // consistently sees the canister Running before handing off.
-        try_join_all(sync_canisters.iter().map(|(cid, _, _)| {
-            let agent = agent.clone();
-            let cid = *cid;
-            async move { wait_until_serving_queries(&agent, cid).await }
-        }))
-        .await?;
-
-        // TODO: When `--proxy` is used and the canister was newly created, the proxy
-        // canister is its only controller. Sync steps (e.g. asset uploads to a frontend
-        // canister) will fail because the user's identity lacks the required permissions.
-        // The fix is to make a proxy call to the frontend canister's `grant_permission`
-        // method to permit the user identity to upload assets directly before syncing.
-        info!("Syncing canisters:");
-
-        let canister_ids: BTreeMap<String, Principal> = ctx
-            .ids_by_environment(&environment_selection)
-            .await?
-            .into_iter()
-            .collect();
-
-        let pkg_cache = ctx.dirs.package_cache()?;
-
-        rendered(ctx.debug, async |reporter| {
-            sync_many(
-                ctx.syncer.clone(),
-                agent.clone(),
-                sync_canisters,
-                environment_selection.name().to_owned(),
-                env.network.name.clone(),
-                canister_ids,
-                args.proxy,
-                &pkg_cache,
-                reporter,
-            )
-            .await
-        })
-        .await?;
-    }
-
-    // Print URLs for deployed canisters
-    print_canister_urls(
-        ctx,
-        &environment_selection,
-        agent.clone(),
-        &cnames,
-        args.json,
-    )
-    .await?;
+    print_canister_urls(ctx, &environment_selection, agent, &canisters, args.json).await?;
 
     Ok(())
-}
-
-/// A method name no real canister exports — used purely as a liveness probe.
-/// Querying it is side-effect-free: the replica rejects an unknown method before
-/// any canister code runs (no cycles, no logs, no state change), and the reject
-/// reason tells us whether the canister is serving queries yet.
-const READINESS_PROBE_METHOD: &str = "<icp-cli readiness probe>";
-
-/// Wait until the canister's *query* path consistently observes it as Running.
-///
-/// After `start_canister` the canister is Running in the subnet's certified
-/// state, but query calls are eventually-consistent reads: each is answered by a
-/// single replica that may still lag the restart's commit height and would then
-/// see the just-vacated Stopped state. The sync plugin's first calls are queries,
-/// so without this wait sync can fail with a transient IC0508 right after a
-/// restart.
-///
-/// We probe with a query for a method no canister exports and classify the result:
-///
-/// - a reject of "is stopped"/"is stopping" (IC0508/IC0509) means the replica is
-///   still lagging behind the restart.
-/// - any other reject (e.g. "no query method"), or a reply, means the replica got
-///   far enough to answer for a non-status reason, so it sees the canister Running.
-/// - a transport or timeout error is inconclusive.
-///
-/// We require a few consecutive ready observations, spaced out so they may land on
-/// different replicas, to raise confidence the lagging set has drained. This is not
-/// a hard guarantee — query reads are per-node and boundary nodes load-balance
-/// across replicas — but it makes the post-restart race rare.
-async fn wait_until_serving_queries(
-    agent: &Agent,
-    canister_id: Principal,
-) -> Result<(), anyhow::Error> {
-    const REQUIRED_CONSECUTIVE: u32 = 2;
-    // Total wall-clock budget for the whole wait — the hard cap on the failure
-    // path. PROBE_TIMEOUT below only bounds a single hung probe (so retries keep
-    // flowing); this outer budget is what guarantees we give up promptly, rather
-    // than attempts * (probe timeout + interval).
-    const READINESS_BUDGET: Duration = Duration::from_secs(30);
-    const POLL_INTERVAL: Duration = Duration::from_millis(500);
-    const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-
-    let poll = async {
-        let mut consecutive_ready: u32 = 0;
-        loop {
-            let probe = agent
-                .query(&canister_id, READINESS_PROBE_METHOD)
-                .with_arg(Vec::<u8>::new())
-                .call();
-            let ready = match tokio::time::timeout(PROBE_TIMEOUT, probe).await {
-                Ok(Ok(_)) => true,                       // replied -> Running
-                Ok(Err(err)) => is_serving_reject(&err), // non-stopped reject -> Running
-                Err(_elapsed) => false,                  // probe timed out -> inconclusive
-            };
-
-            if ready {
-                consecutive_ready += 1;
-                if consecutive_ready >= REQUIRED_CONSECUTIVE {
-                    return;
-                }
-            } else {
-                consecutive_ready = 0;
-            }
-            tokio::time::sleep(POLL_INTERVAL).await;
-        }
-    };
-
-    match tokio::time::timeout(READINESS_BUDGET, poll).await {
-        Ok(()) => Ok(()),
-        Err(_elapsed) => bail!(
-            "canister {canister_id} did not start serving queries within {}s after being \
-             started; the asset sync plugin's first call would fail. Re-run the deploy.",
-            READINESS_BUDGET.as_secs()
-        ),
-    }
-}
-
-/// True when a query error is a *reject from the replica* that indicates the
-/// canister is Running and serving — i.e. a positive readiness signal.
-///
-/// A reject means the replica processed the request to a verdict (e.g. "no such
-/// query method"), so the canister is up — unless the reject says it is
-/// stopped/stopping (IC0508/IC0509, with a message-substring fallback), which is
-/// a replica still lagging behind the restart. Every other `AgentError`
-/// (transport, HTTP, timeout, …) is inconclusive — not evidence the canister is
-/// serving — and returns false so the caller retries rather than proceeding.
-fn is_serving_reject(err: &AgentError) -> bool {
-    let reject = match err {
-        AgentError::CertifiedReject { reject, .. }
-        | AgentError::UncertifiedReject { reject, .. } => reject,
-        _ => return false,
-    };
-    let stopped = matches!(
-        reject.error_code.as_deref(),
-        Some("IC0508") | Some("IC0509")
-    ) || reject.reject_message.contains("is stopped")
-        || reject.reject_message.contains("is stopping");
-    !stopped
 }
 
 /// Checks whether a canister speaks the HTTP gateway protocol — i.e. exposes an

--- a/crates/icp-cli/src/render/interactive.rs
+++ b/crates/icp-cli/src/render/interactive.rs
@@ -1,20 +1,22 @@
 //! Live progress-bar renderer: one indicatif widget per task, a rolling
 //! window of the current step's output beneath it, and a ✔/✘ finish state.
-//! Failed tasks replay their captured output once the stream ends.
+//! Nested tasks indent under their parent, and phases print as plain headings
+//! above the bars. Failed tasks replay their captured output once the stream
+//! ends.
 
 use std::{collections::BTreeMap, time::Duration};
 
 use icp_events::{EventKind, TaskId, TaskOutcome};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use itertools::Itertools;
-use tracing::debug;
+use tracing::{debug, info};
 
 use super::style::{
     COLOR_FAILURE, COLOR_REGULAR, COLOR_SUCCESS, TICK_EMPTY, TICK_FAILURE, TICK_SUCCESS, make_style,
 };
 use icp::operations::task::{Event, Widget};
 
-use super::{RollingLines, TaskLog, dump_failures};
+use super::{INDENT, RollingLines, TaskLog, dump_failures};
 
 /// Number of output lines shown live under a task's progress bar.
 const LIVE_WINDOW_LINES: usize = 4;
@@ -26,7 +28,9 @@ pub(crate) struct InteractiveRenderer {
 
 struct TaskView {
     log: TaskLog,
-    bar: ProgressBar,
+    /// The live widget, or `None` for a phase — a heading has no live state,
+    /// so it is printed once above the bars rather than animated.
+    bar: Option<ProgressBar>,
     /// Header of the step currently running, shown above the live window.
     /// While a script command runs this is the step headline plus that
     /// command, so output is attributed to the command producing it.
@@ -46,41 +50,83 @@ impl InteractiveRenderer {
         }
     }
 
+    /// How deeply a task nests, from its parent's depth. A task whose parent
+    /// is unknown is treated as top-level.
+    fn depth_of(&self, parent: Option<TaskId>) -> usize {
+        parent
+            .and_then(|id| self.tasks.get(&id))
+            .map(|view| view.log.depth() + 1)
+            .unwrap_or(0)
+    }
+
+    /// Announce a heading.
+    ///
+    /// A top-level heading closes the live view first: dropping the
+    /// `MultiProgress` leaves its last frame on the terminal, so the bars
+    /// above become scrollback and the heading lands beneath them, with the
+    /// next phase's bars drawing below that. Without this the finished bars
+    /// would be redrawn *under* each new heading and the run would read out
+    /// of order. Nested headings have live siblings to preserve, so they are
+    /// written through the live view instead.
+    ///
+    /// The heading goes out over tracing rather than as a bar so it survives
+    /// a hidden draw target — under a pipe or in CI there are no bars, but
+    /// the phase headings still belong in the log.
+    fn heading(&mut self, depth: usize, title: &str) {
+        let line = format!("{}{title}", INDENT.repeat(depth));
+        if depth == 0 {
+            self.multi_progress = MultiProgress::new();
+            info!("{line}");
+        } else {
+            self.multi_progress.suspend(|| info!("{line}"));
+        }
+    }
+
     pub(crate) fn handle(&mut self, event: Event) {
         match event.kind {
-            EventKind::TaskStarted { task } => {
+            EventKind::TaskStarted { parent, task } => {
+                let depth = self.depth_of(parent);
+                let indent = INDENT.repeat(depth);
                 let presentation = task.presentation();
                 // Bars are configured fully before insertion: adding to the
                 // MultiProgress switches the draw target, and `set_style`
                 // adapts a style to stderr only while the bar is still
                 // detached.
                 let bar = match presentation.widget() {
+                    // A heading has no live state; it just titles whatever
+                    // nests beneath it.
+                    Widget::Heading { title } => {
+                        self.heading(depth, &title);
+                        None
+                    }
                     // Quantifiable work gets a determinate byte bar, labeled
                     // by the blob rather than the canister.
-                    Widget::Bytes { label, total } => self.multi_progress.add(
-                        ProgressBar::new(total)
-                            .with_style(transfer_style())
-                            .with_prefix(label),
+                    Widget::Bytes { label, total } => Some(
+                        self.multi_progress.add(
+                            ProgressBar::new(total)
+                                .with_style(transfer_style())
+                                .with_prefix(format!("{indent}{label}")),
+                        ),
                     ),
                     // The bracket decoration is this renderer's convention,
                     // matching the captured-output and failure-dump prefixes.
                     Widget::Indeterminate { label } => {
                         let mut bar = ProgressBar::new_spinner()
                             .with_style(make_style(TICK_EMPTY, COLOR_REGULAR))
-                            .with_prefix(format!("[{label}]"));
+                            .with_prefix(format!("{indent}[{label}]"));
                         if let Some(message) = presentation.running_message() {
                             bar = bar.with_message(message);
                         }
                         let bar = self.multi_progress.add(bar);
                         bar.enable_steady_tick(Duration::from_millis(120));
-                        bar
+                        Some(bar)
                     }
                 };
 
                 self.tasks.insert(
                     event.task_id,
                     TaskView {
-                        log: TaskLog::new(task),
+                        log: TaskLog::new(task, depth),
                         bar,
                         header: String::new(),
                         headline: String::new(),
@@ -90,8 +136,10 @@ impl InteractiveRenderer {
             }
 
             EventKind::Progress { position } => {
-                if let Some(view) = self.tasks.get(&event.task_id) {
-                    view.bar.set_position(position);
+                if let Some(view) = self.tasks.get(&event.task_id)
+                    && let Some(bar) = &view.bar
+                {
+                    bar.set_position(position);
                 }
             }
 
@@ -126,7 +174,9 @@ impl InteractiveRenderer {
                 // attributed to this one. The captured log is unaffected.
                 view.header = format!("{}\n$ {command}", view.headline);
                 view.window = RollingLines::new(LIVE_WINDOW_LINES);
-                view.bar.set_message(view.header.clone());
+                if let Some(bar) = &view.bar {
+                    bar.set_message(view.header.clone());
+                }
             }
 
             EventKind::Output { line, .. } => {
@@ -134,7 +184,13 @@ impl InteractiveRenderer {
                     return;
                 };
 
-                debug!("[{}] {line}", view.log.presentation().canister());
+                // A heading drives no widget and reports no output; there
+                // is no live window to roll.
+                let Some(bar) = &view.bar else {
+                    return;
+                };
+
+                debug!("{}", view.log.line(&line));
 
                 view.window.push(line.clone());
                 view.log.push_line(line);
@@ -144,8 +200,7 @@ impl InteractiveRenderer {
                 // │ look prettier...
                 // └
                 let rolled = view.window.iter().map(|s| format!("│ {s}")).join("\n");
-                view.bar
-                    .set_message(format!("{}\n{rolled}\n└\n\n", view.header));
+                bar.set_message(format!("{}\n{rolled}\n└\n\n", view.header));
             }
 
             EventKind::StepCompleted { .. } => {
@@ -161,27 +216,35 @@ impl InteractiveRenderer {
 
                 match outcome {
                     TaskOutcome::Succeeded { retained_output } => {
-                        // A byte bar has no message or tick slot, so it just
-                        // freezes at its final position.
-                        if let Some(message) = view.log.presentation().success_message() {
-                            view.bar.set_style(make_style(TICK_SUCCESS, COLOR_SUCCESS));
-                            view.bar.set_message(message);
+                        if let Some(bar) = &view.bar {
+                            // A byte bar has no message or tick slot, so it
+                            // just freezes at its final position.
+                            if let Some(message) = view.log.presentation().success_message() {
+                                bar.set_style(make_style(TICK_SUCCESS, COLOR_SUCCESS));
+                                bar.set_message(message);
+                            }
+                            bar.finish();
                         }
-                        view.bar.finish();
                         super::print_retained(view.log.task(), &retained_output);
                     }
                     TaskOutcome::Failed { message, causes } => {
-                        if let Some(rendered) = view.log.presentation().failure_message(&message) {
-                            view.bar.set_style(make_style(TICK_FAILURE, COLOR_FAILURE));
-                            view.bar.set_message(rendered);
+                        if let Some(bar) = &view.bar {
+                            if let Some(rendered) =
+                                view.log.presentation().failure_message(&message)
+                            {
+                                bar.set_style(make_style(TICK_FAILURE, COLOR_FAILURE));
+                                bar.set_message(rendered);
+                            }
+                            bar.finish();
                         }
-                        view.bar.finish();
                         view.log.fail(message, causes);
                     }
                     // Skipped keeps the neutral style — nothing succeeded or
                     // failed.
                     TaskOutcome::Skipped { reason } => {
-                        view.bar.finish_with_message(format!("Skipped ({reason})"));
+                        if let Some(bar) = &view.bar {
+                            bar.finish_with_message(format!("Skipped ({reason})"));
+                        }
                     }
                 }
             }

--- a/crates/icp-cli/src/render/mod.rs
+++ b/crates/icp-cli/src/render/mod.rs
@@ -10,6 +10,10 @@
 //! is being run; the vocabulary comes from [`icp::operations::task`], where
 //! each kind of work describes itself. What lives here is only how those
 //! descriptions are drawn on a terminal.
+//!
+//! Tasks arrive as a tree — a composite operation forwards the tasks of the
+//! operations it calls as children of its own phase — so a renderer tracks
+//! each task's depth and indents accordingly.
 
 use std::collections::{BTreeMap, VecDeque};
 
@@ -31,6 +35,9 @@ use icp::operations::task::{Event, Reporter, TaskReporter};
 
 /// The maximum number of lines to display for a step output
 const MAX_LINES_PER_STEP: usize = 10_000;
+
+/// Indentation applied per level of task nesting.
+const INDENT: &str = "  ";
 
 pub(crate) enum Renderer {
     Interactive(InteractiveRenderer),
@@ -107,11 +114,21 @@ pub(crate) async fn rendered_task<T, E: std::fmt::Display>(
     .await
 }
 
+/// Prefix a line with the canister a task is about, so concurrent tasks stay
+/// attributable. A task that names no canister — a phase heading — is left
+/// undecorated.
+fn attributed(task: &Task, text: &str) -> String {
+    match task.presentation().canister() {
+        Some(name) => format!("[{name}] {text}"),
+        None => text.to_owned(),
+    }
+}
+
 /// Print output lines a task retained past its rolling step view (e.g.
-/// sync-plugin stderr), prefixed with the canister name.
+/// sync-plugin stderr), attributed to the task that produced them.
 fn print_retained(task: &Task, lines: &[String]) {
     for line in lines {
-        eprintln!("[{}] {line}", task.presentation().canister());
+        eprintln!("{}", attributed(task, line));
     }
 }
 
@@ -119,6 +136,8 @@ fn print_retained(task: &Task, lines: &[String]) {
 /// live view is gone.
 pub(super) struct TaskLog {
     task: Task,
+    /// Levels of nesting below the root, for indentation.
+    depth: usize,
     finished_steps: Vec<StepLog>,
     current_step: Option<StepLog>,
     failure: Option<Failure>,
@@ -164,9 +183,10 @@ impl RollingLines {
 }
 
 impl TaskLog {
-    fn new(task: Task) -> Self {
+    fn new(task: Task, depth: usize) -> Self {
         Self {
             task,
+            depth,
             finished_steps: Vec::new(),
             current_step: None,
             failure: None,
@@ -177,8 +197,17 @@ impl TaskLog {
         &self.task
     }
 
+    fn depth(&self) -> usize {
+        self.depth
+    }
+
     fn presentation(&self) -> &dyn Presentation {
         self.task.presentation()
+    }
+
+    /// Attribute a line to the canister this task is about.
+    fn line(&self, text: &str) -> String {
+        attributed(&self.task, text)
     }
 
     fn start_step(&mut self, title: String) {
@@ -215,13 +244,7 @@ impl TaskLog {
             return Vec::new();
         }
 
-        let name = self.presentation().canister();
-        let mut lines = Vec::new();
-
-        lines.push(format!(
-            "[{name}] {} output:",
-            self.presentation().output_label()
-        ));
+        let mut lines = vec![self.line(&format!("{} output:", self.presentation().output_label()))];
 
         let steps: &[StepLog] = if all_steps {
             &self.finished_steps
@@ -235,14 +258,18 @@ impl TaskLog {
         for step in steps {
             for line in step.title.lines() {
                 if !line.is_empty() {
-                    lines.push(format!("[{name}] {line}:"));
+                    lines.push(self.line(&format!("{line}:")));
                 }
             }
 
             if step.lines.is_empty() {
-                lines.push(format!("[{name}] <no output>"));
+                lines.push(self.line("<no output>"));
             } else {
-                lines.extend(step.lines.iter().map(|line| format!("[{name}] > {line}")));
+                lines.extend(
+                    step.lines
+                        .iter()
+                        .map(|line| self.line(&format!("> {line}"))),
+                );
             }
         }
 

--- a/crates/icp-cli/src/render/plain.rs
+++ b/crates/icp-cli/src/render/plain.rs
@@ -5,11 +5,11 @@
 use std::collections::BTreeMap;
 
 use icp_events::{EventKind, TaskId, TaskOutcome};
-use tracing::debug;
+use tracing::{debug, info};
 
-use icp::operations::task::Event;
+use icp::operations::task::{Event, Widget};
 
-use super::{TaskLog, dump_failures};
+use super::{INDENT, TaskLog, dump_failures};
 
 pub(crate) struct PlainRenderer {
     tasks: BTreeMap<TaskId, TaskLog>,
@@ -22,10 +22,25 @@ impl PlainRenderer {
         }
     }
 
+    /// How deeply a task nests, from its parent's depth. A task whose parent
+    /// is unknown is treated as top-level.
+    fn depth_of(&self, parent: Option<TaskId>) -> usize {
+        parent
+            .and_then(|id| self.tasks.get(&id))
+            .map(|log| log.depth() + 1)
+            .unwrap_or(0)
+    }
+
     pub(crate) fn handle(&mut self, event: Event) {
         match event.kind {
-            EventKind::TaskStarted { task } => {
-                self.tasks.insert(event.task_id, TaskLog::new(task));
+            EventKind::TaskStarted { parent, task } => {
+                let depth = self.depth_of(parent);
+                // A heading has no live state to animate, so with the bars
+                // gone it is simply a line.
+                if let Widget::Heading { title } = task.presentation().widget() {
+                    info!("{}{title}", INDENT.repeat(depth));
+                }
+                self.tasks.insert(event.task_id, TaskLog::new(task, depth));
             }
 
             EventKind::StepStarted {
@@ -46,7 +61,7 @@ impl PlainRenderer {
                 };
                 // Mark command boundaries so interleaved output stays
                 // attributable to the command producing it.
-                debug!("[{}] $ {command}", log.presentation().canister());
+                debug!("{}", log.line(&format!("$ {command}")));
             }
 
             EventKind::Output { line, .. } => {
@@ -55,7 +70,7 @@ impl PlainRenderer {
                 };
                 // Prefix with the canister so interleaved concurrent tasks
                 // stay attributable.
-                debug!("[{}] {line}", log.presentation().canister());
+                debug!("{}", log.line(&line));
                 log.push_line(line);
             }
 

--- a/crates/icp-cli/tests/deploy_tests.rs
+++ b/crates/icp-cli/tests/deploy_tests.rs
@@ -1578,3 +1578,44 @@ async fn deploy_starts_stopped_canister_before_sync() {
         .success()
         .stdout(contains("apple"));
 }
+
+/// A canister created before a later phase fails still exists, so its id must
+/// still reach the user — it is the only place the run reports it, and without
+/// it a follow-up deploy is the only way to find out what was made.
+#[tokio::test]
+async fn deploy_prints_created_ids_when_a_later_phase_fails() {
+    let ctx = TestContext::new();
+    let project_dir = ctx.create_project_dir("icp");
+    let wasm = ctx.make_asset("example_icp_mo.wasm");
+
+    // Build, create and install all succeed; the sync step then fails.
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm}' "$ICP_WASM_OUTPUT_PATH"
+            sync:
+              steps:
+                - type: script
+                  command: exit 1
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
+        .mint_cycles(10 * TRILLION);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "--environment", "random-environment"])
+        .assert()
+        .failure()
+        .stdout(contains("Created canister my-canister with ID"));
+}

--- a/crates/icp-events/src/lib.rs
+++ b/crates/icp-events/src/lib.rs
@@ -13,6 +13,12 @@
 //! are stored as `Arc<dyn Build>` / `Arc<dyn Synchronize>` — can accept one
 //! without naming the consumer's task type.
 //!
+//! Tasks form a tree: [`TaskReporter::reporter`] hands back a [`Reporter`]
+//! whose tasks nest under that task. An operation cannot tell such a reporter
+//! from the one a command would have given it, which is what lets a composite
+//! operation forward the progress of the operations it calls onto one stream
+//! without those operations changing at all.
+//!
 //! Sends never block and never fail: the channel is unbounded, and with no
 //! receiver events are simply dropped, so tests and headless callers get
 //! silence for free. Errors do not travel on this stream — an operation's
@@ -50,7 +56,16 @@ pub enum EventKind<T> {
     /// The task began. Emitted once per task, before any of its steps. `task`
     /// is the caller's own description of the work — this crate never
     /// inspects it.
-    TaskStarted { task: T },
+    ///
+    /// `parent` is set when the task was started through a reporter scoped to
+    /// another task, which is how a composite operation (deploy calling
+    /// build, install, sync, …) forwards its children's progress onto one
+    /// stream.
+    TaskStarted {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        parent: Option<TaskId>,
+        task: T,
+    },
 
     /// A step of the task began. Steps within a task are sequential;
     /// `number` is 1-based. `label` describes the step (it may span
@@ -146,6 +161,7 @@ pub fn channel<T: Send + 'static>() -> (Reporter<T>, UnboundedReceiver<Event<T>>
             tx,
             next_task_id: Arc::new(AtomicU64::new(0)),
         }),
+        parent: None,
     };
     (reporter, rx)
 }
@@ -169,8 +185,15 @@ pub fn step_channel<T: Send + 'static>() -> (StepReporter, UnboundedReceiver<Eve
 }
 
 /// Entry point handed to an operation; spawns [`TaskReporter`]s.
+///
+/// A reporter carries the scope it was made in. An operation cannot tell the
+/// difference between the reporter a command handed it and one scoped to a
+/// parent task by a composite operation — which is what lets `deploy` run
+/// `build_many` unmodified and have its tasks nest under the build phase.
 pub struct Reporter<T> {
     inner: Option<ReporterInner<T>>,
+    /// Task the reporter's tasks nest under, if any.
+    parent: Option<TaskId>,
 }
 
 struct ReporterInner<T> {
@@ -189,10 +212,25 @@ impl<T> Clone for ReporterInner<T> {
     }
 }
 
+impl<T: Send + 'static> ReporterInner<T> {
+    fn start(&self, parent: Option<TaskId>, task: T) -> TaskReporter<T> {
+        let task_id = TaskId(self.next_task_id.fetch_add(1, Ordering::Relaxed));
+        let _ = self.tx.send(Event {
+            task_id,
+            kind: EventKind::TaskStarted { parent, task },
+        });
+        TaskReporter {
+            inner: Some(self.clone()),
+            task_id,
+        }
+    }
+}
+
 impl<T> Clone for Reporter<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
+            parent: self.parent,
         }
     }
 }
@@ -200,38 +238,34 @@ impl<T> Clone for Reporter<T> {
 impl<T> Reporter<T> {
     /// A reporter whose events go nowhere.
     pub fn null() -> Self {
-        Self { inner: None }
-    }
-}
-
-impl<T: Send + 'static> Reporter<T> {
-    /// Begin a task, emitting [`EventKind::TaskStarted`].
-    pub fn task(&self, task: T) -> TaskReporter<T> {
-        let Some(inner) = &self.inner else {
-            return TaskReporter::null();
-        };
-        let task_id = TaskId(inner.next_task_id.fetch_add(1, Ordering::Relaxed));
-        let _ = inner.tx.send(Event {
-            task_id,
-            kind: EventKind::TaskStarted { task },
-        });
-        TaskReporter {
-            tx: Some(inner.tx.clone()),
-            task_id,
+        Self {
+            inner: None,
+            parent: None,
         }
     }
 }
 
-/// Reports the lifecycle of one task.
+impl<T: Send + 'static> Reporter<T> {
+    /// Begin a task, emitting [`EventKind::TaskStarted`]. It nests under
+    /// whatever scope this reporter carries.
+    pub fn task(&self, task: T) -> TaskReporter<T> {
+        match &self.inner {
+            Some(inner) => inner.start(self.parent, task),
+            None => TaskReporter::null(),
+        }
+    }
+}
+
+/// Reports the lifecycle of one task, and spawns the tasks nested under it.
 pub struct TaskReporter<T> {
-    tx: Option<UnboundedSender<Event<T>>>,
+    inner: Option<ReporterInner<T>>,
     task_id: TaskId,
 }
 
 impl<T> Clone for TaskReporter<T> {
     fn clone(&self) -> Self {
         Self {
-            tx: self.tx.clone(),
+            inner: self.inner.clone(),
             task_id: self.task_id,
         }
     }
@@ -241,14 +275,23 @@ impl<T> TaskReporter<T> {
     /// A task reporter whose events go nowhere.
     pub fn null() -> Self {
         Self {
-            tx: None,
+            inner: None,
             task_id: TaskId(0),
         }
     }
 
+    /// A reporter scoped to this task. Hand it to an operation that does not
+    /// know it is being composed: whatever tasks it starts nest here.
+    pub fn reporter(&self) -> Reporter<T> {
+        Reporter {
+            inner: self.inner.clone(),
+            parent: Some(self.task_id),
+        }
+    }
+
     fn send(&self, kind: EventKind<T>) {
-        if let Some(tx) = &self.tx {
-            let _ = tx.send(Event {
+        if let Some(inner) = &self.inner {
+            let _ = inner.tx.send(Event {
                 task_id: self.task_id,
                 kind,
             });
@@ -281,9 +324,9 @@ impl<T: Send + 'static> TaskReporter<T> {
             label: label.into(),
         });
         StepReporter {
-            sink: self.tx.clone().map(|tx| {
+            sink: self.inner.as_ref().map(|inner| {
                 Arc::new(TaskSink {
-                    tx,
+                    tx: inner.tx.clone(),
                     task_id: self.task_id,
                 }) as Arc<dyn StepSink>
             }),
@@ -431,7 +474,8 @@ mod tests {
         task.finish(TaskOutcome::succeeded());
 
         // Handles derived from a null reporter are themselves null.
-        assert!(TaskReporter::<DemoTask>::null().tx.is_none());
+        assert!(TaskReporter::<DemoTask>::null().inner.is_none());
+        assert!(task.reporter().inner.is_none());
         assert!(StepReporter::null().sink.is_none());
     }
 
@@ -501,6 +545,38 @@ mod tests {
         );
     }
 
+    /// A reporter scoped to a task hands that task's id to everything it
+    /// starts, without the operation on the other end knowing. Tasks started
+    /// through the unscoped reporter stay at the root.
+    #[tokio::test]
+    async fn a_scoped_reporter_nests_what_it_starts() {
+        let (reporter, mut rx) = channel::<DemoTask>();
+        let phase = reporter.task(demo("phase"));
+        // What a composed operation receives — indistinguishable, to it, from
+        // the reporter a command would have handed it.
+        let scoped = phase.reporter();
+        scoped.task(demo("child"));
+        scoped.clone().task(demo("sibling"));
+        reporter.task(demo("root"));
+
+        let parents: Vec<(TaskId, Option<TaskId>)> = drain(&mut rx)
+            .into_iter()
+            .filter_map(|e| match e.kind {
+                EventKind::TaskStarted { parent, .. } => Some((e.task_id, parent)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            parents,
+            vec![
+                (TaskId(0), None),
+                (TaskId(1), Some(TaskId(0))),
+                (TaskId(2), Some(TaskId(0))),
+                (TaskId(3), None),
+            ]
+        );
+    }
+
     /// A step reporter keeps its own channel handle, so output emitted after
     /// the task reporter is gone still arrives. This is what makes the
     /// spawned stdout/stderr readers in the core library safe.
@@ -555,11 +631,25 @@ mod tests {
         };
 
         assert_eq!(
-            event(EventKind::TaskStarted { task: demo("a") }),
+            event(EventKind::TaskStarted {
+                parent: None,
+                task: demo("a"),
+            }),
             serde_json::json!({
                 "task_id": 7, "event": "task_started",
+                // A root task carries no `parent` key at all.
                 // The payload nests under `task`; its inner shape is the
                 // caller's to define.
+                "task": { "kind": "demo", "name": "a" },
+            })
+        );
+        assert_eq!(
+            event(EventKind::TaskStarted {
+                parent: Some(TaskId(3)),
+                task: demo("a"),
+            }),
+            serde_json::json!({
+                "task_id": 7, "event": "task_started", "parent": 3,
                 "task": { "kind": "demo", "name": "a" },
             })
         );

--- a/crates/icp/src/operations/deploy.rs
+++ b/crates/icp/src/operations/deploy.rs
@@ -188,17 +188,26 @@ pub struct DeployParams {
 }
 
 /// What the deploy did, for the command to report.
+///
+/// Filled in as the run progresses rather than returned at the end: a canister
+/// created before a later phase failed still exists, and its id is still what
+/// the caller needs to pick the run back up. So the caller owns this and reads
+/// it whichever way the deploy went.
+#[derive(Debug, Default)]
 pub struct DeployReport {
     /// Canisters created during this deploy, in creation order.
     pub created: Vec<(String, Principal)>,
 }
 
 /// Run a full deploy, reporting progress as one task tree.
+///
+/// `report` is written as the run goes; see [`DeployReport`].
 pub async fn deploy(
     ctx: &Context,
     params: &DeployParams,
     reporter: &Reporter,
-) -> Result<DeployReport, DeployError> {
+    report: &mut DeployReport,
+) -> Result<(), DeployError> {
     let environment_selection = &params.environment;
     let cnames = &params.canisters;
 
@@ -234,9 +243,8 @@ pub async fn deploy(
         .filter(|name| !existing_canisters.contains_key(*name))
         .collect::<Vec<_>>();
 
-    let created = if canisters_to_create.is_empty() {
+    if canisters_to_create.is_empty() {
         notice(reporter, "All canisters already exist");
-        Vec::new()
     } else if params.no_create {
         return NoCreateSnafu {
             canisters: canisters_to_create.into_iter().cloned().collect::<Vec<_>>(),
@@ -252,10 +260,11 @@ pub async fn deploy(
             &canisters_to_create,
             existing_canisters.into_values().collect(),
             &phase.reporter(),
+            &mut report.created,
         )
         .await;
-        finish(&phase, result)?
-    };
+        finish(&phase, result)?;
+    }
 
     ctx.update_custom_domains(environment_selection).await;
 
@@ -366,10 +375,14 @@ pub async fn deploy(
 
     sync(ctx, params, &agent, reporter).await?;
 
-    Ok(DeployReport { created })
+    Ok(())
 }
 
 /// Create the missing canisters, recording each id as it lands.
+///
+/// Ids are appended to `created` as each canister comes into existence, before
+/// anything that could still fail, so a partial run still reports what it made.
+#[allow(clippy::too_many_arguments)]
 async fn create_canisters(
     ctx: &Context,
     params: &DeployParams,
@@ -378,7 +391,8 @@ async fn create_canisters(
     canisters_to_create: &[&String],
     existing_ids: Vec<Principal>,
     reporter: &Reporter,
-) -> Result<Vec<(String, Principal)>, DeployError> {
+    created: &mut Vec<(String, Principal)>,
+) -> Result<(), DeployError> {
     let target = match (params.subnet, params.proxy) {
         (Some(subnet), _) => CreateTarget::Subnet(subnet),
         (_, Some(proxy)) => CreateTarget::Proxy(proxy),
@@ -411,7 +425,6 @@ async fn create_canisters(
     }
 
     // Cache errors until all futures are processed. Otherwise we risk dropping a canister id.
-    let mut created = Vec::new();
     let mut error: Option<DeployError> = None;
     let mut idx = 0;
     while let Some(res) = futs.next().await {
@@ -420,6 +433,10 @@ async fn create_canisters(
                 let canister_name = canisters_to_create
                     .get(idx)
                     .expect("should have tried to create every canister");
+                // Report the id before recording it or wiring up dependents: the
+                // canister exists from here on, and if either of those fails this
+                // is the only place the user will see the id it was given.
+                created.push(((*canister_name).clone(), id));
                 ctx.set_canister_id_for_env(canister_name, id, &params.environment)
                     .await?;
                 // Apply controller settings for any already-created canister that was
@@ -435,7 +452,6 @@ async fn create_canisters(
                 .context(SyncControllerDependentsSnafu {
                     canister: (*canister_name).clone(),
                 })?;
-                created.push(((*canister_name).clone(), id));
             }
             Err(err) => {
                 error = Some(err.into());
@@ -445,7 +461,7 @@ async fn create_canisters(
     }
     match error {
         Some(err) => Err(err),
-        None => Ok(created),
+        None => Ok(()),
     }
 }
 

--- a/crates/icp/src/operations/deploy.rs
+++ b/crates/icp/src/operations/deploy.rs
@@ -424,7 +424,11 @@ async fn create_canisters(
         });
     }
 
-    // Cache errors until all futures are processed. Otherwise we risk dropping a canister id.
+    // Every creation result must be drained before returning. A create call still
+    // in flight when we bail may already have made its canister on the IC, so
+    // abandoning the remaining futures would lose that id for good — which is the
+    // very loss this loop exists to prevent. So no step below short-circuits the
+    // loop: the first error is held back and returned once the stream is empty.
     let mut error: Option<DeployError> = None;
     let mut idx = 0;
     while let Some(res) = futs.next().await {
@@ -437,24 +441,36 @@ async fn create_canisters(
                 // canister exists from here on, and if either of those fails this
                 // is the only place the user will see the id it was given.
                 created.push(((*canister_name).clone(), id));
-                ctx.set_canister_id_for_env(canister_name, id, &params.environment)
-                    .await?;
-                // Apply controller settings for any already-created canister that was
-                // waiting for this one to exist (e.g. created via `icp canister create`).
-                sync_controller_dependents(
-                    ctx,
-                    agent,
-                    params.proxy,
-                    canister_name,
-                    &params.environment,
-                )
-                .await
-                .context(SyncControllerDependentsSnafu {
-                    canister: (*canister_name).clone(),
-                })?;
+
+                // Scoped to this canister rather than the loop, so a failure here
+                // holds up only its own follow-up work.
+                let result = async {
+                    ctx.set_canister_id_for_env(canister_name, id, &params.environment)
+                        .await?;
+                    // Apply controller settings for any already-created canister that
+                    // was waiting for this one to exist (e.g. created via
+                    // `icp canister create`). Skipped when the id never reached the
+                    // store, since that is what a dependent would be looking it up in.
+                    sync_controller_dependents(
+                        ctx,
+                        agent,
+                        params.proxy,
+                        canister_name,
+                        &params.environment,
+                    )
+                    .await
+                    .context(SyncControllerDependentsSnafu {
+                        canister: (*canister_name).clone(),
+                    })
+                }
+                .await;
+
+                if let Err(err) = result {
+                    error.get_or_insert(err);
+                }
             }
             Err(err) => {
-                error = Some(err.into());
+                error.get_or_insert(err.into());
             }
         }
         idx += 1;

--- a/crates/icp/src/operations/deploy.rs
+++ b/crates/icp/src/operations/deploy.rs
@@ -1,0 +1,771 @@
+//! Deploy as one operation: build, create, wire, check, install, sync.
+//!
+//! Deploy used to be orchestration written into the command, with each phase
+//! opening its own renderer and the phase headings printed directly between
+//! them — the sequencing was what kept those headings from tearing through a
+//! live progress view. Here the whole run is a single task tree on a single
+//! event stream: each phase is a heading task, and the per-canister tasks the
+//! sub-operations start nest under it, because the reporter they are handed
+//! is scoped to the phase. They do not know they are being composed.
+//!
+//! Nothing in here writes to the terminal. Progress goes out as events;
+//! results come back on [`DeployReport`] for the command to print. That split
+//! is what lets the same orchestration run somewhere without a terminal at
+//! all.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::time::Duration;
+
+use candid::Principal;
+use futures::{StreamExt, future::try_join_all, stream::FuturesOrdered};
+use ic_agent::{Agent, AgentError};
+use ic_management_canister_types::{CanisterId, CanisterIdRecord};
+use icp_events::TaskOutcome;
+use itertools::Itertools;
+use snafu::{OptionExt, ResultExt, Snafu};
+
+use crate::context::{
+    CanisterSelection, Context, EnvironmentSelection, GetAgentForEnvError,
+    GetCanisterIdForEnvError, GetEnvCanisterError, GetEnvironmentError, GetIdsByEnvironmentError,
+    SetCanisterIdForEnvError,
+};
+use crate::fs::lock::LockError;
+use crate::identity::IdentitySelection;
+use crate::operations::{
+    binding_env_vars::{SetBindingEnvVarsManyError, set_binding_env_vars_many},
+    build::{BuildManyError, build_many},
+    candid_compat::{CandidCheckManyError, check_candid_compatibility_many},
+    create::{CreateFunding, CreateOperation, CreateOperationError, CreateTarget},
+    install::{
+        InstallManyError, ResolveInstallModeError, install_many, resolve_install_mode_and_status,
+    },
+    proxy::UpdateOrProxyError,
+    proxy_management,
+    settings::{
+        SyncControllerDependentsError, SyncSettingsManyError, sync_controller_dependents,
+        sync_settings_many,
+    },
+    sync::{SyncOperationError, sync_many},
+    task::{Reporter, Task, TaskReporter, notice},
+};
+use crate::{InitArgsToBytesError, ProjectLoadError};
+
+/// Everything that can stop a deploy. Each phase's failure keeps the typed
+/// error of the operation that produced it, so a caller can still tell a
+/// build failure from a failed install.
+#[derive(Debug, Snafu)]
+pub enum DeployError {
+    /// Sub-operation failures forward as they are: each already names what it
+    /// was doing and which canister it was doing it to, so a deploy-level
+    /// wrapper would only say it twice.
+    #[snafu(transparent)]
+    ResolveBuildTargets { source: GetEnvCanisterError },
+
+    #[snafu(transparent)]
+    PackageCache { source: LockError },
+
+    #[snafu(transparent)]
+    Build { source: BuildManyError },
+
+    #[snafu(transparent)]
+    GetEnvironment { source: GetEnvironmentError },
+
+    #[snafu(transparent)]
+    GetAgent { source: GetAgentForEnvError },
+
+    #[snafu(transparent)]
+    GetIds { source: GetIdsByEnvironmentError },
+
+    #[snafu(display(
+        "`--no-create` was specified but the following canisters do not exist: {}",
+        canisters.iter().format(", ")
+    ))]
+    NoCreate { canisters: Vec<String> },
+
+    #[snafu(transparent)]
+    Create { source: CreateOperationError },
+
+    #[snafu(transparent)]
+    RecordCanisterId { source: SetCanisterIdForEnvError },
+
+    #[snafu(display(
+        "Failed to apply settings that were waiting on canister '{canister}' to exist"
+    ))]
+    SyncControllerDependents {
+        canister: String,
+        source: SyncControllerDependentsError,
+    },
+
+    #[snafu(transparent)]
+    GetCanisterId { source: GetCanisterIdForEnvError },
+
+    /// The id store and the environment disagree: an id is recorded for a
+    /// canister the manifest does not declare.
+    #[snafu(display("Canister id exists but no canister info: '{canister}'"))]
+    MissingCanisterInfo { canister: String },
+
+    #[snafu(display("{message}"))]
+    CanisterNotInEnvironment { message: String },
+
+    #[snafu(transparent)]
+    SetEnvironmentVariables { source: SetBindingEnvVarsManyError },
+
+    #[snafu(transparent)]
+    ApplySettings { source: SyncSettingsManyError },
+
+    #[snafu(transparent)]
+    ResolveInstallMode { source: ResolveInstallModeError },
+
+    #[snafu(display("Failed to encode the init arguments of canister '{canister}'"))]
+    InitArgs {
+        canister: String,
+        source: InitArgsToBytesError,
+    },
+
+    #[snafu(transparent)]
+    CandidCheck { source: CandidCheckManyError },
+
+    #[snafu(transparent)]
+    Install { source: InstallManyError },
+
+    #[snafu(display("Failed to start canister {canister_id} before syncing it"))]
+    StartCanister {
+        canister_id: Principal,
+        source: UpdateOrProxyError,
+    },
+
+    #[snafu(display(
+        "canister {canister_id} did not start serving queries within {seconds}s after being \
+         started; the asset sync plugin's first call would fail. Re-run the deploy."
+    ))]
+    NotServingQueries {
+        canister_id: Principal,
+        seconds: u64,
+    },
+
+    #[snafu(transparent)]
+    Sync { source: SyncOperationError },
+}
+
+/// Everything that can stop [`resolve_targets`] before a deploy begins.
+#[derive(Debug, Snafu)]
+pub enum ResolveTargetsError {
+    #[snafu(transparent)]
+    LoadEnvironment { source: GetEnvironmentError },
+
+    #[snafu(transparent)]
+    LoadProject { source: ProjectLoadError },
+
+    #[snafu(transparent)]
+    LoadCanisterIds { source: GetIdsByEnvironmentError },
+
+    #[snafu(display(
+        "this sub-project depends on canister(s) not yet deployed in the workspace: {}. \
+         Run `icp deploy` from the workspace root first (or deploy them explicitly by name).",
+        canisters.iter().format(", ")
+    ))]
+    MissingWorkspaceDependencies { canisters: Vec<String> },
+}
+
+/// Everything a deploy needs that the command line supplies. Resolved by the
+/// command so this layer never touches clap.
+pub struct DeployParams {
+    pub environment: EnvironmentSelection,
+    pub identity: IdentitySelection,
+    /// Canisters to deploy, already resolved from the command line (or from
+    /// the environment when none were named).
+    pub canisters: Vec<String>,
+    pub mode: String,
+    pub subnet: Option<Principal>,
+    pub proxy: Option<Principal>,
+    pub cycles: u128,
+    pub no_create: bool,
+    /// Skip the Candid interface compatibility check.
+    pub yes: bool,
+    /// Install arguments, already resolved to bytes. Only ever set when a
+    /// single canister is being deployed.
+    pub init_args: Option<Vec<u8>>,
+}
+
+/// What the deploy did, for the command to report.
+pub struct DeployReport {
+    /// Canisters created during this deploy, in creation order.
+    pub created: Vec<(String, Principal)>,
+}
+
+/// Run a full deploy, reporting progress as one task tree.
+pub async fn deploy(
+    ctx: &Context,
+    params: &DeployParams,
+    reporter: &Reporter,
+) -> Result<DeployReport, DeployError> {
+    let environment_selection = &params.environment;
+    let cnames = &params.canisters;
+
+    let canisters_to_build = try_join_all(
+        cnames
+            .iter()
+            .map(|name| ctx.get_canister_and_path_for_env(name, environment_selection)),
+    )
+    .await?;
+
+    // Build
+    let pkg_cache = ctx.dirs.package_cache()?;
+    let phase = reporter.task(Task::phase("Building canisters:"));
+    let result = build_many(
+        canisters_to_build,
+        environment_selection.name(),
+        ctx.builder.clone(),
+        ctx.artifacts.clone(),
+        &pkg_cache,
+        &phase.reporter(),
+    )
+    .await;
+    finish(&phase, result)?;
+
+    // Create any canisters that do not exist yet
+    let env = ctx.get_environment(environment_selection).await?;
+    let agent = ctx
+        .get_agent_for_env(&params.identity, environment_selection)
+        .await?;
+    let existing_canisters = ctx.ids_by_environment(environment_selection).await?;
+    let canisters_to_create = cnames
+        .iter()
+        .filter(|name| !existing_canisters.contains_key(*name))
+        .collect::<Vec<_>>();
+
+    let created = if canisters_to_create.is_empty() {
+        notice(reporter, "All canisters already exist");
+        Vec::new()
+    } else if params.no_create {
+        return NoCreateSnafu {
+            canisters: canisters_to_create.into_iter().cloned().collect::<Vec<_>>(),
+        }
+        .fail();
+    } else {
+        let phase = reporter.task(Task::phase("Creating canisters:"));
+        let result = create_canisters(
+            ctx,
+            params,
+            &agent,
+            &env,
+            &canisters_to_create,
+            existing_canisters.into_values().collect(),
+            &phase.reporter(),
+        )
+        .await;
+        finish(&phase, result)?
+    };
+
+    ctx.update_custom_domains(environment_selection).await;
+
+    // Wire canister ids into each other's environment variables, then apply
+    // manifest settings.
+    let env = ctx.get_environment(environment_selection).await?;
+    let env_canisters = &env.canisters;
+    let target_canisters = try_join_all(cnames.iter().map(|name| async move {
+        let cid = ctx
+            .get_canister_id_for_env(
+                &CanisterSelection::Named(name.clone()),
+                environment_selection,
+            )
+            .await?;
+        let (_, info) = env_canisters
+            .get(name)
+            .context(MissingCanisterInfoSnafu { canister: name })?;
+        Ok::<_, DeployError>((cid, info.clone()))
+    }))
+    .await?;
+
+    let canister_list = ctx.ids_by_environment(environment_selection).await?;
+
+    let phase = reporter.task(Task::phase("Setting environment variables:"));
+    let result = set_binding_env_vars_many(
+        agent.clone(),
+        params.proxy,
+        &env.name,
+        target_canisters.clone(),
+        canister_list.clone(),
+        &phase.reporter(),
+    )
+    .await;
+    finish(&phase, result)?;
+
+    let phase = reporter.task(Task::phase("Applying canister settings:"));
+    let result = sync_settings_many(
+        agent.clone(),
+        params.proxy,
+        target_canisters,
+        canister_list,
+        &phase.reporter(),
+    )
+    .await;
+    finish(&phase, result)?;
+
+    // Resolve install plans
+    let canisters = try_join_all(cnames.iter().map(|name| {
+        let agent = agent.clone();
+        async move {
+            let cid = ctx
+                .get_canister_id_for_env(
+                    &CanisterSelection::Named(name.clone()),
+                    environment_selection,
+                )
+                .await?;
+
+            let (mode, status) =
+                resolve_install_mode_and_status(&agent, params.proxy, name, &cid, &params.mode)
+                    .await?;
+
+            let env = ctx.get_environment(environment_selection).await?;
+            let (_canister_path, canister_info) = env
+                .get_canister_info(name)
+                .map_err(|message| DeployError::CanisterNotInEnvironment { message })?;
+
+            // Command-line arguments take priority over manifest init_args.
+            let init_args_bytes = match &params.init_args {
+                Some(bytes) => Some(bytes.clone()),
+                None => canister_info
+                    .init_args
+                    .as_ref()
+                    .map(|ia| ia.to_bytes())
+                    .transpose()
+                    .context(InitArgsSnafu { canister: name })?,
+            };
+
+            Ok::<_, DeployError>((name.clone(), cid, mode, status, init_args_bytes))
+        }
+    }))
+    .await?;
+
+    if !params.yes {
+        let phase = reporter.task(Task::phase("Checking compatibility:"));
+        let result = check_candid_compatibility_many(
+            agent.clone(),
+            canisters
+                .iter()
+                .map(|(name, cid, mode, _, _)| (&**name, *cid, *mode)),
+            ctx.artifacts.clone(),
+            &phase.reporter(),
+        )
+        .await;
+        finish(&phase, result)?;
+    }
+
+    // Install
+    let phase = reporter.task(Task::phase("Installing canisters:"));
+    let result = install_many(
+        agent.clone(),
+        params.proxy,
+        canisters,
+        ctx.artifacts.clone(),
+        &phase.reporter(),
+    )
+    .await;
+    finish(&phase, result)?;
+
+    sync(ctx, params, &agent, reporter).await?;
+
+    Ok(DeployReport { created })
+}
+
+/// Create the missing canisters, recording each id as it lands.
+async fn create_canisters(
+    ctx: &Context,
+    params: &DeployParams,
+    agent: &Agent,
+    env: &crate::Environment,
+    canisters_to_create: &[&String],
+    existing_ids: Vec<Principal>,
+    reporter: &Reporter,
+) -> Result<Vec<(String, Principal)>, DeployError> {
+    let target = match (params.subnet, params.proxy) {
+        (Some(subnet), _) => CreateTarget::Subnet(subnet),
+        (_, Some(proxy)) => CreateTarget::Proxy(proxy),
+        _ => CreateTarget::None,
+    };
+    let create_operation = CreateOperation::new(
+        agent.clone(),
+        target,
+        CreateFunding::Cycles(params.cycles),
+        existing_ids,
+    );
+
+    let mut futs = FuturesOrdered::new();
+    for name in canisters_to_create.iter() {
+        let task = reporter.task(Task::create((*name).clone()));
+        let create_op = create_operation.clone();
+        let (_, canister_info) = env
+            .get_canister_info(name)
+            .map_err(|message| DeployError::CanisterNotInEnvironment { message })?;
+        futs.push_back(async move {
+            let result = create_op.create(&canister_info.settings.into()).await;
+
+            match &result {
+                Ok(_) => task.finish(TaskOutcome::succeeded()),
+                Err(err) => task.finish(TaskOutcome::failed(err.to_string())),
+            }
+
+            result
+        });
+    }
+
+    // Cache errors until all futures are processed. Otherwise we risk dropping a canister id.
+    let mut created = Vec::new();
+    let mut error: Option<DeployError> = None;
+    let mut idx = 0;
+    while let Some(res) = futs.next().await {
+        match res {
+            Ok(id) => {
+                let canister_name = canisters_to_create
+                    .get(idx)
+                    .expect("should have tried to create every canister");
+                ctx.set_canister_id_for_env(canister_name, id, &params.environment)
+                    .await?;
+                // Apply controller settings for any already-created canister that was
+                // waiting for this one to exist (e.g. created via `icp canister create`).
+                sync_controller_dependents(
+                    ctx,
+                    agent,
+                    params.proxy,
+                    canister_name,
+                    &params.environment,
+                )
+                .await
+                .context(SyncControllerDependentsSnafu {
+                    canister: (*canister_name).clone(),
+                })?;
+                created.push(((*canister_name).clone(), id));
+            }
+            Err(err) => {
+                error = Some(err.into());
+            }
+        }
+        idx += 1;
+    }
+    match error {
+        Some(err) => Err(err),
+        None => Ok(created),
+    }
+}
+
+/// Run the sync steps of every canister that has any.
+async fn sync(
+    ctx: &Context,
+    params: &DeployParams,
+    agent: &Agent,
+    reporter: &Reporter,
+) -> Result<(), DeployError> {
+    let environment_selection = &params.environment;
+    let env = ctx.get_environment(environment_selection).await?;
+
+    let env_canisters = &env.canisters;
+    let sync_canisters = try_join_all(params.canisters.iter().map(|name| async move {
+        let cid = ctx
+            .get_canister_id_for_env(
+                &CanisterSelection::Named(name.clone()),
+                environment_selection,
+            )
+            .await?;
+        let (canister_path, info) = env_canisters
+            .get(name)
+            .context(MissingCanisterInfoSnafu { canister: name })?;
+        Ok::<_, DeployError>((cid, canister_path.clone(), info.clone()))
+    }))
+    .await?;
+
+    // Filter out canisters with no sync steps
+    let sync_canisters: Vec<_> = sync_canisters
+        .into_iter()
+        .filter(|(_, _, info)| !info.sync.steps.is_empty())
+        .collect();
+
+    if sync_canisters.is_empty() {
+        notice(reporter, "No canisters have sync steps configured");
+        return Ok(());
+    }
+
+    // Asset sync requires the canister to be Running. install_code is status-
+    // preserving, so a canister that entered deploy Stopped/Stopping (handed out
+    // Stopped from a pool, or left so by an earlier interrupted deploy) is still
+    // not Running here. Start each canister we're about to sync. Per the IC spec
+    // start_canister is synchronous — its Ok reply means the canister is already
+    // Running, so no status poll is needed — and idempotent (no-op if Running).
+    let proxy = params.proxy;
+    try_join_all(sync_canisters.iter().map(|(cid, _, _)| {
+        let agent = agent.clone();
+        let cid = *cid;
+        async move {
+            proxy_management::start_canister(
+                &agent,
+                proxy,
+                CanisterIdRecord {
+                    canister_id: CanisterId::from(cid),
+                },
+            )
+            .await
+            .context(StartCanisterSnafu { canister_id: cid })
+        }
+    }))
+    .await?;
+
+    // start_canister is synchronous, so each canister is now Running in the
+    // subnet's *certified* state — but IC query calls are eventually-consistent
+    // reads, answered by a single replica that may still lag the height at which
+    // the restart committed and would then observe the just-vacated Stopped state.
+    // The sync plugin's first calls are queries, so without this wait sync can fail
+    // with a transient IC0508 right after a restart. Wait until the query path
+    // consistently sees the canister Running before handing off.
+    try_join_all(sync_canisters.iter().map(|(cid, _, _)| {
+        let agent = agent.clone();
+        let cid = *cid;
+        async move { wait_until_serving_queries(&agent, cid).await }
+    }))
+    .await?;
+
+    // TODO: When `--proxy` is used and the canister was newly created, the proxy
+    // canister is its only controller. Sync steps (e.g. asset uploads to a frontend
+    // canister) will fail because the user's identity lacks the required permissions.
+    // The fix is to make a proxy call to the frontend canister's `grant_permission`
+    // method to permit the user identity to upload assets directly before syncing.
+    let canister_ids: BTreeMap<String, Principal> = ctx
+        .ids_by_environment(environment_selection)
+        .await?
+        .into_iter()
+        .collect();
+
+    let pkg_cache = ctx.dirs.package_cache()?;
+
+    let phase = reporter.task(Task::phase("Syncing canisters:"));
+    let result = sync_many(
+        ctx.syncer.clone(),
+        agent.clone(),
+        sync_canisters,
+        environment_selection.name().to_owned(),
+        env.network.name.clone(),
+        canister_ids,
+        proxy,
+        &pkg_cache,
+        &phase.reporter(),
+    )
+    .await;
+    finish(&phase, result)?;
+
+    Ok(())
+}
+
+/// Close a phase's heading task from its result, and hand the result back.
+///
+/// The heading carries no failure text of its own: whichever child failed
+/// already said what went wrong, and the error itself is on the return path.
+fn finish<T, E: std::fmt::Display>(phase: &TaskReporter, result: Result<T, E>) -> Result<T, E> {
+    match &result {
+        Ok(_) => phase.finish(TaskOutcome::succeeded()),
+        Err(error) => phase.finish(TaskOutcome::failed(error.to_string())),
+    }
+    result
+}
+
+/// Resolve the canisters a deploy targets, and check that a member-scoped
+/// deploy is not about to wire canisters to dependencies that do not exist.
+pub async fn resolve_targets(
+    ctx: &Context,
+    environment_selection: &EnvironmentSelection,
+    named: &[String],
+) -> Result<Vec<String>, ResolveTargetsError> {
+    let env = ctx.get_environment(environment_selection).await?;
+
+    let mut member_scoped = false;
+    let cnames: Vec<String> = if named.is_empty() {
+        // No canisters specified: default to the whole environment, unless the
+        // command is run inside a vendored member — then scope to that member's
+        // own canisters. (The resolved-root notice is emitted centrally during
+        // project load.)
+        let project = ctx.project.load().await?;
+        let member_dir = ctx.project.member_dir();
+        match crate::project::member_scoped_canisters(&project.dir, member_dir.as_deref(), &env) {
+            Some(scoped) => {
+                member_scoped = true;
+                scoped
+            }
+            None => env.canisters.keys().cloned().collect(),
+        }
+    } else {
+        named.to_vec()
+    };
+
+    // A member-scoped deploy targets only the sub-project's own canisters, but
+    // those canisters are wired to their dependencies' ids — and the dependency
+    // canisters are outside the scope, so they are not (re)deployed here. If any
+    // are missing from the workspace store, fail fast rather than silently
+    // deploying an unwired canister.
+    if member_scoped {
+        let scoped: HashSet<&str> = cnames.iter().map(String::as_str).collect();
+        let deployed: BTreeMap<String, Principal> = ctx
+            .ids_by_environment(environment_selection)
+            .await?
+            .into_iter()
+            .collect();
+        let mut missing: BTreeSet<String> = BTreeSet::new();
+        for name in &cnames {
+            if let Some((_, canister)) = env.canisters.get(name) {
+                for target in canister.bindings.values() {
+                    if !scoped.contains(target.as_str()) && !deployed.contains_key(target) {
+                        missing.insert(target.clone());
+                    }
+                }
+            }
+        }
+        if !missing.is_empty() {
+            return MissingWorkspaceDependenciesSnafu {
+                canisters: missing.into_iter().collect::<Vec<_>>(),
+            }
+            .fail();
+        }
+    }
+
+    Ok(cnames)
+}
+
+/// A method name no real canister exports — used purely as a liveness probe.
+/// Querying it is side-effect-free: the replica rejects an unknown method before
+/// any canister code runs (no cycles, no logs, no state change), and the reject
+/// reason tells us whether the canister is serving queries yet.
+const READINESS_PROBE_METHOD: &str = "<icp-cli readiness probe>";
+
+/// Wait until the canister's *query* path consistently observes it as Running.
+///
+/// After `start_canister` the canister is Running in the subnet's certified
+/// state, but query calls are eventually-consistent reads: each is answered by a
+/// single replica that may still lag the restart's commit height and would then
+/// see the just-vacated Stopped state. The sync plugin's first calls are queries,
+/// so without this wait sync can fail with a transient IC0508 right after a
+/// restart.
+///
+/// We probe with a query for a method no canister exports and classify the result:
+///
+/// - a reject of "is stopped"/"is stopping" (IC0508/IC0509) means the replica is
+///   still lagging behind the restart.
+/// - any other reject (e.g. "no query method"), or a reply, means the replica got
+///   far enough to answer for a non-status reason, so it sees the canister Running.
+/// - a transport or timeout error is inconclusive.
+///
+/// We require a few consecutive ready observations, spaced out so they may land on
+/// different replicas, to raise confidence the lagging set has drained. This is not
+/// a hard guarantee — query reads are per-node and boundary nodes load-balance
+/// across replicas — but it makes the post-restart race rare.
+async fn wait_until_serving_queries(
+    agent: &Agent,
+    canister_id: Principal,
+) -> Result<(), DeployError> {
+    const REQUIRED_CONSECUTIVE: u32 = 2;
+    // Total wall-clock budget for the whole wait — the hard cap on the failure
+    // path. PROBE_TIMEOUT below only bounds a single hung probe (so retries keep
+    // flowing); this outer budget is what guarantees we give up promptly, rather
+    // than attempts * (probe timeout + interval).
+    const READINESS_BUDGET: Duration = Duration::from_secs(30);
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+    let poll = async {
+        let mut consecutive_ready: u32 = 0;
+        loop {
+            let probe = agent
+                .query(&canister_id, READINESS_PROBE_METHOD)
+                .with_arg(Vec::<u8>::new())
+                .call();
+            let ready = match tokio::time::timeout(PROBE_TIMEOUT, probe).await {
+                Ok(Ok(_)) => true,                       // replied -> Running
+                Ok(Err(err)) => is_serving_reject(&err), // non-stopped reject -> Running
+                Err(_elapsed) => false,                  // probe timed out -> inconclusive
+            };
+
+            if ready {
+                consecutive_ready += 1;
+                if consecutive_ready >= REQUIRED_CONSECUTIVE {
+                    return;
+                }
+            } else {
+                consecutive_ready = 0;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    };
+
+    match tokio::time::timeout(READINESS_BUDGET, poll).await {
+        Ok(()) => Ok(()),
+        Err(_elapsed) => NotServingQueriesSnafu {
+            canister_id,
+            seconds: READINESS_BUDGET.as_secs(),
+        }
+        .fail(),
+    }
+}
+
+/// True when a query error is a *reject from the replica* that indicates the
+/// canister is Running and serving — i.e. a positive readiness signal.
+///
+/// A reject means the replica processed the request to a verdict (e.g. "no such
+/// query method"), so the canister is up — unless the reject says it is
+/// stopped/stopping (IC0508/IC0509, with a message-substring fallback), which is
+/// a replica still lagging behind the restart. Every other `AgentError`
+/// (transport, HTTP, timeout, …) is inconclusive — not evidence the canister is
+/// serving — and returns false so the caller retries rather than proceeding.
+fn is_serving_reject(err: &AgentError) -> bool {
+    let reject = match err {
+        AgentError::CertifiedReject { reject, .. }
+        | AgentError::UncertifiedReject { reject, .. } => reject,
+        _ => return false,
+    };
+    let stopped = matches!(
+        reject.error_code.as_deref(),
+        Some("IC0508") | Some("IC0509")
+    ) || reject.reject_message.contains("is stopped")
+        || reject.reject_message.contains("is stopping");
+    !stopped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_agent::agent::{RejectCode, RejectResponse};
+
+    fn reject(error_code: Option<&str>, reject_message: &str) -> AgentError {
+        AgentError::UncertifiedReject {
+            reject: RejectResponse {
+                reject_code: RejectCode::CanisterError,
+                reject_message: reject_message.to_string(),
+                error_code: error_code.map(String::from),
+            },
+            operation: None,
+        }
+    }
+
+    #[test]
+    fn stopped_rejects_are_not_a_readiness_signal() {
+        // A replica still lagging behind the restart.
+        assert!(!is_serving_reject(&reject(
+            Some("IC0508"),
+            "Canister abc is stopped"
+        )));
+        assert!(!is_serving_reject(&reject(
+            None,
+            "Canister abc is stopping"
+        )));
+    }
+
+    #[test]
+    fn any_other_reject_means_the_canister_is_serving() {
+        // The replica got far enough to answer for a non-status reason.
+        assert!(is_serving_reject(&reject(
+            Some("IC0536"),
+            "Canister abc has no query method '<icp-cli readiness probe>'"
+        )));
+    }
+
+    #[test]
+    fn a_transport_error_is_inconclusive() {
+        // Not evidence of anything; the caller must retry.
+        assert!(!is_serving_reject(&AgentError::InvalidReplicaStatus));
+    }
+}

--- a/crates/icp/src/operations/mod.rs
+++ b/crates/icp/src/operations/mod.rs
@@ -4,6 +4,7 @@ pub mod bundle;
 pub mod candid_compat;
 pub mod canister_migration;
 pub mod create;
+pub mod deploy;
 pub mod install;
 pub mod proxy;
 pub mod proxy_management;

--- a/crates/icp/src/operations/task.rs
+++ b/crates/icp/src/operations/task.rs
@@ -31,6 +31,9 @@ pub type Event = icp_events::Event<Task>;
 /// The shape of live progress a task can report. How this is drawn — and
 /// how the label is decorated — is the frontend's business.
 pub enum Widget {
+    /// No live progress of its own: an announcement that titles whatever
+    /// nests beneath it. With nothing nested under it, it is just a notice.
+    Heading { title: String },
     /// Work of unknown duration, labeled by the canister it acts on.
     Indeterminate { label: String },
     /// Quantifiable work: `total` bytes, labeled by what is being moved.
@@ -49,13 +52,15 @@ pub struct Failure {
 /// spinner-driven task that reports no steps — so most implementations only
 /// state what makes them different.
 pub trait Presentation {
-    /// The canister this task operates on. Used to prefix captured output.
-    fn canister(&self) -> &str;
+    /// The canister this task operates on, when it is about one. Used to
+    /// attribute captured output; a task that acts on no single canister —
+    /// a phase heading — contributes no attribution.
+    fn canister(&self) -> Option<&str>;
 
     /// The live widget this task drives.
     fn widget(&self) -> Widget {
         Widget::Indeterminate {
-            label: self.canister().to_owned(),
+            label: self.canister().unwrap_or_default().to_owned(),
         }
     }
 
@@ -116,6 +121,51 @@ pub trait Presentation {
 }
 
 // ---------------------------------------------------------------------------
+// Phases
+// ---------------------------------------------------------------------------
+
+/// A step of a composite operation, titling the tasks nested under it.
+///
+/// A phase does no work of its own, so it has nothing to say on either
+/// outcome: whichever child failed has already said what went wrong, and the
+/// error itself is on the operation's return path.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename = "phase")]
+pub struct PhaseTask {
+    pub title: String,
+}
+
+impl Presentation for PhaseTask {
+    /// A phase spans every canister the operation touches, so it attributes
+    /// nothing to any one of them.
+    fn canister(&self) -> Option<&str> {
+        None
+    }
+
+    fn widget(&self) -> Widget {
+        Widget::Heading {
+            title: self.title.clone(),
+        }
+    }
+
+    fn success_message(&self) -> Option<String> {
+        None
+    }
+
+    fn failure_message(&self, _message: &str) -> Option<String> {
+        None
+    }
+}
+
+/// Announce something in passing: a phase with no work under it, finished as
+/// soon as it is started.
+pub fn notice(reporter: &Reporter, text: impl Into<String>) {
+    reporter
+        .task(Task::phase(text))
+        .finish(icp_events::TaskOutcome::succeeded());
+}
+
+// ---------------------------------------------------------------------------
 // Multi-step tasks
 // ---------------------------------------------------------------------------
 
@@ -126,8 +176,8 @@ pub struct BuildTask {
 }
 
 impl Presentation for BuildTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn step_header(&self, number: usize, total: usize, label: &str) -> String {
@@ -162,8 +212,8 @@ pub struct SyncTask {
 }
 
 impl Presentation for SyncTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn step_header(&self, number: usize, total: usize, label: &str) -> String {
@@ -201,8 +251,8 @@ pub struct CreateTask {
 }
 
 impl Presentation for CreateTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn running_message(&self) -> Option<&'static str> {
@@ -228,8 +278,8 @@ pub struct InstallTask {
 }
 
 impl Presentation for InstallTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn running_message(&self) -> Option<&'static str> {
@@ -260,8 +310,8 @@ pub struct UpdateSettingsTask {
 }
 
 impl Presentation for UpdateSettingsTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn running_message(&self) -> Option<&'static str> {
@@ -292,8 +342,8 @@ pub struct UpdateEnvironmentVariablesTask {
 }
 
 impl Presentation for UpdateEnvironmentVariablesTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn running_message(&self) -> Option<&'static str> {
@@ -324,8 +374,8 @@ pub struct CandidCheckTask {
 }
 
 impl Presentation for CandidCheckTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn running_message(&self) -> Option<&'static str> {
@@ -410,8 +460,8 @@ pub struct SnapshotTransferTask {
 }
 
 impl Presentation for SnapshotTransferTask {
-    fn canister(&self) -> &str {
-        &self.canister
+    fn canister(&self) -> Option<&str> {
+        Some(&self.canister)
     }
 
     fn widget(&self) -> Widget {
@@ -445,6 +495,7 @@ impl Presentation for SnapshotTransferTask {
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum Task {
+    Phase(PhaseTask),
     Build(BuildTask),
     Sync(SyncTask),
     Create(CreateTask),
@@ -460,6 +511,7 @@ impl Task {
     /// per-task presentation rules.
     pub fn presentation(&self) -> &dyn Presentation {
         match self {
+            Task::Phase(task) => task,
             Task::Build(task) => task,
             Task::Sync(task) => task,
             Task::Create(task) => task,
@@ -469,6 +521,12 @@ impl Task {
             Task::CandidCheck(task) => task,
             Task::SnapshotTransfer(task) => task,
         }
+    }
+
+    pub fn phase(title: impl Into<String>) -> Self {
+        Task::Phase(PhaseTask {
+            title: title.into(),
+        })
     }
 
     pub fn build(canister: impl Into<String>) -> Self {
@@ -553,6 +611,10 @@ mod tests {
         let json = |task: Task| serde_json::to_value(task).expect("task should serialize");
 
         assert_eq!(
+            json(Task::phase("Building canisters:")),
+            serde_json::json!({ "kind": "phase", "title": "Building canisters:" })
+        );
+        assert_eq!(
             json(Task::build("frontend")),
             serde_json::json!({ "kind": "build", "canister": "frontend" })
         );
@@ -625,8 +687,38 @@ mod tests {
         ];
 
         for task in &tasks {
-            assert_eq!(task.presentation().canister(), "c");
+            assert_eq!(task.presentation().canister(), Some("c"));
         }
+
+        // A phase spans all of them, so it names none.
+        assert_eq!(
+            Task::phase("Building canisters:").presentation().canister(),
+            None
+        );
+    }
+
+    /// A phase is a heading and nothing else: no live state, no closing line
+    /// on either outcome, and no deferred dump — whichever child failed has
+    /// already reported, and the error is on the return path.
+    #[test]
+    fn a_phase_is_a_heading_with_nothing_to_say() {
+        let phase = Task::phase("Installing canisters:");
+        let presentation = phase.presentation();
+
+        match presentation.widget() {
+            Widget::Heading { title } => assert_eq!(title, "Installing canisters:"),
+            _ => panic!("a phase must render as a heading"),
+        }
+        assert!(presentation.success_message().is_none());
+        assert!(presentation.failure_message("boom").is_none());
+        assert!(
+            presentation
+                .failure_dump(&Failure {
+                    message: "boom".to_owned(),
+                    causes: vec!["inner".to_owned()],
+                })
+                .is_none()
+        );
     }
 
     /// Only the two multi-step kinds render step headers and captured-output
@@ -668,7 +760,7 @@ mod tests {
                 assert_eq!(label, "WASM memory");
                 assert_eq!(total, 8);
             }
-            Widget::Indeterminate { .. } => panic!("a transfer must use a byte bar"),
+            _ => panic!("a transfer must use a byte bar"),
         }
     }
 


### PR DESCRIPTION
**Stacked on #730** — base is `linwei/events-task-trait-v2`, so review this diff on its own; it becomes a diff against `rk/ops-in-icp` once #730 merges.

Deploy is the last thing in `icp-cli` that was still doing operations work. This makes it an operation in `icp::operations`, alongside the operations it composes.

## Why

`commands/deploy.rs` was 973 lines of orchestration opening **seven separate renderers** — build, create, env vars, settings, Candid, install, sync — and awaiting each before starting the next. That sequencing was not a style choice: it was the mechanism keeping `info!("Installing canisters:")` from tearing through a live progress view. It did not fully hold either — the `println!("Created canister … with ID …")` inside the create scope raced the `MultiProgress` it was printing over.

## What

The whole run is now one task tree on one event stream. Each phase is a heading task, and the reporter handed to `build_many`, `install_many`, `sync_many` and the rest is **scoped to that phase**, so their per-canister tasks nest under it.

**None of those operations changed.** They still take a `&Reporter` and still start what they think are top-level tasks. That is the property that makes this worth doing: composing an operation costs nothing at the operations it composes.

## How

Three pieces:

| | change |
| --- | --- |
| `icp-events` | `TaskStarted` carries a `parent`; `TaskReporter::reporter()` hands back a `Reporter` scoped to that task. A reporter carries the scope it was made in, so an operation cannot tell one apart from the reporter a command would have given it. |
| `icp::operations::task` | `Task::phase` + `Widget::Heading` — an announcement with no live state that titles whatever nests beneath it (and, with nothing nested, is just a notice). `canister()` becomes `Option<&str>`: a phase spans every canister the run touches, so it attributes output to none. |
| `render/` | Each renderer tracks a task's depth and indents by it. A top-level heading closes the live view first, reproducing what tearing down a per-phase renderer used to do. |

## Result

```
Building canisters:
  [canister-1] ✔ Built successfully
  [canister-2] ✔ Built successfully
Creating canisters:
  [canister-1] ✔ Created successfully
  [canister-2] ✔ Created successfully
Setting environment variables:
  [canister-1] ✔ Environment variables updated successfully
Applying canister settings:
  [canister-1] ✔ Canister settings updated successfully
Checking compatibility:
  [canister-1]   Skipped (not an upgrade)
Installing canisters:
  [canister-1] ✔ Installed successfully
Syncing canisters:
  [canister-1] ✔ Synced successfully: 4zfnl-5t777-77775-aaadq-cai
Created canister canister-1 with ID 4zfnl-5t777-77775-aaadq-cai
Deployed canisters:
…
```

## Deliberate changes

- **The settings phase gained the heading it never had.** Its bars used to appear under `Setting environment variables:`.
- **`Created canister … with ID …` now prints after the last phase** rather than interleaved with the create bars. It rides back on `DeployReport` and the command prints it, so stdout stays in the command layer next to `--json` — and the println/`MultiProgress` race is gone structurally rather than by careful placement.
- **Typed errors.** Living in `icp` rather than the binary, deploy returns `DeployError`/`ResolveTargetsError` instead of `anyhow`. Sub-operation failures forward transparently — each already names what it was doing and to which canister, so a deploy-level wrapper would only say it twice — and the variants carrying their own message are the ones with no source.

`resolve_targets` is split out so the command can decide there is nothing to do, and reject `--args` with more than one canister, before starting a run.

## Testing

All 24 deploy tests, 13 sync tests and 12 build tests pass **unmodified**, as does the rest of the workspace (only the 5 SoftHSM2 identity tests fail locally, for want of the library). `icp-events` gains a nesting test and its pinned wire format covers `parent`; the task vocabulary gains two tests for the phase kind. Verified by eye against `examples/icp-progress-bar-test-bed`, in a terminal and under a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QooMLZ15EWRrknWtXfFZNp
