### PR TITLE
chore: update docs site to v1.4

### DIFF
--- a/docs-site/versions.json
+++ b/docs-site/versions.json
@@ -2,8 +2,11 @@
   "$comment": "Before first release: Empty array redirects to /main/. After releases: Add versions here (newest first). Only 'version' is required; 'latest: true' marks the current release.",
   "versions": [
     {
-      "version": "1.3",
+      "version": "1.4",
       "latest": true
+    },
+    {
+      "version": "1.3"
     },
     {
       "version": "1.2"


### PR DESCRIPTION
Adds `1.4` to the docs version switcher as the latest release and demotes `1.3` to a regular entry.

The `v1.4.0` tag is already published, so `/1.4/` exists on `docs-deployment`; merging this points the root redirect and root `llms.txt` at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)