### PR TITLE
docs: resolve the cargo target dir in rust build steps

### DIFF
--- a/docs/concepts/build-deploy-sync.md
+++ b/docs/concepts/build-deploy-sync.md
@@ -45,7 +45,9 @@ build:
     - type: script
       commands:
         - cargo build --target wasm32-unknown-unknown --release
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 **Pre-built** — Use existing WASM:

--- a/docs/concepts/build-deploy-sync.md
+++ b/docs/concepts/build-deploy-sync.md
@@ -45,7 +45,7 @@ build:
     - type: script
       commands:
         - cargo build --target wasm32-unknown-unknown --release
-        - cp target/wasm32-unknown-unknown/release/my_canister.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 **Pre-built** — Use existing WASM:

--- a/docs/concepts/project-model.md
+++ b/docs/concepts/project-model.md
@@ -49,7 +49,7 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - cp target/wasm32-unknown-unknown/release/hello.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/hello.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ## Network Discovery

--- a/docs/concepts/project-model.md
+++ b/docs/concepts/project-model.md
@@ -49,7 +49,9 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/hello.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/hello.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ## Network Discovery

--- a/docs/concepts/recipes.md
+++ b/docs/concepts/recipes.md
@@ -36,7 +36,7 @@ canisters:
         - type: script
           commands:
             - cargo build --package my-backend --target wasm32-unknown-unknown --release
-            - cp target/wasm32-unknown-unknown/release/my_backend.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_backend.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ## Recipe Sources

--- a/docs/concepts/recipes.md
+++ b/docs/concepts/recipes.md
@@ -21,7 +21,7 @@ Given this recipe usage:
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: my-backend
 ```
@@ -49,7 +49,7 @@ Official recipes from the DFINITY registry:
 
 ```yaml
 recipe:
-  type: "@dfinity/rust@v3.0.0"
+  type: "@dfinity/rust@v3.4.0"
   configuration:
     package: my-crate
 ```
@@ -117,7 +117,7 @@ Recipe templates have access to two kinds of variables:
 
 ```yaml
 recipe:
-  type: "@dfinity/rust@v3.0.0"
+  type: "@dfinity/rust@v3.4.0"
   configuration:
     shrink: true   # available as {{ shrink }} in the template
 ```

--- a/docs/concepts/recipes.md
+++ b/docs/concepts/recipes.md
@@ -36,7 +36,9 @@ canisters:
         - type: script
           commands:
             - cargo build --package my-backend --target wasm32-unknown-unknown --release
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_backend.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_backend.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ## Recipe Sources

--- a/docs/guides/creating-recipes.md
+++ b/docs/guides/creating-recipes.md
@@ -41,7 +41,7 @@ build:
     - type: script
       commands:
         - cargo build --package {{ package }} --target wasm32-unknown-unknown --release
-        - mv target/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script
       commands:
@@ -65,6 +65,22 @@ canisters:
         package: my-backend-crate
         shrink: true
 ```
+
+### Locating Cargo Build Output
+
+Cargo does not always write to `./target`. In a Cargo workspace the target directory sits at the
+workspace root, and `CARGO_TARGET_DIR` or a `build.target-dir` config key moves it anywhere. A recipe
+that hardcodes `target/...` builds successfully and then fails to find the wasm, so ask cargo where it
+builds:
+
+```
+- TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+```
+
+Each entry in `commands:` runs in its own shell, so keep the lookup and the command that uses
+`$TARGET_DIR` on one line, separated by `;`. The `sed` avoids taking a dependency on `jq`.
+
+Shorter snippets below omit this lookup to keep the syntax they demonstrate in focus.
 
 ## Template Syntax
 
@@ -115,7 +131,7 @@ build:
     - type: script
       commands:
         - cargo build --package {{ package }} --target wasm32-unknown-unknown --release
-        - mv target/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script
       commands:

--- a/docs/guides/creating-recipes.md
+++ b/docs/guides/creating-recipes.md
@@ -80,7 +80,6 @@ builds:
 Each entry in `commands:` runs in its own shell, so keep the lookup and the command that uses
 `$TARGET_DIR` on one line, separated by `;`. The `sed` avoids taking a dependency on `jq`.
 
-Shorter snippets below omit this lookup to keep the syntax they demonstrate in focus.
 
 ## Template Syntax
 
@@ -109,10 +108,10 @@ build:
       commands:
         {{#if shrink}}
         - cargo build --release --target wasm32-unknown-unknown
-        - ic-wasm target/wasm32-unknown-unknown/release/{{ package }}.wasm -o "$ICP_WASM_OUTPUT_PATH" shrink
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); ic-wasm "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ package }}.wasm" -o "$ICP_WASM_OUTPUT_PATH" shrink
         {{else}}
         - cargo build --target wasm32-unknown-unknown
-        - cp target/wasm32-unknown-unknown/debug/{{ package }}.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/debug/{{ package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
         {{/if}}
 ```
 
@@ -176,7 +175,7 @@ Built-in recipe variables work with all Handlebars helpers. For example, the `re
 
 ```
 - cargo build --package {{_.canister.name}} --target wasm32-unknown-unknown --release
-- cp "target/wasm32-unknown-unknown/release/{{ replace "-" "_" _.canister.name }}.wasm" "$ICP_WASM_OUTPUT_PATH"
+- TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" _.canister.name }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 User-provided overrides can still be supported with an `{{#if}}` fallback for cases where the user needs to supply a different name (e.g. when the Cargo package name differs from the canister name):

--- a/docs/guides/creating-recipes.md
+++ b/docs/guides/creating-recipes.md
@@ -41,7 +41,9 @@ build:
     - type: script
       commands:
         - cargo build --package {{ package }} --target wasm32-unknown-unknown --release
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script
       commands:
@@ -68,17 +70,23 @@ canisters:
 
 ### Locating Cargo Build Output
 
-Cargo does not always write to `./target`. In a Cargo workspace the target directory sits at the
-workspace root, and `CARGO_TARGET_DIR` or a `build.target-dir` config key moves it anywhere. A recipe
-that hardcodes `target/...` builds successfully and then fails to find the wasm, so ask cargo where it
-builds:
+Cargo does not always write to `./target`. A build step runs in the canister directory, so in a Cargo
+workspace the target directory sits above it at the workspace root, and `CARGO_TARGET_DIR` or a
+`build.target-dir` config key moves it anywhere. A recipe that hardcodes `target/...` builds
+successfully and then fails to find the wasm, so ask cargo where it builds:
 
-```
-- TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+```yaml
+- |-
+  TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+  cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
-Each entry in `commands:` runs in its own shell, so keep the lookup and the command that uses
-`$TARGET_DIR` on one line, separated by `;`. The `sed` avoids taking a dependency on `jq`.
+Each entry in `commands:` runs in its own shell, so `$TARGET_DIR` would be empty in a following entry.
+The `|-` block keeps both commands in one entry, and therefore one shell. The `sed` avoids taking a
+dependency on `jq`.
+
+Copy the wasm rather than moving it: cargo materializes the top-level artifact from `deps/`, and a
+build step has no reason to remove cargo's output.
 
 
 ## Template Syntax
@@ -108,10 +116,14 @@ build:
       commands:
         {{#if shrink}}
         - cargo build --release --target wasm32-unknown-unknown
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); ic-wasm "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ package }}.wasm" -o "$ICP_WASM_OUTPUT_PATH" shrink
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          ic-wasm "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ package }}.wasm" -o "$ICP_WASM_OUTPUT_PATH" shrink
         {{else}}
         - cargo build --target wasm32-unknown-unknown
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/debug/{{ package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/debug/{{ package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
         {{/if}}
 ```
 
@@ -130,7 +142,9 @@ build:
     - type: script
       commands:
         - cargo build --package {{ package }} --target wasm32-unknown-unknown --release
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" package }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 
     - type: script
       commands:
@@ -175,7 +189,9 @@ Built-in recipe variables work with all Handlebars helpers. For example, the `re
 
 ```
 - cargo build --package {{_.canister.name}} --target wasm32-unknown-unknown --release
-- TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" _.canister.name }}.wasm" "$ICP_WASM_OUTPUT_PATH"
+- |-
+  TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+  cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{ replace "-" "_" _.canister.name }}.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 User-provided overrides can still be supported with an `{{#if}}` fallback for cases where the user needs to supply a different name (e.g. when the Cargo package name differs from the canister name):

--- a/docs/guides/creating-templates.md
+++ b/docs/guides/creating-templates.md
@@ -157,7 +157,7 @@ canisters:
   - name: {{project-name}}
     {% if backend_language == "rust" %}
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: {{crate_name}}
     {% else %}

--- a/docs/guides/managing-environments.md
+++ b/docs/guides/managing-environments.md
@@ -182,7 +182,7 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - cp target/wasm32-unknown-unknown/release/backend.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
 
 environments:
   - name: staging

--- a/docs/guides/managing-environments.md
+++ b/docs/guides/managing-environments.md
@@ -182,7 +182,9 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
 
 environments:
   - name: staging

--- a/docs/guides/using-recipes.md
+++ b/docs/guides/using-recipes.md
@@ -29,8 +29,18 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/rust@v3.4.0"
+```
+
+`package` defaults to the canister name, so it only needs setting when the Cargo package is named
+something else:
+
+```yaml
+canisters:
+  - name: backend
+    recipe:
+      type: "@dfinity/rust@v3.4.0"
       configuration:
-        package: backend
+        package: my-backend-crate
 ```
 
 ### Motoko Canister
@@ -85,8 +95,6 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/rust@v3.4.0"
-      configuration:
-        package: backend
 ```
 
 ## Local Recipes
@@ -157,8 +165,6 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/rust@v3.4.0"
-      configuration:
-        package: backend
     settings:
       compute_allocation: 10
       environment_variables:

--- a/docs/guides/using-recipes.md
+++ b/docs/guides/using-recipes.md
@@ -101,7 +101,9 @@ build:
     - type: script
       commands:
         - cargo build --package {{package}} --target wasm32-unknown-unknown --release
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{package}}.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{package}}.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 Reference it in your `icp.yaml`:

--- a/docs/guides/using-recipes.md
+++ b/docs/guides/using-recipes.md
@@ -17,8 +17,8 @@ Recipes are reusable build templates that simplify canister configuration. Inste
 DFINITY maintains recipes for common use cases at [github.com/dfinity/icp-cli-recipes](https://github.com/dfinity/icp-cli-recipes).
 
 You can reference recipes by pointing to a URL. For the official recipes, you can use a shorthand for example these recipe types are equivalent:
-* `@dfinity/rust@v3.0.0`
-* `https://github.com/dfinity/icp-cli-recipes/releases/download/rust-v3.0.0/recipe.hbs`
+* `@dfinity/rust@v3.4.0`
+* `https://github.com/dfinity/icp-cli-recipes/releases/download/rust-v3.4.0/recipe.hbs`
 
 ### Rust Canister
 
@@ -28,7 +28,7 @@ For building a rust canister:
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: backend
 ```
@@ -77,14 +77,14 @@ canisters:
 
 A version is always required for registry recipes. These two types are equivalent:
 
-* `@dfinity/rust@v3.0.0`
-* `https://github.com/dfinity/icp-cli-recipes/releases/download/rust-v3.0.0/recipe.hbs`
+* `@dfinity/rust@v3.4.0`
+* `https://github.com/dfinity/icp-cli-recipes/releases/download/rust-v3.4.0/recipe.hbs`
 
 ```yaml
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: backend
 ```
@@ -101,7 +101,7 @@ build:
     - type: script
       commands:
         - cargo build --package {{package}} --target wasm32-unknown-unknown --release
-        - cp target/wasm32-unknown-unknown/release/{{package}}.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/{{package}}.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 Reference it in your `icp.yaml`:
@@ -154,7 +154,7 @@ in the configuration file. eg:
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: backend
     settings:

--- a/docs/guides/writing-sync-plugins.md
+++ b/docs/guides/writing-sync-plugins.md
@@ -134,7 +134,9 @@ A value always arrives as a string, so parse the ones you want as another type �
 cargo build --target wasm32-wasip2 --release
 ```
 
-The output `.wasm` (under `target/wasm32-wasip2/release/`) is loaded directly by icp-cli — no extra component-packaging step is required.
+The output `.wasm` is loaded directly by icp-cli — no extra component-packaging step is required.
+It lands in `<cargo-target-dir>/wasm32-wasip2/release/`, which is `./target` only for a standalone
+crate with no `CARGO_TARGET_DIR` or `build.target-dir` set; in a workspace it sits at the workspace root.
 
 ## Wire It Into the Manifest
 
@@ -152,6 +154,10 @@ sync:
         api_url: https://example.com
         retries: 3
 ```
+
+`path` is a plain path relative to the canister directory — it is not expanded, so it cannot
+reference `$CARGO_TARGET_DIR`. If your target directory is elsewhere, point `path` at the real
+location or copy the plugin wasm into the canister directory as a build step.
 
 Then run the sync phase:
 

--- a/docs/migration/from-dfx.md
+++ b/docs/migration/from-dfx.md
@@ -66,7 +66,9 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ### Build parallelism

--- a/docs/migration/from-dfx.md
+++ b/docs/migration/from-dfx.md
@@ -49,8 +49,6 @@ canisters:
   - name: my_canister
     recipe:
       type: "@dfinity/rust@v3.4.0"
-      configuration:
-        package: my_canister
 ```
 
 ### Build Process
@@ -133,7 +131,6 @@ canisters:
     recipe:
       type: "@dfinity/rust@v3.4.0"
       configuration:
-        package: backend
         candid: "src/backend/backend.did"
 ```
 
@@ -234,8 +231,6 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/rust@v3.4.0"
-      configuration:
-        package: backend
 ```
 
 **Key differences:**

--- a/docs/migration/from-dfx.md
+++ b/docs/migration/from-dfx.md
@@ -66,7 +66,7 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - cp target/wasm32-unknown-unknown/release/backend.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ### Build parallelism

--- a/docs/migration/from-dfx.md
+++ b/docs/migration/from-dfx.md
@@ -48,7 +48,7 @@ icp-cli introduces recipes — reusable build templates. Instead of dfx's built-
 canisters:
   - name: my_canister
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: my_canister
 ```
@@ -129,7 +129,7 @@ icp-cli assumes users will use canister environment variables to connect caniste
 canisters:
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: backend
         candid: "src/backend/backend.did"
@@ -231,7 +231,7 @@ canisters:
 
   - name: backend
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: backend
 ```

--- a/docs/reference/canister-settings.md
+++ b/docs/reference/canister-settings.md
@@ -304,7 +304,7 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - cp target/wasm32-unknown-unknown/release/backend.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
     settings:
       compute_allocation: 5
       memory_allocation: 2gib

--- a/docs/reference/canister-settings.md
+++ b/docs/reference/canister-settings.md
@@ -304,7 +304,9 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
     settings:
       compute_allocation: 5
       memory_allocation: 2gib

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,7 +75,7 @@ build:
     - type: script
       commands:
         - cargo build --target wasm32-unknown-unknown --release
-        - cp target/wasm32-unknown-unknown/release/my_canister.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 **Environment variables:**
@@ -514,7 +514,7 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - cp target/wasm32-unknown-unknown/release/backend.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
     settings:
       compute_allocation: 5
     init_args:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -217,7 +217,7 @@ The plugin runs in a WASI sandbox: it can call update and query methods on the c
 canisters:
   - name: my-canister
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       sha256: abc123...  # Required for remote URLs
       configuration:
         package: my-crate
@@ -233,7 +233,7 @@ canisters:
 
 ```yaml
 # Registry (recommended)
-type: "@dfinity/rust@v3.0.0"
+type: "@dfinity/rust@v3.4.0"
 
 # Local file
 type: ./recipes/my-recipe.hb.yaml

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -75,7 +75,9 @@ build:
     - type: script
       commands:
         - cargo build --target wasm32-unknown-unknown --release
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 **Environment variables:**
@@ -514,7 +516,9 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/backend.wasm" "$ICP_WASM_OUTPUT_PATH"
     settings:
       compute_allocation: 5
     init_args:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -22,7 +22,7 @@ build:
     - type: script
       commands:
         - cargo build --target wasm32-unknown-unknown --release
-        - cp target/wasm32-unknown-unknown/release/my_canister.wasm "$ICP_WASM_OUTPUT_PATH"
+        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ### `ICP_CLI_ENVIRONMENT`

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -22,7 +22,9 @@ build:
     - type: script
       commands:
         - cargo build --target wasm32-unknown-unknown --release
-        - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
+        - |-
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+          cp "${TARGET_DIR}/wasm32-unknown-unknown/release/my_canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 ```
 
 ### `ICP_CLI_ENVIRONMENT`

--- a/examples/icp-rust-recipe/README.md
+++ b/examples/icp-rust-recipe/README.md
@@ -14,7 +14,7 @@ The [`icp.yaml`](./icp.yaml) file configures a canister using the `@dfinity/rust
 canisters:
   - name: my-canister
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         package: icp-canister
         shrink: true
@@ -22,7 +22,7 @@ canisters:
 
 ### Key Components
 
-- **`type: "@dfinity/rust@v3.0.0"`**: Uses the official DFINITY Rust recipe
+- **`type: "@dfinity/rust@v3.4.0"`**: Uses the official DFINITY Rust recipe
 - **`package`**: Specifies the Cargo package name to build (required)
 - **`shrink`**: Enables WASM optimization (optional)
 

--- a/examples/icp-rust-recipe/README.md
+++ b/examples/icp-rust-recipe/README.md
@@ -23,7 +23,7 @@ canisters:
 ### Key Components
 
 - **`type: "@dfinity/rust@v3.4.0"`**: Uses the official DFINITY Rust recipe
-- **`package`**: Specifies the Cargo package name to build (required)
+- **`package`**: The Cargo package name to build (optional, defaults to the canister name — set here because this crate is named `icp-canister`, not `my-canister`)
 - **`shrink`**: Enables WASM optimization (optional)
 
 ## Project Structure

--- a/examples/icp-rust-recipe/icp.yaml
+++ b/examples/icp-rust-recipe/icp.yaml
@@ -3,7 +3,7 @@
 canisters:
   - name: my-canister
     recipe:
-      type: "@dfinity/rust@v3.0.0"
+      type: "@dfinity/rust@v3.4.0"
       configuration:
         # cargo package for canister (required field)
         package: icp-canister

--- a/examples/icp-rust-recipe/icp.yaml
+++ b/examples/icp-rust-recipe/icp.yaml
@@ -5,7 +5,8 @@ canisters:
     recipe:
       type: "@dfinity/rust@v3.4.0"
       configuration:
-        # cargo package for canister (required field)
+        # cargo package for canister; optional, defaults to the canister
+        # name. Needed here because this crate is not named `my-canister`.
         package: icp-canister
         shrink: true
         # optional

--- a/examples/icp-rust/icp.yaml
+++ b/examples/icp-rust/icp.yaml
@@ -7,4 +7,6 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release --locked
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/icp_template_rust.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/icp_template_rust.wasm" "$ICP_WASM_OUTPUT_PATH"

--- a/examples/icp-rust/icp.yaml
+++ b/examples/icp-rust/icp.yaml
@@ -7,4 +7,4 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release --locked
-            - mv target/wasm32-unknown-unknown/release/icp_template_rust.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/icp_template_rust.wasm" "$ICP_WASM_OUTPUT_PATH"

--- a/examples/icp-sync-plugin/icp.yaml
+++ b/examples/icp-sync-plugin/icp.yaml
@@ -5,7 +5,9 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release --locked -p canister
-            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/canister.wasm" "$ICP_WASM_OUTPUT_PATH"
+            - |-
+              TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+              cp "${TARGET_DIR}/wasm32-unknown-unknown/release/canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 
         - type: script
           commands:

--- a/examples/icp-sync-plugin/icp.yaml
+++ b/examples/icp-sync-plugin/icp.yaml
@@ -5,7 +5,7 @@ canisters:
         - type: script
           commands:
             - cargo build --target wasm32-unknown-unknown --release --locked -p canister
-            - mv target/wasm32-unknown-unknown/release/canister.wasm "$ICP_WASM_OUTPUT_PATH"
+            - TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'); mv "${TARGET_DIR}/wasm32-unknown-unknown/release/canister.wasm" "$ICP_WASM_OUTPUT_PATH"
 
         - type: script
           commands:

--- a/scripts/validate-examples.sh
+++ b/scripts/validate-examples.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 # Add the icp binary to PATH. Ask cargo for the target directory rather than
 # assuming ./target, which CARGO_TARGET_DIR and build.target-dir both move.
 TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "Could not determine the cargo target directory (got: '$TARGET_DIR')" >&2
+  exit 1
+fi
 export PATH="${TARGET_DIR}/debug:$PATH"
 echo "icp version: $(icp --version)"
 echo "icp path: $(which icp)"

--- a/scripts/validate-examples.sh
+++ b/scripts/validate-examples.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 # Script to validate all examples in the examples/ directory
 # This script can be run locally or in CI
 
-# Add icp binary to PATH (assumes it's in target/debug)
-export PATH="$(pwd)/target/debug:$PATH"
+# Add the icp binary to PATH. Ask cargo for the target directory rather than
+# assuming ./target, which CARGO_TARGET_DIR and build.target-dir both move.
+TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+export PATH="${TARGET_DIR}/debug:$PATH"
 echo "icp version: $(icp --version)"
 echo "icp path: $(which icp)"
 


### PR DESCRIPTION
Follow-up after reviewing #760.

Rust build steps that hardcode `target/...` compile successfully and then fail to find the wasm, because cargo does not necessarily write to `./target`.

The dominant case is not an exotic env var. A build step runs in the **canister** directory (`crates/icp/src/operations/build.rs:62` passes `canister_path`), so in the standard Rust monorepo layout the path is simply wrong:

```
repo/
├── Cargo.toml          # workspace root — cargo writes target/ HERE
├── target/
└── canisters/backend/
    ├── Cargo.toml      # workspace member
    └── icp.yaml        # build step runs HERE, so "target/" → canisters/backend/target → missing
```

`CARGO_TARGET_DIR` and `build.target-dir` move it too. Reproduced against `examples/icp-rust`:

```
mv: rename target/wasm32-unknown-unknown/release/icp_template_rust.wasm to …: No such file or directory
```

The official rust recipe fixed this in `rust-v3.1.0`. This applies the same lookup wherever we still hardcode the path, and bumps our pins.

### Changes

- **All rust build snippets in `docs/`** resolve the target dir via `cargo metadata`, in a `|-` block so the lookup and the copy read as two lines.
- **`examples/icp-rust`, `examples/icp-sync-plugin`** likewise. Both examples are flat, so this is defensive for them as-run — it matters because they are templates people copy into projects that are not flat.
- **`scripts/validate-examples.sh`** no longer assumes `./target/debug`. This one was a live bug in our own tooling.
- **Every `@dfinity/rust` pin bumped v3.0.0 → v3.4.0**, in both the `type:` and release-URL forms. v3.0.0 predates the recipe's own fix.
- **`docs/guides/creating-recipes.md`** gains a short section explaining the rule and the `|-` block form.
- **`package` is documented as optional**, which the bump exposed: `examples/icp-rust-recipe` called it a required field in both its manifest comment and its README, but it has defaulted to the canister name since `rust-v3.3.0`. Dropped from the five snippets where it only repeated the canister name; kept where the crate name genuinely differs, and in the custom-recipe examples whose own `package` parameter is unrelated.

### Notes for the reviewer

- The lookup and the copy are one `commands:` entry, written as a `|-` block. They must share a shell — each entry gets its own `sh -c`, so a naive split leaves `$TARGET_DIR` empty and fails with `cp: /wasm32-unknown-unknown/…: No such file or directory` — but they do not have to share a line.
- `cp`, not `mv`, matching the recipe: cargo materializes the top-level artifact from `deps/`, so a build step has no reason to remove its output. (It does not cause a rebuild either way — cargo re-creates the top-level file in ~0.03s.)
- The `sed` is inherited from the recipe, which avoids `jq` *"in order not to introduce a dependency on jq"*. There is no better form on stable: `--artifact-dir` would remove the lookup entirely but is nightly-only ([cargo#6790](https://github.com/rust-lang/cargo/issues/6790), open since 2019), `cargo locate-project --workspace` misses `CARGO_TARGET_DIR`, and `tr`/`cut` variants break on paths containing a comma.
- Only `validate-examples.sh` guards against an unresolved lookup, because an empty result there was genuinely silent — it prepended `/debug` to `PATH` and surfaced later as `icp: not found`. A build step needs no guard: the lookup only runs after a successful `cargo build` (a step aborts on its first failing command), and an empty result makes `cp` fail and fail the step.
- `path:` on a plugin sync step is a plain relative path with no expansion (`crates/icp/src/manifest/adapter/plugin.rs:136`), so it cannot reference the target dir. The sync plugin guide now says so.

### Verification

- `icp build` on `examples/icp-rust`, with and without `CARGO_TARGET_DIR`: fails on `main`, passes here, no stray `target/` in the source tree, artifact left in place by `cp`.
- Confirmed a naive split into two `commands:` entries does fail, and that the `|-` block does not.
- `icp build` with `package` omitted and the canister named after the crate: the recipe derives `--package icp-canister` and `icp_canister.wasm`, and the build succeeds.
- `icp project show` on the changed examples; the bumped pin resolves and renders v3.4.0's lookup.
- Parsed all 97 non-template YAML blocks across the changed docs.

### Follow-up (separate repo)

These docs now differ from the recipe itself, which still uses the one-line form. The `|-` block is worth proposing upstream in `icp-cli-recipes`.
