### PR TITLE
fix: fix __eh_frame linker warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,17 @@ missing_debug_implementations = "warn"
 [workspace.lints.clippy]
 enum_variant_names = "allow"
 
-[profile.dev.package.scrypt]
-opt-level = 3
+[profile.dev.package]
+# too slow to ever leave unoptimized
+scrypt = { opt-level = 3 }
+# these bloat the exception handling table producing a macos linker warning
+cargo-generate = { opt-level = 1 }
+cranelift-codegen = { opt-level = 1 }
+rhai = { opt-level = 1 }
+wasmparser = { opt-level = 1 }
+wasmtime-environ = { opt-level = 1 }
+wasmtime-internal-cranelift = { opt-level = 1 }
+wast = { opt-level = 1 }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/icp/src/fs/lock.rs
+++ b/crates/icp/src/fs/lock.rs
@@ -50,34 +50,28 @@ impl<T: PathsAccess> DirectoryStructureLock<T> {
 
     /// Converts the lock structure into an owned read-lock.
     pub async fn into_read(self) -> Result<DirectoryStructureGuardOwned<LRead<T>>, LockError> {
-        spawn_blocking(move || {
-            let lock_file = self.lock_file.into_inner();
-            lock_file.lock_shared().context(LockFailedSnafu {
+        let lock_file = acquire(self.lock_file.into_inner(), Mode::Shared)
+            .await
+            .context(LockFailedSnafu {
                 lock_path: self.lock_path,
             })?;
-            Ok(DirectoryStructureGuardOwned {
-                paths_access: LRead(self.paths_access),
-                guard: lock_file,
-            })
+        Ok(DirectoryStructureGuardOwned {
+            paths_access: LRead(self.paths_access),
+            guard: lock_file,
         })
-        .await
-        .unwrap()
     }
 
     /// Converts the lock structure into an owned write-lock.
     pub async fn into_write(self) -> Result<DirectoryStructureGuardOwned<LWrite<T>>, LockError> {
-        spawn_blocking(move || {
-            let lock_file = self.lock_file.into_inner();
-            lock_file.lock().context(LockFailedSnafu {
+        let lock_file = acquire(self.lock_file.into_inner(), Mode::Exclusive)
+            .await
+            .context(LockFailedSnafu {
                 lock_path: self.lock_path,
             })?;
-            Ok(DirectoryStructureGuardOwned {
-                paths_access: LWrite(self.paths_access),
-                guard: lock_file,
-            })
+        Ok(DirectoryStructureGuardOwned {
+            paths_access: LWrite(self.paths_access),
+            guard: lock_file,
         })
-        .await
-        .unwrap()
     }
 
     /// Accesses the directory structure under a read lock.
@@ -86,9 +80,8 @@ impl<T: PathsAccess> DirectoryStructureLock<T> {
         let lock_file = guard.try_clone().context(HandleCloneFailedSnafu {
             path: &self.lock_path,
         })?;
-        spawn_blocking(move || lock_file.lock_shared())
+        acquire(lock_file, Mode::Shared)
             .await
-            .unwrap()
             .context(LockFailedSnafu {
                 lock_path: &self.lock_path,
             })?;
@@ -108,9 +101,8 @@ impl<T: PathsAccess> DirectoryStructureLock<T> {
         let lock_file = guard.try_clone().context(HandleCloneFailedSnafu {
             path: &self.lock_path,
         })?;
-        spawn_blocking(move || lock_file.lock())
+        acquire(lock_file, Mode::Exclusive)
             .await
-            .unwrap()
             .context(LockFailedSnafu {
                 lock_path: &self.lock_path,
             })?;
@@ -120,6 +112,29 @@ impl<T: PathsAccess> DirectoryStructureLock<T> {
         })?;
         Ok(ret)
     }
+}
+
+#[derive(Debug)]
+enum Mode {
+    Shared,
+    Exclusive,
+}
+
+/// Takes the advisory lock on `file`, returning it once held.
+///
+/// Deliberately free of type parameters: every caller is a generic method, so a `spawn_blocking`
+/// written inline there would carry those parameters into the closure type and monomorphize the
+/// whole of tokio's blocking-task machinery once per call site. Keep it that way.
+async fn acquire(file: File, mode: Mode) -> io::Result<File> {
+    spawn_blocking(move || {
+        let locked = match mode {
+            Mode::Shared => file.lock_shared(),
+            Mode::Exclusive => file.lock(),
+        };
+        locked.map(|()| file)
+    })
+    .await
+    .unwrap()
 }
 
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
The debug binary warns that the exception handling table is too large for unwinds to work properly. This PR optimizes the worst offenders in the dependency tree and crate generics.