### PR TITLE
fix: fall back on the public status for every access-denied reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ air-gapped signing
 * feat: `script` build steps now receive `ICP_CLI_ENVIRONMENT`, the name of the environment the canisters are being built for, so a build can vary by environment the way a sync step already could.
 * feat: `icp completions <SHELL>` prints a shell completion script for `bash`, `zsh`, `fish`, `powershell`, or `elvish` to stdout. See the [installation guide](docs/guides/installation.md#shell-completions) for where to put it.
 * fix: `icp canister logs` output formats are corrected. `--json` now emits machine-readable JSON and the default emits the human-readable lines (the two were swapped), and `--follow --json` emits newline-delimited JSON, one record per line, streamed as each record arrives. This is breaking for scripts: parsing the default output as JSON now requires `--json`, and consumers of `--follow --json` must read one JSON object per line.
+* fix: `icp canister status` again falls back on the publicly readable state-tree information when the caller may not read the status. Replicas now reject those calls with `IC0542`, which the fallback did not recognise, so the command failed with `Error looking up canister <id>` instead of printing the controllers and module hash. `IC0541`, returned on subnets with administrators, is now recognised too, and the fallback no longer depends on whether the rejection arrives certified or uncertified.
 
 ## Experimental
 

--- a/crates/icp-cli/src/commands/canister/status.rs
+++ b/crates/icp-cli/src/commands/canister/status.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail};
 use clap::Args;
 use clap_complete::ArgValueCandidates;
-use ic_agent::{Agent, AgentError, export::Principal};
+use ic_agent::{Agent, AgentError, agent::RejectResponse, export::Principal};
 use ic_management_canister_types::{
     CanisterIdRecord, CanisterStatusResult, EnvironmentVariable, LogVisibility,
 };
@@ -19,13 +19,33 @@ use crate::{commands::args, options};
 
 /// Error code returned by the replica if the target canister is not found
 const E_CANISTER_NOT_FOUND: &str = "IC0301";
-/// Error code returned by the replica if the caller is not a controller
-const E_NOT_A_CONTROLLER: &str = "IC0512";
+/// Error codes the replica returns when the caller may not read the status.
+///
+/// Which one comes back depends on the replica version and on whether the
+/// subnet has administrators: `IC0542` since status visibility was introduced,
+/// `IC0541` on subnets with administrators before that, and `IC0512` otherwise.
+const E_STATUS_ACCESS_DENIED: [&str; 3] = ["IC0512", "IC0541", "IC0542"];
+
+/// The reject carried by a direct update call, however it was delivered.
+///
+/// The replica checks who may read the status both when accepting the ingress
+/// message and again during execution, so the same denial arrives uncertified
+/// from the first and certified from the second.
+fn direct_call_reject(err: &UpdateOrProxyError) -> Option<&RejectResponse> {
+    match err {
+        UpdateOrProxyError::DirectUpdateCall {
+            source:
+                AgentError::CertifiedReject { reject, .. }
+                | AgentError::UncertifiedReject { reject, .. },
+        } => Some(reject),
+        _ => None,
+    }
+}
 
 /// Show the status of canister(s).
 ///
 /// By default this queries the status endpoint of the management canister.
-/// If the caller is not a controller, falls back on fetching public
+/// If the caller may not read the status, falls back on fetching public
 /// information from the state tree.
 #[derive(Debug, Args)]
 #[command(after_long_help = "\
@@ -266,18 +286,20 @@ pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow:
                                 .expect("Failed to build canister status output"),
                         }
                     }
-                    Err(UpdateOrProxyError::DirectUpdateCall {
-                        source:
-                            AgentError::UncertifiedReject {
-                                reject,
-                                operation: _,
-                            },
-                    }) => {
+                    Err(e) => {
+                        let Some(reject) = direct_call_reject(&e) else {
+                            bail!("Unknown error fetching canister {cid} status: {e}");
+                        };
+
                         if reject.error_code.as_deref() == Some(E_CANISTER_NOT_FOUND) {
                             bail!("Canister {cid} was not found.");
                         }
 
-                        if reject.error_code.as_deref() != Some(E_NOT_A_CONTROLLER) {
+                        if !reject
+                            .error_code
+                            .as_deref()
+                            .is_some_and(|code| E_STATUS_ACCESS_DENIED.contains(&code))
+                        {
                             bail!(
                                 "Error looking up canister {cid}: {:?} - {}",
                                 reject.error_code,
@@ -285,7 +307,7 @@ pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow:
                             );
                         }
 
-                        // We got E_NOT_A_CONTROLLER so we fallback on fetching the public status
+                        // Access was denied, so fall back on fetching the public status
                         let status =
                             build_public_status(&agent, cid.to_owned(), maybe_name.clone()).await?;
 
@@ -295,9 +317,6 @@ pub(crate) async fn exec(ctx: &Context, args: &StatusArgs) -> Result<(), anyhow:
                             false => build_public_output(&status)
                                 .expect("Failed to build canister status output"),
                         }
-                    }
-                    Err(e) => {
-                        bail!("Unknown error fetching canister {cid} status: {e}");
                     }
                 }
             }
@@ -565,4 +584,45 @@ fn build_output(result: &SerializableCanisterStatusResult) -> Result<String, any
     )?;
 
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use ic_agent::agent::{RejectCode, RejectResponse};
+
+    use super::*;
+
+    /// A denial arrives uncertified when ingress inspection catches it and
+    /// certified when execution does, so the fallback has to see both. Anything
+    /// that is not a reject must keep surfacing as an error.
+    #[test]
+    fn both_reject_forms_are_recognised() {
+        let reject = || RejectResponse {
+            reject_code: RejectCode::CanisterError,
+            reject_message: "denied".to_string(),
+            error_code: Some("IC0542".to_string()),
+        };
+
+        for source in [
+            AgentError::CertifiedReject {
+                reject: reject(),
+                operation: None,
+            },
+            AgentError::UncertifiedReject {
+                reject: reject(),
+                operation: None,
+            },
+        ] {
+            let err = UpdateOrProxyError::DirectUpdateCall { source };
+            let found = direct_call_reject(&err).expect("reject should be extracted");
+            assert!(E_STATUS_ACCESS_DENIED.contains(&found.error_code.as_deref().unwrap()));
+        }
+
+        assert!(
+            direct_call_reject(&UpdateOrProxyError::ProxyCall {
+                message: "boom".to_string(),
+            })
+            .is_none()
+        );
+    }
 }

--- a/crates/icp-cli/tests/canister_status_tests.rs
+++ b/crates/icp-cli/tests/canister_status_tests.rs
@@ -131,3 +131,80 @@ async fn canister_status_through_proxy() {
                 .and(contains(&proxy_cid)),
         );
 }
+
+/// A caller that may not read the status falls back on the state-tree
+/// information, rather than failing.
+#[tokio::test]
+async fn canister_status_falls_back_when_access_is_denied() {
+    let ctx = TestContext::new();
+
+    let project_dir = ctx.create_project_dir("icp");
+
+    let client = clients::icp(&ctx, &project_dir, None);
+    client.create_identity("alice");
+    let principal_alice = client.get_principal("alice").to_string();
+
+    let wasm = ctx.make_asset("example_icp_mo.wasm");
+
+    let pm = formatdoc! {r#"
+        canisters:
+          - name: my-canister
+            build:
+              steps:
+                - type: script
+                  command: cp '{wasm}' "$ICP_WASM_OUTPUT_PATH"
+
+        {NETWORK_RANDOM_PORT}
+        {ENVIRONMENT_RANDOM_PORT}
+    "#};
+
+    write_string(&project_dir.join("icp.yaml"), &pm).expect("failed to write project manifest");
+
+    let _g = ctx.start_network_in(&project_dir, "random-network").await;
+    ctx.ping_until_healthy(&project_dir, "random-network");
+
+    clients::icp(&ctx, &project_dir, Some("random-environment".to_string()))
+        .mint_cycles(10 * TRILLION);
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args(["deploy", "--environment", "random-environment"])
+        .assert()
+        .success();
+
+    // Hand sole controllership to alice, so the default identity may no longer
+    // read the status.
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "settings",
+            "update",
+            "my-canister",
+            "--environment",
+            "random-environment",
+            "--force",
+            "--remove-all-controllers",
+            "--add-controller",
+            principal_alice.as_str(),
+        ])
+        .assert()
+        .success();
+
+    ctx.icp()
+        .current_dir(&project_dir)
+        .args([
+            "canister",
+            "status",
+            "my-canister",
+            "--environment",
+            "random-environment",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            contains(format!("Controllers: {principal_alice}"))
+                .and(contains("Module hash:"))
+                .and(contains("Status:").not()),
+        );
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -737,7 +737,7 @@ Start a canister on a network
 
 Show the status of canister(s).
 
-By default this queries the status endpoint of the management canister. If the caller is not a controller, falls back on fetching public information from the state tree.
+By default this queries the status endpoint of the management canister. If the caller may not read the status, falls back on fetching public information from the state tree.
 
 **Usage:** `icp canister status [OPTIONS] [CANISTER]`
 


### PR DESCRIPTION
## What

`icp canister status` falls back on the publicly readable state-tree information — controllers and module hash — when the caller may not read the status. That fallback keyed on the single error code `IC0512`.

Replicas carrying the status-visibility feature reject the call with `IC0542` (`CanisterStatusAccessDenied`) instead, so **on today's mainnet the released CLI already fails** with `Error looking up canister <id>` rather than falling back. `IC0541` (`CanisterInvalidControllerOrSubnetAdmin`, returned on subnets with administrators) was never handled either. All three are now recognised.

The fallback also matched only `AgentError::UncertifiedReject`. The replica checks access twice — when accepting the ingress message, and again in `get_canister_status` during execution — so the same denial arrives uncertified from the first and certified from the second, and the certified path bypassed the fallback entirely. Both are now matched, as `is_canister_not_found` and `is_serving_reject` already do elsewhere.

The certified path is defensive rather than a reproduced failure: in practice the ingress filter catches the denial first and the reject arrives uncertified, which is what the new integration test observes. The same change also means a certified `IC0301` now reports "Canister not found" instead of falling through to the generic error.

## Testing

- `canister_status_falls_back_when_access_is_denied` — hands sole controllership to another identity and reads the status back. Against the pinned network launcher this fails on `main` with exactly `Error looking up canister <id>: Some("IC0542") - Caller ... is not allowed to read the canister status`.
- One unit test pins that both reject forms are recognised and that a non-reject error still surfaces.
